### PR TITLE
Crash details page: enable users to collapse the record history card

### DIFF
--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vision-zero-editor",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vision-zero-editor",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/react-hooks": "^3.0.0",

--- a/editor/src/views/Crashes/CrashChangeLog.js
+++ b/editor/src/views/Crashes/CrashChangeLog.js
@@ -71,16 +71,24 @@ const isNewRecordEvent = change => change.operation_type === "create";
 
 /**
  * The primary UI component which renders the change log with clickable rows
- * can be collapsed
+ * The Card defaults to being "collapsed", the open/closed state is stored in localStorage
  */
 export default function CrashChangeLog({ data }) {
   const [selectedChange, setSelectedChange] = useState(null);
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(
+    localStorage.getItem("showHistory") === "true"
+  );
 
   const changes = useChangeLogData(data);
   if (changes.length === 0) {
     return <p>No change history found</p>;
   }
+
+  const toggleCollapseHistory = () => {
+    const nextIsOpen = !isOpen;
+    setIsOpen(nextIsOpen);
+    localStorage.setItem("showHistory", nextIsOpen);
+  };
 
   return (
     <Card>
@@ -89,7 +97,7 @@ export default function CrashChangeLog({ data }) {
           block
           color="link"
           className="text-left m-0 p-0"
-          onClick={() => setIsOpen(!isOpen)}
+          onClick={toggleCollapseHistory}
         >
           Record history
           <Badge color="secondary float-right">{changes.length}</Badge>

--- a/editor/src/views/Crashes/CrashChangeLog.js
+++ b/editor/src/views/Crashes/CrashChangeLog.js
@@ -1,5 +1,13 @@
 import React, { useMemo, useState } from "react";
-import { Card, CardBody, CardHeader, Table } from "reactstrap";
+import {
+  Badge,
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Table,
+  Collapse,
+} from "reactstrap";
 import { formatDateTimeString } from "../../helpers/format";
 import ChangeDetailsModal from "./CrashChangeLogDetails";
 
@@ -63,9 +71,11 @@ const isNewRecordEvent = change => change.operation_type === "create";
 
 /**
  * The primary UI component which renders the change log with clickable rows
+ * can be collapsed
  */
 export default function CrashChangeLog({ data }) {
   const [selectedChange, setSelectedChange] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
 
   const changes = useChangeLogData(data);
   if (changes.length === 0) {
@@ -74,46 +84,58 @@ export default function CrashChangeLog({ data }) {
 
   return (
     <Card>
-      <CardHeader>Record history</CardHeader>
-      <CardBody>
-        <Table responsive striped hover>
-          <thead>
-            <tr>
-              <th>Record type</th>
-              <th>Event</th>
-              <th>Affected fields</th>
-              <th>Edited by</th>
-              <th>Date</th>
-            </tr>
-          </thead>
-          <tbody className="text-monospace">
-            {changes.map(change => (
-              <tr
-                key={change.id}
-                onClick={() => setSelectedChange(change)}
-                style={{ cursor: "pointer" }}
-              >
-                <td>{change.record_type}</td>
-                <td>{change.operation_type}</td>
-                <td>
-                  {isNewRecordEvent(change)
-                    ? ""
-                    : change.affected_fields.join(", ")}
-                </td>
-                <td>{change.created_by}</td>
-                <td>{formatDateTimeString(change.created_at)}</td>
+      <CardHeader>
+        <Button
+          block
+          color="link"
+          className="text-left m-0 p-0"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          Record history
+          <Badge color="secondary float-right">{changes.length}</Badge>
+        </Button>
+      </CardHeader>
+      <Collapse isOpen={isOpen}>
+        <CardBody>
+          <Table responsive striped hover>
+            <thead>
+              <tr>
+                <th>Record type</th>
+                <th>Event</th>
+                <th>Affected fields</th>
+                <th>Edited by</th>
+                <th>Date</th>
               </tr>
-            ))}
-          </tbody>
-        </Table>
-        {/* Modal with change details table */}
-        {selectedChange && (
-          <ChangeDetailsModal
-            selectedChange={selectedChange}
-            setSelectedChange={setSelectedChange}
-          />
-        )}
-      </CardBody>
+            </thead>
+            <tbody className="text-monospace">
+              {changes.map(change => (
+                <tr
+                  key={change.id}
+                  onClick={() => setSelectedChange(change)}
+                  style={{ cursor: "pointer" }}
+                >
+                  <td>{change.record_type}</td>
+                  <td>{change.operation_type}</td>
+                  <td>
+                    {isNewRecordEvent(change)
+                      ? ""
+                      : change.affected_fields.join(", ")}
+                  </td>
+                  <td>{change.created_by}</td>
+                  <td>{formatDateTimeString(change.created_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+          {/* Modal with change details table */}
+          {selectedChange && (
+            <ChangeDetailsModal
+              selectedChange={selectedChange}
+              setSelectedChange={setSelectedChange}
+            />
+          )}
+        </CardBody>
+      </Collapse>
     </Card>
   );
 }

--- a/editor/src/views/Crashes/CrashChangeLog.js
+++ b/editor/src/views/Crashes/CrashChangeLog.js
@@ -9,9 +9,11 @@ import {
   Collapse,
 } from "reactstrap";
 import { formatDateTimeString } from "../../helpers/format";
+import { appCodeName } from "../../helpers/environment";
 import ChangeDetailsModal from "./CrashChangeLogDetails";
 
 const KEYS_TO_IGNORE = ["updated_at", "updated_by", "position"];
+const localStorageKey = `${appCodeName}_show_crash_history`;
 
 /**
  * Return an array of values that are different between the `old` object and `new` object
@@ -76,7 +78,7 @@ const isNewRecordEvent = change => change.operation_type === "create";
 export default function CrashChangeLog({ data }) {
   const [selectedChange, setSelectedChange] = useState(null);
   const [isOpen, setIsOpen] = useState(
-    localStorage.getItem("showHistory") === "true"
+    localStorage.getItem(localStorageKey) === "true"
   );
 
   const changes = useChangeLogData(data);
@@ -87,7 +89,7 @@ export default function CrashChangeLog({ data }) {
   const toggleCollapseHistory = () => {
     const nextIsOpen = !isOpen;
     setIsOpen(nextIsOpen);
-    localStorage.setItem("showHistory", nextIsOpen);
+    localStorage.setItem(localStorageKey, nextIsOpen);
   };
 
   return (

--- a/editor/src/views/Crashes/CrashChangeLog.js
+++ b/editor/src/views/Crashes/CrashChangeLog.js
@@ -99,8 +99,10 @@ export default function CrashChangeLog({ data }) {
           className="text-left m-0 p-0"
           onClick={toggleCollapseHistory}
         >
-          Record history
-          <Badge color="secondary float-right">{changes.length}</Badge>
+          <h5 className="m-0 p-0">
+            <i className="fa fa-history" /> Record history
+            <Badge color="secondary float-right">{changes.length}</Badge>
+          </h5>
         </Button>
       </CardHeader>
       <Collapse isOpen={isOpen}>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/19804

## Testing

**URL to test:** 

https://deploy-preview-1599--atd-vze-staging.netlify.app/#/crashes

**Steps to test:**

The first time you visit a crash page, the Record History card should be collapsed aka closed. 
Click the header to open the card. 
If you refresh or leave and go to a different crash, the card should remain open. 
Clicking again will close the card. 
If you refresh or leave and go to a different crash, the card should remain closed. 

* It wasn't explicitly stated in the issue, but I included the badge with a count of how many entries are in the record history card, to mimic what is in the Units, People and Charges cards
* I considered saving a more generalized "accordion state" object in local storage, with an entry for this Card so that in the future we could store the open/closed state of all the other cards. But I opted to keep it simple

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
