### PR TITLE
Fix ability to clear table search and refine layout 

### DIFF
--- a/app/components/TableAdvancedSearchFilterMenu.tsx
+++ b/app/components/TableAdvancedSearchFilterMenu.tsx
@@ -55,11 +55,7 @@ export default function TableAdvancedSearchFilterMenu({
         return (
           <Col key={filterCard.id}>
             <Card>
-              <Card.Header>
-                {filterCard.label}
-                {/* todo: showing the group operator here just for debug help */}
-                <span className="ms-2">{`(match: ${filterCard.groupOperator})`}</span>
-              </Card.Header>
+              <Card.Header>{filterCard.label}</Card.Header>
               <Card.Body>
                 <Form>
                   {filterCard.filterGroups?.map((switchFilterGroup) => {

--- a/app/components/TableAdvancedSearchFilterToggle.tsx
+++ b/app/components/TableAdvancedSearchFilterToggle.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useMemo } from "react";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
-import { FaFilter } from "react-icons/fa6";
+import { FaSliders } from "react-icons/fa6";
 import AlignedLabel from "./AlignedLabel";
 import { QueryConfig } from "@/utils/queryBuilder";
 
@@ -47,7 +47,7 @@ export default function TableAdvancedSearchFilterToggle({
       }
     >
       <AlignedLabel>
-        <FaFilter />
+        <FaSliders />
         <span className="mx-2">Filters</span>
         {activeFilterCount > 0 && (
           <Badge bg="primary">{activeFilterCount}</Badge>

--- a/app/components/TablePaginationControls.tsx
+++ b/app/components/TablePaginationControls.tsx
@@ -3,7 +3,6 @@ import { produce } from "immer";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import ButtonToolbar from "react-bootstrap/ButtonToolbar";
-import Spinner from "react-bootstrap/Spinner";
 import AlignedLabel from "./AlignedLabel";
 import { QueryConfig } from "@/utils/queryBuilder";
 import "react-datepicker/dist/react-datepicker.css";
@@ -56,10 +55,7 @@ export default function TablePaginationControls({
           variant="outline-primary"
           style={{ border: "none", pointerEvents: "none" }}
         >
-          {!isLoading && (
-            <span className="mx-2 text-nowrap">{`Page ${currentPageNum}`}</span>
-          )}
-          {isLoading && <Spinner size="sm" variant="primary" />}
+          <span className="mx-2 text-nowrap">{`Page ${currentPageNum}`}</span>
         </Button>
         <Button
           variant="outline-primary"

--- a/app/components/TableResetFiltersToggle.tsx
+++ b/app/components/TableResetFiltersToggle.tsx
@@ -19,12 +19,12 @@ export default function TableResetFiltersToggle({
 }: Props) {
   return (
     <Button
-      variant="outline-danger"
+      variant="outline-secondary"
       onClick={() => setQueryConfig(queryConfig)}
     >
       <AlignedLabel>
         <FaXmark className="me-2" />
-        Reset filters
+        Reset
       </AlignedLabel>
     </Button>
   );

--- a/app/components/TableSearch.tsx
+++ b/app/components/TableSearch.tsx
@@ -33,7 +33,7 @@ export default function TableSearch({
         <FaMagnifyingGlass />
       </InputGroup.Text>
       <Form.Control
-        placeholder="Find a crash..."
+        placeholder="Search..."
         aria-label="Crash search"
         aria-describedby="search-icon"
         onChange={(e) => {
@@ -50,10 +50,9 @@ export default function TableSearch({
               return newQueryConfig;
             });
             setQueryConfig(newQueryConfig);
-          } else {
-            searchSettings.searchString = e.target.value;
-            setSearchSettings({ ...searchSettings });
           }
+          searchSettings.searchString = e.target.value;
+          setSearchSettings({ ...searchSettings });
         }}
         value={searchSettings.searchString}
         type="search"

--- a/app/components/TableSearchFieldSelector.tsx
+++ b/app/components/TableSearchFieldSelector.tsx
@@ -6,7 +6,6 @@ export default function TableSearchFieldSelector({
   setSearchSettings,
   queryConfig,
 }: TableSearchProps) {
-  // todo: bug here where changing the search field clears the search input if it hasn't been searched
   return (
     <>
       <Form.Label className="fw-bold me-2 my-0">Search by </Form.Label>

--- a/app/components/TableSearchFieldSelector.tsx
+++ b/app/components/TableSearchFieldSelector.tsx
@@ -9,7 +9,7 @@ export default function TableSearchFieldSelector({
   // todo: bug here where changing the search field clears the search input if it hasn't been searched
   return (
     <>
-      <Form.Label className="fw-bold me-2 mb-0">Search by </Form.Label>
+      <Form.Label className="fw-bold me-2 my-0">Search by </Form.Label>
       {queryConfig.searchFields.map((field) => {
         return (
           <Form.Check

--- a/app/components/TableWrapper.tsx
+++ b/app/components/TableWrapper.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
+import Spinner from "react-bootstrap/Spinner";
 import isEqual from "lodash/isEqual";
 import { useQuery, useDataCache } from "@/utils/graphql";
 import Table from "@/components/Table";
@@ -131,7 +132,11 @@ export default function TableWrapper<T extends Record<string, unknown>>({
                   setSearchSettings={setSearchSettings}
                 />
               </Col>
-              <Col xs={12} md="auto" className="mt-sm-3 mt-md-0">
+              <Col
+                xs={12}
+                md="auto"
+                className="align-items-center"
+              >
                 <TableDateSelector
                   queryConfig={queryConfig}
                   setQueryConfig={setQueryConfig}
@@ -141,7 +146,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
           </Col>
         </Row>
         <Row className="mb-3">
-          <Col xs={12} md={6} className="d-flex justify-content-between">
+          <Col xs={12} md={6} className="d-flex justify-content-start mt-2">
             {queryConfig.filterCards?.length > 0 && (
               <TableAdvancedSearchFilterToggle
                 setIsFilterOpen={setIsFilterOpen}
@@ -155,15 +160,18 @@ export default function TableWrapper<T extends Record<string, unknown>>({
               setSearchSettings={setSearchSettings}
             />
           </Col>
-          <Col xs="auto">
-            {areFiltersDirty && (
+          {areFiltersDirty && (
+            <Col className="px-0 mt-2" xs="auto">
               <TableResetFiltersToggle
                 queryConfig={initialQueryConfig}
                 setQueryConfig={setQueryConfig}
               />
-            )}
+            </Col>
+          )}
+          <Col className="d-flex justify-content-end align-items-center mt-2">
+            {isLoading && <Spinner variant="primary" />}
           </Col>
-          <Col className="d-flex justify-content-end">
+          <Col className="d-flex justify-content-end mt-2" xs="auto">
             <TablePaginationControls
               queryConfig={queryConfig}
               setQueryConfig={setQueryConfig}


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20310

Fixes a bug with the search input not being clearable. And some light refinements to the UI 👇 

<img width="1445" alt="Screenshot 2024-12-16 at 2 18 26 PM" src="https://github.com/user-attachments/assets/e513b514-0277-4411-bf3b-1ebef2213cbf" />


## Testing

**URL to test:** Local 

**Steps to test:**

1. Navigate to the crashes page and put some text into the search box, but don't hit the **Search** button
2. Use your keyboard to clear the search input. Observe that it can be cleared

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
