### PR TITLE
Rework token hook to use access token instead of ID token

### DIFF
--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -24,14 +24,8 @@ const localStorageKey = "sidebarCollapsed";
  */
 export default function SidebarLayout({ children }: { children: ReactNode }) {
   const [isCollapsed, setIsCollapsed] = useState(true);
-  const {
-    getAccessTokenSilently,
-    loginWithRedirect,
-    logout,
-    isAuthenticated,
-    isLoading,
-    user,
-  } = useAuth0();
+  const { loginWithRedirect, logout, isAuthenticated, isLoading, user } =
+    useAuth0();
   const pathName = usePathname();
   const segments = useSelectedLayoutSegments();
 
@@ -50,48 +44,6 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
       localStorage.getItem(localStorageKey) === "true";
     setIsCollapsed(collapsedFromStorage);
   }, []);
-
-  /**
-   * Hook which refreshes the user's token and redirects to the Auth0 login page
-   * if the user's session expires. The hook re-runs every time the app route
-   * changes and on a 5-minute loop.
-   * 
-   * Note that the token has a short lifespan
-   * (10 hrs at the time of writing) vs the user session, which is currently
-   * set to 3 days (of inactivity) up to a max of 7 days. 
-   */
-  useEffect(() => {
-    const refreshToken = async () => {
-      /**
-       * No reason to do this if the user is not authenticated, since the login
-       * page will render anyway
-       */
-      if (isAuthenticated) {
-        try {
-          /**
-           * getAccessTokenSilently() will pull the current token from localstorage
-           * if it's valid and not going to expire in the next 60 seconds. otherwise,
-           * it will attempt to fetch a fresh token. if the user no longer has a valid
-           * Auth0 session, getAccessTokenSilently() will fail and the user will be
-           * redirected to the login page
-           */
-          await getAccessTokenSilently();
-        } catch (error) {
-          console.error("Failed to refresh token:", error);
-          loginWithRedirect({
-            appState: {
-              returnTo: pathName,
-            },
-          });
-        }
-      }
-    };
-    refreshToken();
-    // refresh token every 5 minutes
-    const intervalId = setInterval(refreshToken, 60 * 5 * 1000);
-    // cleanup on loop unmount
-    return () => clearInterval(intervalId);
-  }, [getAccessTokenSilently, loginWithRedirect, isAuthenticated, pathName]);
 
   if (isLoading) {
     /**

--- a/app/configs/crashesListViewColumns.tsx
+++ b/app/configs/crashesListViewColumns.tsx
@@ -9,7 +9,7 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
     label: "Crash ID",
     sortable: true,
     valueRenderer: (record: CrashesListRow) => (
-      <Link href={`/crashes/${record.record_locator}`}>
+      <Link href={`/crashes/${record.record_locator}`} prefetch={false}>
         {record.record_locator}
       </Link>
     ),

--- a/app/configs/locationsListViewColumns.tsx
+++ b/app/configs/locationsListViewColumns.tsx
@@ -10,7 +10,7 @@ export const locationsListViewColumns: ColDataCardDef<LocationsListRow>[] =
       label: "Location ID",
       sortable: true,
       valueRenderer: (record: LocationsListRow) => (
-        <Link href={`/locations/${record.location_id}`}>
+        <Link href={`/locations/${record.location_id}`} prefetch={false}>
           {record.location_id}
         </Link>
       ),

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { useAuth0 } from "@auth0/auth0-react";
 import { User } from "@auth0/auth0-react";
 
@@ -53,32 +54,33 @@ export const formatRoleName = (role: string): string => {
 };
 
 /**
- * Hook which retrieves the user's bearer token from the logged-in
- * user's IdToken claims.
- *
- * Todo: our Auth0 app is configured to return idTokens, which are
- * "opaque" proprietary Auth0 tokens, seemingly because this enables us
- * to interact with the User Management API. as a result, we must
- * use idToken.__raw to grab the actual JWT. it seems like our setup
- * may be misconfigured, because accessing .__raw seems like a hack :/
- *
- * the typical setup would enable use to use the getAccessTokenSilently()
- * method, but that doesn't work with the opaque tokens.
- *
- * discussion here: https://community.auth0.com/t/getting-the-jwt-id-token-from-auth0-spa-js/28281/3
+ * Hook which retrieves the user's access token and redirects to the
+ * login page if the user's refresh token has expired
  */
-export const useToken = () => {
-  const [token, setToken] = useState<string>("");
-  const { getIdTokenClaims } = useAuth0();
-  /**
-   * Get the user token - just one time
-   */
+export const useToken = (): string | null => {
+  const pathName = usePathname();
+  const { getAccessTokenSilently, loginWithRedirect, isAuthenticated } =
+    useAuth0();
+  const [token, setToken] = useState<string | null>(null);
   useEffect(() => {
-    if (!token) {
-      getIdTokenClaims().then((idToken) => {
-        setToken(idToken?.__raw || "");
-      });
-    }
-  }, [token, getIdTokenClaims]);
+    const getToken = async () => {
+      if (!isAuthenticated) {
+        return;
+      }
+
+      try {
+        const accessToken = await getAccessTokenSilently();
+        setToken(accessToken);
+      } catch (err) {
+        await loginWithRedirect({
+          appState: {
+            returnTo: pathName,
+          },
+        });
+      }
+    };
+    getToken();
+  }, [getAccessTokenSilently, isAuthenticated, loginWithRedirect]);
+
   return token;
 };

--- a/app/utils/graphql.ts
+++ b/app/utils/graphql.ts
@@ -81,7 +81,7 @@ export const useQuery = <T extends Record<string, unknown>>({
     Variables
   ]): Promise<{ [K in typeof typename]: T[] }> => {
     const hasuraRoleName = getHasuraRoleName(getRolesArray(user));
-    return fetcher([query, variables, token, hasuraRoleName]);
+    return fetcher([query, variables, token || "", hasuraRoleName]);
   };
 
   // todo: document falsey query handling

--- a/app/utils/users.ts
+++ b/app/utils/users.ts
@@ -20,7 +20,7 @@ const fetcher = async (url: string, token: string) =>
  * SWR hook that fetches all users up to the first
  * <INITIAL_PAGE_LIMIT> * <PAGE_SIZE>
  */
-export function useUsersInfinite(token: string) {
+export function useUsersInfinite(token: string | null) {
   const getKey = (pageIndex: number, previousPageData: ListUsersPage) => {
     if (!token) {
       return null;
@@ -37,7 +37,7 @@ export function useUsersInfinite(token: string) {
     isLoading,
     error,
     mutate,
-  } = useSWRInfinite<ListUsersPage>(getKey, (url) => fetcher(url, token), {
+  } = useSWRInfinite<ListUsersPage>(getKey, (url) => fetcher(url, token || ""), {
     revalidateOnReconnect: false,
     revalidateOnFocus: false,
     // initial size ensures that we fetch up to 10 pages of data. if the user base
@@ -58,7 +58,7 @@ export function useUsersInfinite(token: string) {
  *
  * Will not fetch until userId and token are truthy
  */
-export function useUser(userId?: string, token?: string) {
+export function useUser(userId?: string, token?: string | null ) {
   const url = `${process.env.NEXT_PUBLIC_CR3_API_DOMAIN}/user/get_user/${userId}`;
   return useSWR<User | UserAPIError>(
     token && userId ? url : null,

--- a/app/utils/users.ts
+++ b/app/utils/users.ts
@@ -54,9 +54,7 @@ export function useUsersInfinite(token: string | null) {
 }
 
 /**
- * Hook to fetch a single user.
- *
- * Will not fetch until userId and token are truthy
+ * Hook to fetch a single user
  */
 export function useUser(userId?: string, token?: string | null ) {
   const url = `${process.env.NEXT_PUBLIC_CR3_API_DOMAIN}/user/get_user/${userId}`;


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20391

## Testing

**URL to test:** [Netlify](https://deploy-preview-1638--vision-zero-nextjs.netlify.app/)

The best way to test this is to let your auth token expire and verify that the app refreshes it automatically. This takes 24 hours! Here's how to go about it:

1. Login to the deploy preview
2. Inspect your network requests and to copy your bearer token from the graphql request payload
3. Paste your token in `https://jwt.io/` and check the `exp` claim. It should be 24 hours from the time you logged in.
4. Have a great day (optional).
5. 25 hours later, open the deploy preview again. You should be logged in and the crashes page should load normally. Inspect token again, and the `exp` should now be 24 hours in the future. You can inspect the `iat` (Issued At) timestamp to verify your token was just issued.
6. Great, the tokens are refreshing as expected 🚢 


---


#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
