### PR TITLE
Add release drafter github action 

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Associated issues
https://github.com/cityofaustin/atd-data-tech/issues/19588

## Testing

https://github.com/marketplace/actions/release-drafter

I think the only way to test is see that its working as PRs are merged to main.

There are many ways to [configure the drafter](https://github.com/marketplace/actions/release-drafter#configuration-options), some that might be useful for VZ
- specify which paths to include in release notes `- include-paths: ` (i wish we could specify what to exclude, like the app folder but its a whitelist type thing)
- add headers to the template, like Editor, Viewer, API etc
- and if you feel like reworking how the changes are formatted, you can `change-template: '- $TITLE @$AUTHOR (#$NUMBER)'`



---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
