### PR TITLE
Force login screen if the user's token is expired

### DIFF
--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -52,8 +52,13 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
   }, []);
 
   /**
-   * Hook which keeps refreshes the user's token in localstorage and redirects to the
-   * Auth0 login page if the token is expired
+   * Hook which refreshes the user's token and redirects to the Auth0 login page
+   * if the user's session expires. The hook re-runs every time the app route
+   * changes and on a 5-minute loop.
+   * 
+   * Note that the token has a short lifespan
+   * (10 hrs at the time of writing) vs the user session, which is currently
+   * set to 3 days (of inactivity) up to a max of 7 days. 
    */
   useEffect(() => {
     const refreshToken = async () => {
@@ -64,9 +69,11 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
       if (isAuthenticated) {
         try {
           /**
-           * getAccessTokenSilently will fetch a fresh token if current token is still valid,
-           * otherwise it will throw and the user will be redirected to the Auth0
-           * login page
+           * getAccessTokenSilently() will pull the current token from localstorage
+           * if it's valid and not going to expire in the next 60 seconds. otherwise,
+           * it will attempt to fetch a fresh token. if the user no longer has a valid
+           * Auth0 session, getAccessTokenSilently() will fail and the user will be
+           * redirected to the login page
            */
           await getAccessTokenSilently();
         } catch (error) {

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -86,11 +86,10 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
         }
       }
     };
-
     refreshToken();
-
-    const intervalId = setInterval(refreshToken, 60 * 5 * 1000); // Every 5 minutes
-    // Cleanup on unmount
+    // refresh token every 5 minutes
+    const intervalId = setInterval(refreshToken, 60 * 5 * 1000);
+    // cleanup on loop unmount
     return () => clearInterval(intervalId);
   }, [getAccessTokenSilently, loginWithRedirect, isAuthenticated, pathName]);
 


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20253

This PR fixes the issue of your token expiring despite the app acting like you're logged in. It's particularly confusing in local dev because local Hasura does not validate JWTs.

## Testing

**URL to test:** Local

1. Log out and back into the app
2. In your browser's dev console, clear all data from local storage.
3. Navigate to another page in the app, or refresh the page. 
4. When the page loads, the login screen should briefly appear, and then the app should behave normally. You can watch your localstorage re-hydrate with Auth0 data.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
