### PR TITLE
Restores helper script's ability to download db data

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,3 @@
-FROM frankinaustin/postgis-multiarch:14-3.3
+dFROM frankinaustin/postgis-multiarch:14-3.3
 RUN apt-get update
-RUN apt-get install -y aptitude magic-wormhole vim
+RUN apt-get install -y aptitude vim

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,3 @@
-dFROM frankinaustin/postgis-multiarch:14-3.3
+FROM frankinaustin/postgis-multiarch:14-3.3
 RUN apt-get update
 RUN apt-get install -y aptitude vim

--- a/docker-compose-docker-volume.yml
+++ b/docker-compose-docker-volume.yml
@@ -6,6 +6,7 @@ services:
       - .env
     volumes:
       - visionzero_postgis_pgdata:/var/lib/postgresql/data
+      - ./database/snapshots:/snapshots
     ports:
       - 5432:5432
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,6 @@ services:
       HASURA_GRAPHQL_DATABASE_URL: postgres://visionzero:visionzero@postgis:5432/atd_vz_data
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
-  db-tools:
-    container_name: visionzero_download_db_data
-    logging:
-      driver: none
-    build: toolbox/download-db-data
-    command: tail -f /dev/null
-    hostname: db-tools
-    env_file:
-      - .env
-    volumes:
-      - ./database/snapshots:/snapshots
   vze:
     tty: true
     container_name: visionzero-vze

--- a/vision-zero
+++ b/vision-zero
@@ -18,8 +18,6 @@ if not os.path.exists(".env"):
 load_dotenv()
 
 TABLES_TO_IGNORE = [
-    "public.atd_txdot_change_log",
-    "public.polygons",
     "public.change_log_crashes",
     "public.change_log_crashes_cris",
     "public.change_log_units_cris",
@@ -29,10 +27,6 @@ TABLES_TO_IGNORE = [
     "public.change_log_people_edits",
     "public.change_log_units_edits",
     "public.change_log_crashes_edits",
-    "public.atd_txdot_crashes",
-    "public.atd_txdot_units",
-    "public.atd_txdot_person",
-    "public.atd_txdot_primaryperson",
 ]
 
 

--- a/vision-zero
+++ b/vision-zero
@@ -145,7 +145,7 @@ def replicateDb(args):
         "-e", "PGDATABASE=" + os.environ["RR_DATABASE"],
         "-e", "PGUSER=" + os.environ["RR_USERNAME"],
         "-e", "PGPASSWORD=" + os.environ["RR_PASSWORD"],
-        "db-tools",
+        "postgis",
     ]
 
     replicate_command = [
@@ -174,7 +174,7 @@ def replicateDb(args):
         "-e", "PGUSER=" + os.environ["POSTGRES_USER"],
         "-e", "PGPASSWORD=" + os.environ["POSTGRES_PASSWORD"],
         "-e", "PGDATABASE=postgres",
-        "db-tools",
+        "postgis",
     ]
     
     populate_runner_command = docker_compose_invocation + [
@@ -187,7 +187,7 @@ def replicateDb(args):
         "-e", "PGUSER=" + os.environ["POSTGRES_USER"],
         "-e", "PGPASSWORD=" + os.environ["POSTGRES_PASSWORD"],
         "-e", "PGDATABASE=postgres",
-        "db-tools",
+        "postgis",
     ]
     # fmt: on
 
@@ -251,7 +251,7 @@ def dumpLocalDb(args):
         "PGPASSWORD=" + os.environ["POSTGRES_PASSWORD"],
         "-e",
         "PGDATABASE=" + os.environ["POSTGRES_DB"],
-        "db-tools",
+        "postgis",
     ]
 
     dump_command = [
@@ -280,7 +280,7 @@ def psql(args):
         "-e", "PGDATABASE=" + os.environ["POSTGRES_DB"],
         "-e", "PGUSER=" + os.environ["POSTGRES_USER"],
         "-e", "PGPASSWORD=" + os.environ["POSTGRES_PASSWORD"],
-        "db-tools",
+        "postgis",
     ]
     # fmt: on
 
@@ -498,7 +498,7 @@ def toolsShell(args):
         "-e", "PGUSER=" + os.environ["POSTGRES_USER"],
         "-e", "PGPASSWORD=" + os.environ["POSTGRES_PASSWORD"],
         "-e", "PGDATABASE=" + os.environ["POSTGRES_DB"],
-        "db-tools",
+        "postgis",
     ]
     # fmt: on
 


### PR DESCRIPTION
## Associated issues

As mentioned [in Slack](https://austininnovation.slack.com/archives/CM9MK950S/p1727286078220699), i broke the helper script when i cleaned up the toolbox in https://github.com/cityofaustin/vision-zero/pull/1543.

It looks like we can just use the existing `postgis` service to run the `psql` commands that the toolbox container was managing. I definitely want Frank to take a look before we merge this.


## Testing

**URL to test:** Local

**Steps to test:**
Run through your normal replicate DB steps and make sure the VZE behaves normally.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
