### PR TITLE
Add more spatial attributes to crashes

### DIFF
--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/down.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/down.sql
@@ -1,0 +1,5 @@
+alter table crashes
+    drop column signal_engineer_area_id,
+    drop column zipcode,
+    drop column apd_sector_id,
+    drop column is_coa_roadway;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/down.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/down.sql
@@ -2,4 +2,4 @@ alter table crashes
     drop column signal_engineer_area_id,
     drop column zipcode,
     drop column apd_sector_id,
-    drop column is_coa_roadway;
+    drop column is_non_coa_roadway;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/down.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/down.sql
@@ -2,4 +2,4 @@ alter table crashes
     drop column signal_engineer_area_id,
     drop column zipcode,
     drop column apd_sector_id,
-    drop column is_non_coa_roadway;
+    drop column is_coa_roadway;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
@@ -1,0 +1,17 @@
+alter table crashes
+    add column signal_engineer_area_id integer,
+    add constraint crashes_signal_engineer_area_id_fkey
+        foreign key (signal_engineer_area_id)  
+        references geo.signal_engineer_areas (signal_engineer_area_id)
+        on update cascade on delete set null,
+    add column zipcode text,
+    add constraint crashes_zipcode_fkey
+        foreign key (zipcode)  
+        references geo.zip_codes (zipcode)
+        on update cascade on delete set null,
+    add column apd_sector_id integer,
+    add constraint crashes_apd_sector_id_fkey
+        foreign key (apd_sector_id)  
+        references geo.apd_sectors (primary_key)
+        on update cascade on delete set null,
+    add column is_coa_roadway boolean default false;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
@@ -14,4 +14,4 @@ alter table crashes
         foreign key (apd_sector_id)  
         references geo.apd_sectors (primary_key)
         on update cascade on delete set null,
-    add column is_non_coa_roadway boolean not null default true;
+    add column is_coa_roadway boolean not null default false;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
@@ -15,3 +15,9 @@ alter table crashes
         references geo.apd_sectors (primary_key)
         on update cascade on delete set null,
     add column is_non_coa_roadway boolean not null default true;
+
+
+COMMENT ON COLUMN public.crashes.signal_engineer_area_id IS 'The traffic signal engineer area which intersects with this crash. Set via trigger function.';
+COMMENT ON COLUMN public.crashes.zipcode IS 'The postal ZIP coda which intersects with this crash. Set via trigger function.';
+COMMENT ON COLUMN public.crashes.apd_sector_id IS 'The Austin Police Dept response area which intersects with this crash. Set via trigger function.';
+COMMENT ON COLUMN public.crashes.is_non_coa_roadway IS 'If the crash has a occured on a roadway that is not maintained by the City of Austin. Defaults to true, and is false if the crash does not intersects with the non_coa_roadways layer and the crash occured in the Austin Full Purpose Jursidiction. Set via trigger function.';

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
@@ -14,4 +14,4 @@ alter table crashes
         foreign key (apd_sector_id)  
         references geo.apd_sectors (primary_key)
         on update cascade on delete set null,
-    add column is_non_coa_roadway boolean default true;
+    add column is_non_coa_roadway boolean not null default true;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
@@ -14,4 +14,4 @@ alter table crashes
         foreign key (apd_sector_id)  
         references geo.apd_sectors (primary_key)
         on update cascade on delete set null,
-    add column is_coa_roadway boolean not null default false;
+    add column is_non_coa_roadway boolean not null default true;

--- a/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
+++ b/database/migrations/default/1729608549704_new_crash_spatial_cols/up.sql
@@ -14,4 +14,4 @@ alter table crashes
         foreign key (apd_sector_id)  
         references geo.apd_sectors (primary_key)
         on update cascade on delete set null,
-    add column is_coa_roadway boolean default false;
+    add column is_non_coa_roadway boolean default true;

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/down.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/down.sql
@@ -1,4 +1,4 @@
--- revwer to 1728581588450_create_geo_schema
+-- revert to 1728581588450_create_geo_schema
 create or replace function public.crashes_set_spatial_attributes()
 returns trigger
 language plpgsql

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/down.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/down.sql
@@ -1,0 +1,143 @@
+-- revwer to 1728581588450_create_geo_schema
+create or replace function public.crashes_set_spatial_attributes()
+returns trigger
+language plpgsql
+as $function$
+begin
+    if (new.latitude is not null and new.longitude is not null) then
+        -- save lat/lon into geometry col
+        new.position = st_setsrid(st_makepoint(new.longitude, new.latitude), 4326);
+        --
+        -- get location polygon id
+        --
+        if (new.rpt_road_part_id != 2 and upper(ltrim(new.rpt_hwy_num)) in ('35', '183','183A','1','290','71','360','620','45','130')) then
+            -- use level 5 polygon
+            new.location_id = (
+                select
+                    location_id
+                from
+                    public.atd_txdot_locations
+                where
+                    location_group = 2 -- level 5
+                    and st_contains(geometry, new.position)
+                limit 1);
+        else
+            -- use the other polygons
+            new.location_id = (
+                select
+                    location_id
+                from
+                    public.atd_txdot_locations
+                where
+                    location_group = 1 -- not level 5
+                    and st_contains(geometry, new.position)
+                limit 1);
+        end if;
+
+        raise debug 'found location: % compared to previous location: %', new.location_id, old.location_id;
+        --
+        -- check if in austin full purpose jurisdiction
+        --
+        new.in_austin_full_purpose =  st_contains((select geometry from geo.atd_jurisdictions where id = 5), new.position);
+        raise debug 'in austin full purpose: % compared to previous: %', new.in_austin_full_purpose, old.in_austin_full_purpose;
+        --
+        -- get council district
+        --
+        new.council_district = (
+            select
+                council_district
+            from
+                geo.council_districts
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'council_district: % compared to previous: %', new.council_district, old.council_district;
+        --
+        -- get engineering area
+        --
+        new.engineering_area_id = (
+            select
+                engineering_area_id
+            from
+                geo.engineering_areas
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'engineering_area_id: % compared to previous: %', new.engineering_area_id, old.engineering_area_id;
+        else
+            raise debug 'setting location id and council district to null';
+            -- nullify position column
+            new.position = null;
+            -- reset location id
+            new.location_id = null;
+            -- use city id to determine full purpose jurisdiction
+            new.in_austin_full_purpose = coalesce(new.rpt_city_id = 22, false);
+            raise debug 'setting in_austin_full_purpose based on city id: %', new.in_austin_full_purpose;
+            -- reset council district
+            new.council_district = null;
+            -- reset engineering area
+            new.engineering_area_id = null;
+    end if;
+    return new;
+end;
+$function$;
+
+
+CREATE OR REPLACE FUNCTION public.afd_incidents_trigger()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  update afd__incidents set
+    austin_full_purpose = (
+      select ST_Contains(jurisdiction.geometry, incidents.geometry)
+      from afd__incidents incidents
+      left join geo.atd_jurisdictions jurisdiction on (jurisdiction.jurisdiction_label = 'AUSTIN FULL PURPOSE')
+      where incidents.id = new.id),
+    location_id = (
+      select locations.location_id
+      from afd__incidents incidents
+      join atd_txdot_locations locations on (
+        true
+        and locations.location_group = 1 -- this was added to rule out old level 5s
+        and incidents.geometry && locations.geometry
+        and ST_Contains(locations.geometry, incidents.geometry)
+      )
+      where incidents.id = new.id),
+    latitude = ST_Y(afd__incidents.geometry),
+    longitude = ST_X(afd__incidents.geometry),
+    ems_incident_number_1 = afd__incidents.ems_incident_numbers[1],
+    ems_incident_number_2 = afd__incidents.ems_incident_numbers[2],
+    call_date = date(afd__incidents.call_datetime),
+    call_time = afd__incidents.call_datetime::time
+    where afd__incidents.id = new.id;
+RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.ems_incidents_trigger()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  update ems__incidents set
+    austin_full_purpose = (
+      select ST_Contains(jurisdiction.geometry, incidents.geometry)
+      from ems__incidents incidents
+      left join geo.atd_jurisdictions jurisdiction on (jurisdiction.jurisdiction_label = 'AUSTIN FULL PURPOSE')
+      where incidents.id = new.id),
+    location_id = (
+      select locations.location_id
+      from ems__incidents incidents
+      join atd_txdot_locations locations on (locations.location_group = 1 and incidents.geometry && locations.geometry and ST_Contains(locations.geometry, incidents.geometry))
+      where incidents.id = new.id),
+    latitude = ST_Y(ems__incidents.geometry),
+    longitude = ST_X(ems__incidents.geometry),
+    apd_incident_number_1 = ems__incidents.apd_incident_numbers[1],
+    apd_incident_number_2 = ems__incidents.apd_incident_numbers[2],
+    mvc_form_date = date(ems__incidents.mvc_form_extrication_datetime),
+    mvc_form_time = ems__incidents.mvc_form_extrication_datetime::time
+    where ems__incidents.id = new.id;
+RETURN NEW;
+END;
+$function$;

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
@@ -101,11 +101,11 @@ begin
             limit 1);
         raise debug 'apd_sector_id: % compared to previous: %', new.apd_sector_id, old.apd_sector_id;
         --
-        -- check if is_non_coa_roadway
+        -- check if is_coa_roadway if the crash is in austin
         --
         if (new.in_austin_full_purpose or new.rpt_city_id = 22) then
-            new.is_non_coa_roadway = st_contains((select geometry from geo.non_coa_roadways), new.position);
-            raise debug 'is_non_coa_roadway: % compared to previous: %', new.is_non_coa_roadway, old.is_non_coa_roadway;
+            new.is_coa_roadway = not st_contains((select geometry from geo.non_coa_roadways), new.position);
+            raise debug 'is_coa_roadway: % compared to previous: %', new.is_coa_roadway, old.is_coa_roadway;
         end if;
         else
             raise debug 'reseting spatial attributes due to null latitude and/or longitude values';
@@ -126,8 +126,8 @@ begin
             new.zipcode = null;
             -- reset apd_sector
             new.apd_sector_id = null;
-            -- reset is_non_coa_roadway
-            new.is_non_coa_roadway = true;
+            -- reset is_coa_roadway
+            new.is_coa_roadway = false;
     end if;
     return new;
 end;

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
@@ -101,11 +101,11 @@ begin
             limit 1);
         raise debug 'apd_sector_id: % compared to previous: %', new.apd_sector_id, old.apd_sector_id;
         --
-        -- check if is_coa_roadway if the crash is in austin
+        -- check if is_non_coa_roadway
         --
         if (new.in_austin_full_purpose or new.rpt_city_id = 22) then
-            new.is_coa_roadway = not st_contains((select geometry from geo.non_coa_roadways), new.position);
-            raise debug 'is_coa_roadway: % compared to previous: %', new.is_coa_roadway, old.is_coa_roadway;
+            new.is_non_coa_roadway = st_contains((select geometry from geo.non_coa_roadways), new.position);
+            raise debug 'is_non_coa_roadway: % compared to previous: %', new.is_non_coa_roadway, old.is_non_coa_roadway;
         end if;
         else
             raise debug 'reseting spatial attributes due to null latitude and/or longitude values';
@@ -126,8 +126,8 @@ begin
             new.zipcode = null;
             -- reset apd_sector
             new.apd_sector_id = null;
-            -- reset is_coa_roadway
-            new.is_coa_roadway = false;
+            -- reset is_non_coa_roadway
+            new.is_non_coa_roadway = true;
     end if;
     return new;
 end;

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
@@ -100,6 +100,13 @@ begin
                 st_contains(geometry, new.position)
             limit 1);
         raise debug 'apd_sector_id: % compared to previous: %', new.apd_sector_id, old.apd_sector_id;
+        --
+        -- check if is_non_coa_roadway
+        --
+        if (new.in_austin_full_purpose or new.rpt_city_id = 22) then
+            new.is_non_coa_roadway = st_contains((select geometry from geo.non_coa_roadways), new.position);
+            raise debug 'is_non_coa_roadway: % compared to previous: %', new.is_non_coa_roadway, old.is_non_coa_roadway;
+        end if;
         else
             raise debug 'setting location id and council district to null';
             -- nullify position column

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
@@ -108,7 +108,7 @@ begin
             raise debug 'is_non_coa_roadway: % compared to previous: %', new.is_non_coa_roadway, old.is_non_coa_roadway;
         end if;
         else
-            raise debug 'setting location id and council district to null';
+            raise debug 'reseting spatial attributes due to null latitude and/or longitude values';
             -- nullify position column
             new.position = null;
             -- reset location id
@@ -120,6 +120,14 @@ begin
             new.council_district = null;
             -- reset engineering area
             new.engineering_area_id = null;
+            -- reset signal eng area
+            new.signal_engineer_area_id = null;
+            -- reset zip code
+            new.zipcode = null;
+            -- reset apd_sector
+            new.apd_sector_id = null;
+            -- reset is_non_coa_roadway
+            new.is_non_coa_roadway = true;
     end if;
     return new;
 end;

--- a/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
+++ b/database/migrations/default/1729616317798_set_more_spatial_attributes/up.sql
@@ -1,0 +1,119 @@
+
+CREATE OR REPLACE FUNCTION public.crashes_set_spatial_attributes()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+begin
+    if (new.latitude is not null and new.longitude is not null) then
+        -- save lat/lon into geometry col
+        new.position = st_setsrid(st_makepoint(new.longitude, new.latitude), 4326);
+        --
+        -- get location polygon id
+        --
+        if (new.rpt_road_part_id != 2 and upper(ltrim(new.rpt_hwy_num)) in ('35', '183','183A','1','290','71','360','620','45','130')) then
+            -- use level 5 polygon
+            new.location_id = (
+                select
+                    location_id
+                from
+                    public.atd_txdot_locations
+                where
+                    location_group = 2 -- level 5
+                    and st_contains(geometry, new.position)
+                limit 1);
+        else
+            -- use the other polygons
+            new.location_id = (
+                select
+                    location_id
+                from
+                    public.atd_txdot_locations
+                where
+                    location_group = 1 -- not level 5
+                    and st_contains(geometry, new.position)
+                limit 1);
+        end if;
+
+        raise debug 'found location: % compared to previous location: %', new.location_id, old.location_id;
+        --
+        -- check if in austin full purpose jurisdiction
+        --
+        new.in_austin_full_purpose =  st_contains((select geometry from geo.atd_jurisdictions where id = 5), new.position);
+        raise debug 'in austin full purpose: % compared to previous: %', new.in_austin_full_purpose, old.in_austin_full_purpose;
+        --
+        -- get council district
+        --
+        new.council_district = (
+            select
+                council_district
+            from
+                geo.council_districts
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'council_district: % compared to previous: %', new.council_district, old.council_district;
+        --
+        -- get engineering area
+        --
+        new.engineering_area_id = (
+            select
+                engineering_area_id
+            from
+                geo.engineering_areas
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'engineering_area_id: % compared to previous: %', new.engineering_area_id, old.engineering_area_id;
+        --
+        -- get signal engineer area
+        --
+        new.signal_engineer_area_id = (
+            select
+                signal_engineer_area_id
+            from
+                geo.signal_engineer_areas
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'signal_engineer_area_id: % compared to previous: %', new.signal_engineer_area_id, old.signal_engineer_area_id;
+        --
+        -- get zip code
+        --
+        new.zipcode = (
+            select
+                zipcode
+            from
+                geo.zip_codes
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'zipcode: % compared to previous: %', new.zipcode, old.zipcode;
+        --
+        -- get apd sector
+        --
+        new.apd_sector_id = (
+            select
+                primary_key
+            from
+                geo.apd_sectors
+            where
+                st_contains(geometry, new.position)
+            limit 1);
+        raise debug 'apd_sector_id: % compared to previous: %', new.apd_sector_id, old.apd_sector_id;
+        else
+            raise debug 'setting location id and council district to null';
+            -- nullify position column
+            new.position = null;
+            -- reset location id
+            new.location_id = null;
+            -- use city id to determine full purpose jurisdiction
+            new.in_austin_full_purpose = coalesce(new.rpt_city_id = 22, false);
+            raise debug 'setting in_austin_full_purpose based on city id: %', new.in_austin_full_purpose;
+            -- reset council district
+            new.council_district = null;
+            -- reset engineering area
+            new.engineering_area_id = null;
+    end if;
+    return new;
+end;
+$function$


### PR DESCRIPTION
## Associated issues

- https://github.com/cityofaustin/atd-data-tech/issues/19434
- https://github.com/cityofaustin/atd-data-tech/issues/19554

This PR adds new spatial columns to the `crashes` table and updates our spatial attributes trigger to set them. Note that the task of backfilling these values will be handled via https://github.com/cityofaustin/atd-data-tech/issues/19555.

## Testing - local

1. Follow the [`load_agol_layer` tool instructions ](https://github.com/cityofaustin/vision-zero/tree/19434-jc-mor-spatial-attrs/toolbox/load_agol_layer) to load `apd_sectors`, `non_coa_roadways`, `signal_engineer_areas`, and `zip_codes` into your local instance
2. Apply Hasura migrations and metadata 
3. First we'll debug one record by manually editing its position. Run the following commands to see the trigger at work:

```sql
-- enable debugging
set client_min_messages to debug;
-- clear latitude from crashes_cris 
update crashes_cris set latitude = null where id = 160441;
-- reset latitude from crashes_cris
update crashes_cris set latitude = 30.19565639 where id = 160441; 
```

Observe the debug statements, which should look like this:
```sql
DEBUG:  Updating crashes record from CRIS update
DEBUG:  found location: 7DB65B49D7 compared to previous location: <NULL>
DEBUG:  in austin full purpose: t compared to previous: t
DEBUG:  council_district: 2 compared to previous: <NULL>
DEBUG:  engineering_area_id: 3 compared to previous: <NULL>
DEBUG:  signal_engineer_area_id: 2 compared to previous: <NULL>
DEBUG:  zipcode: 78744 compared to previous: <NULL>
DEBUG:  apd_sector_id: 10 compared to previous: <NULL>
DEBUG:  is_non_coa_roadway: f compared to previous: t
```

5. Now clear the `latitude` column and verify that the spatial columns are reset:

```sql
update crashes_cris set latitude = null where id = 160441; 
```

6. ✨ Bonus points ✨ Test this CRIS import. This is a bit tricky, because our spatial attribute trigger only fires when lat/lon values have change. So we're actually going to run the CRIS import script twice. I keep an unzipped extract in my `cris_import/extracts`, so it's always as easy as running this docker command:

```shell
 docker run -it  --rm --env-file local.env --network host -v $PWD:/app cris_import_cris_import ./cris_import.py --csv --skip-unzip
```

7. Great, now we're going to nullify the latitude column of all the crashes you just ran through the import. run these commands: 

```sql
-- remember to disable debug logging!
set client_min_messages to error;

-- nullify latitude for every crash that we just updated
update crashes_cris set latitude = null where updated_at >= CURRENT_DATE
```

8. Nice—now run this CRIS import again. once it completes we can check the results of the trigger.

```sql
--- this should return results!
SELECT
    id,
    is_non_coa_roadway,
    apd_sector_id,
    signal_engineer_area_id,
    zipcode
FROM
    crashes
WHERE
    is_non_coa_roadway = FALSE
    AND apd_sector_id IS NOT NULL
    AND signal_engineer_area_id IS NOT NULL
    AND zipcode IS NOT NULL
    AND council_district IS NOT NULL
    AND in_austin_full_purpose IS TRUE;
```
---

9. Lastly, run the down migrations to make sure they apply as expected. 


#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
