### PR TITLE
Exclude test accounts when copying email addresses

### DIFF
--- a/editor/src/views/Users/Users.js
+++ b/editor/src/views/Users/Users.js
@@ -59,9 +59,14 @@ async function getAllUsers(pageCount, perPage, totalUsers, setAllUsers, token) {
 // Copy all user emails to the clipboard
 const getUserEmails = (userArray, setCopyUserEmailsClicked) => {
   let userEmails = "";
-  userArray.forEach(user => {
-    userEmails += `${user.email}; `;
-  });
+  userArray
+    // exclude test accounts
+    .filter(
+      user => !user.email.toLowerCase().startsWith("transportation.data+")
+    )
+    .forEach(user => {
+      userEmails += `${user.email}; `;
+    });
   // timeout determines how long the status popover displays
   const popOverTime = 2000;
   setTimeout(() => setCopyUserEmailsClicked(false), popOverTime);


### PR DESCRIPTION
## Associated issues
- https://github.com/cityofaustin/atd-data-tech/issues/19138

## Testing: [Deploy preview](https://deploy-preview-1562--atd-vze-staging.netlify.app/#/users)

1. Sign in as an admin and go to the **Users** page and click the **Copy user emails**
2. Paste your clipboard somewhere and verify that the none of the `transportation.data+<whatever>` email addresses are included

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
