### PR TITLE
Add message for when there are no records to RelatedRecordsTable component

### DIFF
--- a/app/components/RelatedRecordTable.tsx
+++ b/app/components/RelatedRecordTable.tsx
@@ -38,16 +38,24 @@ export default function RelatedRecordTable<T extends Record<string, unknown>>({
             </tr>
           </thead>
           <tbody>
-            {records.map((record, i) => (
-              <RelatedRecordTableRow
-                key={i}
-                columns={columns}
-                isValidating={isValidating}
-                onSaveCallback={onSaveCallback}
-                record={record}
-                mutation={mutation}
-              />
-            ))}
+            {records.length === 0 ? (
+              <tr>
+                <td colSpan={columns.length} style={{ textAlign: "center" }}>
+                  No {title.toLowerCase()} found
+                </td>
+              </tr>
+            ) : (
+              records.map((record, i) => (
+                <RelatedRecordTableRow
+                  key={i}
+                  columns={columns}
+                  isValidating={isValidating}
+                  onSaveCallback={onSaveCallback}
+                  record={record}
+                  mutation={mutation}
+                />
+              ))
+            )}
           </tbody>
         </Table>
       </Card.Body>


### PR DESCRIPTION
## Associated issues

This PR hopes to close https://github.com/cityofaustin/atd-data-tech/issues/20318.

## Testing

Grab the deploy preview down below and find a crash with no units (very hard), no charges (pretty easy), or no people (impossible, since the table doesn't exist yet). Essentially, find a crash with no charges, like [this one](https://deploy-preview-1636--vision-zero-nextjs.netlify.app/crashes/20338971), and take a gander at the charges table. You should see a message indicating why the table is empty.

Note: I didn't take the fixed width font choice in use in the changes table. I kept the font in use in the component being enhanced. Right?

---

#### Ship list


- [ ] Code reviewed
- [ ] Product manager approved
