### PR TITLE
Crash details page: use select component for the City field

### DIFF
--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -119,7 +119,7 @@ export const crashesColumns: {
     label: "City",
     editable: true,
     inputType: "select",
-    relationshipName: "rpt_city_id",
+    relationshipName: "city",
     lookupTable: {
       tableSchema: "lookups",
       tableName: "city",

--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -118,7 +118,12 @@ export const crashesColumns: {
     name: "rpt_city_id",
     label: "City",
     editable: true,
-    inputType: "number",
+    inputType: "select",
+    relationshipName: "rpt_city_id",
+    lookupTable: {
+      tableSchema: "lookups",
+      tableName: "city",
+    },
   },
   rpt_hwy_num: {
     name: "rpt_hwy_num",

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -23,6 +23,10 @@ export const GET_CRASH = gql`
         label
       }
       rpt_city_id
+      city {
+        id
+        label
+      }
       light_cond_id
       wthr_cond_id
       obj_struck {

--- a/app/types/crashes.ts
+++ b/app/types/crashes.ts
@@ -33,6 +33,7 @@ export type Crash = {
   road_constr_zone_fl: boolean | null;
   rpt_block_num: string | null;
   rpt_city_id: number | null;
+  city: LookupTableOption | null;
   rpt_hwy_num: string | null;
   rpt_rdwy_sys_id: number | null;
   rpt_road_part_id: number | null;


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20035

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

**Steps to test:**

On the crash page, check out the summary card. You no longer see the number 22 as the City, but instead should see Austin. 

Click once to enter edit mode, change your city and save. Or cancel. 
![Screenshot 2024-12-10 at 9 00 10 AM](https://github.com/user-attachments/assets/8df3bc4c-33c0-46df-b2da-9dc272354b58)


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
