### PR TITLE
Location details: crashes list

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -78,7 +78,8 @@ npm run dev
   - filters are preserved (in local storage) when refreshing the page or navigating back to it
 - Location details page
   - Location polygon map
-  - Location data card displays the location ID
+  - Location data card displays the location ID, crash counts and comp costs
+  - combined cr3 and noncr3 crashes list
 - Navabar:
   - Vision Zero logo displays on left side
   - Avatar image displays on right side with dropdown items
@@ -118,9 +119,6 @@ npm run dev
 - locations
   - export records
 - location details
-  - data card: crash counts and comp costs
-  - cr3 crashes list
-  - noncr3 crashes list
   - crash charts and widgets
 - create crash record
 - upload non-cr3

--- a/app/app/locations/[location_id]/page.tsx
+++ b/app/app/locations/[location_id]/page.tsx
@@ -19,10 +19,9 @@ import { locationCrashesQueryConfig } from "@/configs/locationCrashesTable";
 const typename = "atd_txdot_locations";
 
 /**
- * Hook which returns builds a queryBuilder Filter array with the
- * `location_id` param - this can be passed as a `contextFilter`
- * to the TableWrapper so that locationCrashesList is filtered
- * by location
+ * Hook which returns builds a Filter array with the `location_id` param.
+ * This can be passed as a `contextFilter` to the TableWrapper so that the
+ * location's crashes table is filtered by location.
  * @param {string} locationId - the location ID string from the page route
  * @returns {Filter[]} the Filter array with the single location filter
  */

--- a/app/app/locations/[location_id]/page.tsx
+++ b/app/app/locations/[location_id]/page.tsx
@@ -1,16 +1,43 @@
 "use client";
+import { useMemo } from "react";
 import { notFound } from "next/navigation";
-import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
+import Card from "react-bootstrap/Card";
+import Row from "react-bootstrap/Row";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
 import DataCard from "@/components/DataCard";
 import LocationMapCard from "@/components/LocationMapCard";
+import TableWrapper from "@/components/TableWrapper";
 import { useQuery } from "@/utils/graphql";
 import { GET_LOCATION } from "@/queries/location";
 import { Location } from "@/types/locations";
+import { Filter } from "@/utils/queryBuilder";
 import { locationCardColumns } from "@/configs/locationDataCard";
+import { locationCrashesColumns } from "@/configs/locationCrashesColumns";
+import { locationCrashesQueryConfig } from "@/configs/locationCrashesTable";
 
 const typename = "atd_txdot_locations";
+
+/**
+ * Hook which returns builds a queryBuilder Filter array with the
+ * `location_id` param - this can be passed as a `contextFilter`
+ * to the TableWrapper so that locationCrashesList is filtered
+ * by location
+ * @param {string} locationId - the location ID string from the page route
+ * @returns {Filter[]} the Filter array with the single location filter
+ */
+const useLocationIdFilter = (locationId: string): Filter[] =>
+  useMemo(
+    () => [
+      {
+        id: "location_id",
+        value: locationId,
+        column: "location_id",
+        operator: "_eq",
+      },
+    ],
+    [locationId]
+  );
 
 export default function LocationDetailsPage({
   params,
@@ -19,6 +46,7 @@ export default function LocationDetailsPage({
 }) {
   const locationId = params.location_id;
 
+  const locationIdFilter = useLocationIdFilter(locationId);
   const { data, error } = useQuery<Location>({
     query: locationId ? GET_LOCATION : null,
     variables: { locationId },
@@ -58,6 +86,21 @@ export default function LocationDetailsPage({
             onSaveCallback={() => Promise.resolve()}
             record={location}
           />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Card>
+            <Card.Header>Crashes</Card.Header>
+            <Card.Body>
+              <TableWrapper
+                columns={locationCrashesColumns}
+                initialQueryConfig={locationCrashesQueryConfig}
+                localStorageKey="locationCrashesQueryConfig"
+                contextFilters={locationIdFilter}
+              />
+            </Card.Body>
+          </Card>
         </Col>
       </Row>
     </>

--- a/app/components/TableAdvancedSearchFilterMenu.tsx
+++ b/app/components/TableAdvancedSearchFilterMenu.tsx
@@ -53,7 +53,7 @@ export default function TableAdvancedSearchFilterMenu({
     <Row className="p-2 bg-light">
       {queryConfig.filterCards.map((filterCard) => {
         return (
-          <Col key={filterCard.id}>
+          <Col key={filterCard.id} xs={12} md={3}>
             <Card>
               <Card.Header>{filterCard.label}</Card.Header>
               <Card.Body>

--- a/app/components/TableDateSelector.tsx
+++ b/app/components/TableDateSelector.tsx
@@ -40,7 +40,7 @@ export const getStartOfYearDate = (): Date => {
  * Get start/end DateRange for x years ago
  * [now - numYears, null] - in local time
  */
-const getYearsAgoDate = (numYears: number): Date => {
+export const getYearsAgoDate = (numYears: number): Date => {
   const targetStartDate = new Date();
   targetStartDate.setFullYear(targetStartDate.getFullYear() - numYears);
   return targetStartDate;

--- a/app/components/TableWrapper.tsx
+++ b/app/components/TableWrapper.tsx
@@ -8,7 +8,7 @@ import Table from "@/components/Table";
 import TableSearch, { SearchSettings } from "@/components/TableSearch";
 import TableDateSelector from "@/components/TableDateSelector";
 import TableSearchFieldSelector from "@/components/TableSearchFieldSelector";
-import { QueryConfig, useQueryBuilder } from "@/utils/queryBuilder";
+import { QueryConfig, useQueryBuilder, Filter } from "@/utils/queryBuilder";
 import { ColDataCardDef } from "@/types/types";
 import TableAdvancedSearchFilterMenu from "@/components/TableAdvancedSearchFilterMenu";
 import TableAdvancedSearchFilterToggle from "@/components/TableAdvancedSearchFilterToggle";
@@ -20,6 +20,7 @@ interface TableProps<T extends Record<string, unknown>> {
   columns: ColDataCardDef<T>[];
   initialQueryConfig: QueryConfig;
   localStorageKey: string;
+  contextFilters?: Filter[] 
 }
 
 /**
@@ -30,6 +31,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   initialQueryConfig,
   columns,
   localStorageKey,
+  contextFilters
 }: TableProps<T>) {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [areFiltersDirty, setAreFiltersDirty] = useState(false);
@@ -42,7 +44,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
     ...initialQueryConfig,
   });
 
-  const query = useQueryBuilder(queryConfig);
+  const query = useQueryBuilder(queryConfig, contextFilters);
 
   const { data, isLoading, error } = useQuery<T>({
     // dont fire first query until localstorage is loaded
@@ -105,7 +107,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
 
   /**
    * wait until the localstorage hook resolves to render anything
-   * to prevent filter UI elements from jump
+   * to prevent filter UI elements from jumping
    */
   if (!isLocalStorageLoaded) {
     return;

--- a/app/configs/locationCrashesColumns.tsx
+++ b/app/configs/locationCrashesColumns.tsx
@@ -1,30 +1,67 @@
+import Link from "next/link";
 import { ColDataCardDef } from "@/types/types";
 import { LocationCrashRow } from "@/types/locationCrashes";
+import { formatDate, formatDollars } from "@/utils/formatters";
 
 export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
   {
     path: "type",
     label: "Type",
+    sortable: true,
   },
   {
     path: "record_locator",
     label: "Crash ID",
+    sortable: true,
+    valueRenderer: (record: LocationCrashRow) =>
+      record.record_locator ? (
+        <Link href={`/crashes/${record.record_locator}`}>
+          {record.record_locator}
+        </Link>
+      ) : (
+        ""
+      ),
   },
   {
     path: "case_id",
     label: "Case ID",
+    sortable: true,
+  },
+  {
+    path: "crash_timestamp",
+    label: "Date",
+    sortable: true,
+    valueFormatter: formatDate,
   },
   {
     path: "address_primary",
     label: "Primary address",
+    sortable: true,
   },
   {
     path: "address_secondary",
     label: "Secondary address",
+    sortable: true,
   },
-
+  {
+    path: "sus_serious_injry_count",
+    label: "Serious injuries",
+    sortable: true,
+  },
+  {
+    path: "vz_fatality_count",
+    label: "Fatalities",
+    sortable: true,
+  },
   {
     path: "collsn_desc",
     label: "Collision type",
+    sortable: true,
+  },
+  {
+    path: "est_comp_cost_crash_based",
+    label: "Est Comprehensive Cost",
+    sortable: true,
+    valueFormatter: formatDollars,
   },
 ];

--- a/app/configs/locationCrashesColumns.tsx
+++ b/app/configs/locationCrashesColumns.tsx
@@ -7,6 +7,14 @@ export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
     label: "Type",
   },
   {
+    path: "record_locator",
+    label: "Crash ID",
+  },
+  {
+    path: "case_id",
+    label: "Case ID",
+  },
+  {
     path: "address_primary",
     label: "Primary address",
   },
@@ -14,10 +22,7 @@ export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
     path: "address_secondary",
     label: "Secondary address",
   },
-  {
-    path: "case_id",
-    label: "Case ID",
-  },
+
   {
     path: "collsn_desc",
     label: "Collision type",

--- a/app/configs/locationCrashesColumns.tsx
+++ b/app/configs/locationCrashesColumns.tsx
@@ -1,0 +1,25 @@
+import { ColDataCardDef } from "@/types/types";
+import { LocationCrashRow } from "@/types/locationCrashes";
+
+export const locationCrashesColumns: ColDataCardDef<LocationCrashRow>[] = [
+  {
+    path: "type",
+    label: "Type",
+  },
+  {
+    path: "address_primary",
+    label: "Primary address",
+  },
+  {
+    path: "address_secondary",
+    label: "Secondary address",
+  },
+  {
+    path: "case_id",
+    label: "Case ID",
+  },
+  {
+    path: "collsn_desc",
+    label: "Collision type",
+  },
+];

--- a/app/configs/locationCrashesTable.ts
+++ b/app/configs/locationCrashesTable.ts
@@ -53,7 +53,7 @@ export const locationCrashesQueryConfig: QueryConfig = {
   tableName: "location_crashes_view",
   limit: DEFAULT_QUERY_LIMIT,
   offset: 0,
-  sortColName: "crash_date",
+  sortColName: "crash_timestamp",
   sortAsc: false,
   searchFilter: {
     id: "search",

--- a/app/configs/locationCrashesTable.ts
+++ b/app/configs/locationCrashesTable.ts
@@ -1,0 +1,66 @@
+import { locationCrashesColumns } from "./locationCrashesColumns";
+import { QueryConfig, FilterGroup } from "@/utils/queryBuilder";
+import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
+
+const columns = locationCrashesColumns.map((col) => String(col.path));
+
+const locationCrashesFiltercards: FilterGroup[] = [
+  {
+    id: "primary_filter_card",
+    label: "Crash type",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "cr3_crashes",
+        label: "CR3 crashes",
+        groupOperator: "_and",
+        enabled: false,
+        inverted: false,
+        filters: [
+          {
+            id: "cr3_crashes",
+            column: "type",
+            operator: "_eq",
+            value: "CR3",
+          },
+        ],
+      },
+      {
+        id: "non_cr3_crashes",
+        label: "Non-CR3 crashes",
+        groupOperator: "_and",
+        enabled: false,
+        inverted: false,
+        filters: [
+          {
+            id: "cr3_crashes",
+            column: "type",
+            operator: "_eq",
+            value: "NON-CR3",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const locationCrashesQueryConfig: QueryConfig = {
+  columns,
+  tableName: "location_crashes_view",
+  limit: DEFAULT_QUERY_LIMIT,
+  offset: 0,
+  sortColName: "crash_date",
+  sortAsc: false,
+  searchFilter: {
+    id: "search",
+    value: "",
+    column: "address_primary",
+    operator: "_ilike",
+    wildcard: true,
+  },
+  searchFields: [
+    { label: "Address", value: "address_primary" },
+    { label: "Case ID", value: "case_id" },
+  ],
+  filterCards: locationCrashesFiltercards,
+};

--- a/app/configs/locationCrashesTable.ts
+++ b/app/configs/locationCrashesTable.ts
@@ -2,7 +2,7 @@ import { locationCrashesColumns } from "./locationCrashesColumns";
 import { QueryConfig, FilterGroup } from "@/utils/queryBuilder";
 import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 import {
-  getStartOfYearDate,
+  getYearsAgoDate,
   makeDateFilters,
 } from "@/components/TableDateSelector";
 
@@ -73,7 +73,7 @@ export const locationCrashesQueryConfig: QueryConfig = {
     mode: "5y",
     column: "crash_timestamp",
     filters: makeDateFilters("crash_timestamp", {
-      start: getStartOfYearDate(),
+      start: getYearsAgoDate(5),
       end: null,
     }),
   },

--- a/app/configs/locationCrashesTable.ts
+++ b/app/configs/locationCrashesTable.ts
@@ -1,6 +1,10 @@
 import { locationCrashesColumns } from "./locationCrashesColumns";
 import { QueryConfig, FilterGroup } from "@/utils/queryBuilder";
 import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
+import {
+  getStartOfYearDate,
+  makeDateFilters,
+} from "@/components/TableDateSelector";
 
 const columns = locationCrashesColumns.map((col) => String(col.path));
 
@@ -54,13 +58,24 @@ export const locationCrashesQueryConfig: QueryConfig = {
   searchFilter: {
     id: "search",
     value: "",
-    column: "address_primary",
+    column: "case_id",
     operator: "_ilike",
     wildcard: true,
   },
   searchFields: [
-    { label: "Address", value: "address_primary" },
     { label: "Case ID", value: "case_id" },
+    { label: "Crash ID", value: "record_locator" },
+    { label: "Primary address", value: "address_primary" },
+    { label: "Secondary address", value: "address_secondary" },
+    { label: "Collision type", value: "collsn_desc" },
   ],
+  dateFilter: {
+    mode: "5y",
+    column: "crash_timestamp",
+    filters: makeDateFilters("crash_timestamp", {
+      start: getStartOfYearDate(),
+      end: null,
+    }),
+  },
   filterCards: locationCrashesFiltercards,
 };

--- a/app/types/locationCrashes.ts
+++ b/app/types/locationCrashes.ts
@@ -10,6 +10,7 @@ export type LocationCrashRow = {
   crash_date: string | null;
   crash_sev_id: number | null;
   crash_time: string | null;
+  record_locator: string | null;
   cris_crash_id: number | null;
   day_of_week: string;
   est_comp_cost_crash_based: number | null;

--- a/app/types/locationCrashes.ts
+++ b/app/types/locationCrashes.ts
@@ -1,0 +1,31 @@
+/**
+ * Type which describes the `location_crashes_view`, which combines
+ * CR3 and Non-CR3 crashes
+ */
+export type LocationCrashRow = {
+  address_primary: string | null;
+  address_secondary: string | null;
+  case_id: string | null;
+  collsn_desc: string | null;
+  crash_date: string | null;
+  crash_sev_id: number | null;
+  crash_time: string | null;
+  cris_crash_id: number | null;
+  day_of_week: string;
+  est_comp_cost_crash_based: number | null;
+  latitude: number | null;
+  location_id: string;
+  longitude: number | null;
+  movement_desc: string | null;
+  non_injry_count: number | null;
+  nonincap_injry_count: number | null;
+  poss_injry_count: number | null;
+  sus_serious_injry_count: number | null;
+  tot_injry_count: number | null;
+  travel_direction: string | null;
+  type: "CR3" | "NON-CR3";
+  unkn_injry_count: number | null;
+  veh_body_styl_desc: string | null;
+  veh_unit_desc: string | null;
+  vz_fatality_count: number | null;
+};

--- a/app/types/locationCrashes.ts
+++ b/app/types/locationCrashes.ts
@@ -10,6 +10,7 @@ export type LocationCrashRow = {
   crash_date: string | null;
   crash_sev_id: number | null;
   crash_time: string | null;
+  crash_timestamp: string | null;
   record_locator: string | null;
   cris_crash_id: number | null;
   day_of_week: string;

--- a/app/utils/queryBuilder.ts
+++ b/app/utils/queryBuilder.ts
@@ -411,4 +411,4 @@ export const useQueryBuilder = (
 ): string =>
   useMemo(() => {
     return buildQuery(queryConfig, contextFilters);
-  }, [queryConfig]);
+  }, [queryConfig, contextFilters]);

--- a/app/utils/queryBuilder.ts
+++ b/app/utils/queryBuilder.ts
@@ -302,17 +302,20 @@ const getWhereExp = (filterGroups: FilterGroup[]): string => {
  *    }
  *  }
  */
-const buildQuery = ({
-  columns,
-  tableName,
-  limit,
-  offset,
-  sortColName,
-  sortAsc,
-  filterCards,
-  dateFilter,
-  searchFilter,
-}: QueryConfig): string => {
+const buildQuery = (
+  {
+    columns,
+    tableName,
+    limit,
+    offset,
+    sortColName,
+    sortAsc,
+    filterCards,
+    dateFilter,
+    searchFilter,
+  }: QueryConfig,
+  contextFilters?: Filter[]
+): string => {
   const columnString = columns.join("\n");
 
   /**
@@ -340,6 +343,18 @@ const buildQuery = ({
     allFilterGroups.push({
       id: "date_filters",
       filters: dateFilter.filters,
+      groupOperator: "_and",
+    });
+  }
+
+  /**
+   * Shape context filters like a FilterGroup and add
+   * to all filters
+   */
+  if (contextFilters) {
+    allFilterGroups.push({
+      id: "context_filters",
+      filters: contextFilters,
       groupOperator: "_and",
     });
   }
@@ -382,10 +397,18 @@ const buildQuery = ({
 };
 
 /**
- * Hook which memoizes the graphql query from the
- * provided queryConfig
+ * Hook which builds a memoized graphql query from the query configuration
+ * @param {QueryConfig} queryConfig - the QueryConfig object
+ * @param {Filter[]} contextFilters - an optional filter array to be included the
+ * query's `where` expression. It is expected that these filters would be set from
+ * an app context that is not wanted to be kepts in local storage, such as a
+ * URL query param
+ * @returns {string} a graphql querry
  */
-export const useQueryBuilder = (queryConfig: QueryConfig): string =>
+export const useQueryBuilder = (
+  queryConfig: QueryConfig,
+  contextFilters?: Filter[]
+): string =>
   useMemo(() => {
-    return buildQuery(queryConfig);
+    return buildQuery(queryConfig, contextFilters);
   }, [queryConfig]);

--- a/database/metadata/databases/default/tables/public_location_crashes_view.yaml
+++ b/database/metadata/databases/default/tables/public_location_crashes_view.yaml
@@ -12,6 +12,7 @@ select_permissions:
         - tot_injry_count
         - unkn_injry_count
         - vz_fatality_count
+        - record_locator
         - cris_crash_id
         - crash_sev_id
         - est_comp_cost_crash_based
@@ -43,6 +44,7 @@ select_permissions:
         - tot_injry_count
         - unkn_injry_count
         - vz_fatality_count
+        - record_locator
         - cris_crash_id
         - crash_sev_id
         - est_comp_cost_crash_based
@@ -74,6 +76,7 @@ select_permissions:
         - tot_injry_count
         - unkn_injry_count
         - vz_fatality_count
+        - record_locator
         - cris_crash_id
         - crash_sev_id
         - est_comp_cost_crash_based

--- a/database/metadata/databases/default/tables/public_location_crashes_view.yaml
+++ b/database/metadata/databases/default/tables/public_location_crashes_view.yaml
@@ -24,6 +24,7 @@ select_permissions:
         - collsn_desc
         - crash_date
         - crash_time
+        - crash_timestamp
         - day_of_week
         - location_id
         - movement_desc
@@ -56,6 +57,7 @@ select_permissions:
         - collsn_desc
         - crash_date
         - crash_time
+        - crash_timestamp
         - day_of_week
         - location_id
         - movement_desc
@@ -88,6 +90,7 @@ select_permissions:
         - collsn_desc
         - crash_date
         - crash_time
+        - crash_timestamp
         - day_of_week
         - location_id
         - movement_desc

--- a/database/migrations/default/1734981892414_location_crashes_record_locator/down.sql
+++ b/database/migrations/default/1734981892414_location_crashes_record_locator/down.sql
@@ -1,4 +1,4 @@
--- rever to 1727451511064_init
+-- revert to 1727451511064_init
 DROP VIEW IF EXISTS public.location_crashes_view;
 CREATE VIEW public.location_crashes_view AS
 SELECT

--- a/database/migrations/default/1734981892414_location_crashes_record_locator/down.sql
+++ b/database/migrations/default/1734981892414_location_crashes_record_locator/down.sql
@@ -1,0 +1,137 @@
+-- rever to 1727451511064_init
+DROP VIEW IF EXISTS public.location_crashes_view;
+CREATE VIEW public.location_crashes_view AS
+SELECT
+    crashes.cris_crash_id,
+    'CR3'::text AS type,
+    crashes.location_id,
+    crashes.case_id,
+    to_char(
+        (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
+        'YYYY-MM-DD'::text
+    ) AS crash_date,
+    to_char(
+        (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
+        'HH24:MI:SS'::text
+    ) AS crash_time,
+    upper(
+        to_char(
+            (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
+            'dy'::text
+        )
+    ) AS day_of_week,
+    crash_injury_metrics_view.crash_injry_sev_id AS crash_sev_id,
+    crashes.latitude,
+    crashes.longitude,
+    crashes.address_primary,
+    crashes.address_secondary,
+    crash_injury_metrics_view.non_injry_count,
+    crash_injury_metrics_view.nonincap_injry_count,
+    crash_injury_metrics_view.poss_injry_count,
+    crash_injury_metrics_view.sus_serious_injry_count,
+    crash_injury_metrics_view.tot_injry_count,
+    crash_injury_metrics_view.unkn_injry_count,
+    crash_injury_metrics_view.vz_fatality_count,
+    crash_injury_metrics_view.est_comp_cost_crash_based,
+    collsn.label AS collsn_desc,
+    crash_units.movement_desc,
+    crash_units.travel_direction,
+    crash_units.veh_body_styl_desc,
+    crash_units.veh_unit_desc
+FROM crashes
+LEFT JOIN LATERAL (SELECT
+    units.crash_pk,
+    string_agg(movt.label, ','::text) AS movement_desc,
+    string_agg(trvl_dir.label, ','::text) AS travel_direction,
+    string_agg(veh_body_styl.label, ','::text) AS veh_body_styl_desc,
+    string_agg(unit_desc.label, ','::text) AS veh_unit_desc
+FROM units
+LEFT JOIN lookups.movt AS movt ON units.movement_id = movt.id
+LEFT JOIN
+    lookups.trvl_dir AS trvl_dir
+    ON units.veh_trvl_dir_id = trvl_dir.id
+LEFT JOIN
+    lookups.veh_body_styl AS veh_body_styl
+    ON units.veh_body_styl_id = veh_body_styl.id
+LEFT JOIN
+    lookups.unit_desc AS unit_desc
+    ON units.unit_desc_id = unit_desc.id
+WHERE crashes.id = units.crash_pk
+GROUP BY units.crash_pk) AS crash_units ON true
+LEFT JOIN LATERAL (SELECT
+    crash_injury_metrics_view_1.id,
+    crash_injury_metrics_view_1.cris_crash_id,
+    crash_injury_metrics_view_1.unkn_injry_count,
+    crash_injury_metrics_view_1.nonincap_injry_count,
+    crash_injury_metrics_view_1.poss_injry_count,
+    crash_injury_metrics_view_1.non_injry_count,
+    crash_injury_metrics_view_1.sus_serious_injry_count,
+    crash_injury_metrics_view_1.tot_injry_count,
+    crash_injury_metrics_view_1.fatality_count,
+    crash_injury_metrics_view_1.vz_fatality_count,
+    crash_injury_metrics_view_1.law_enf_fatality_count,
+    crash_injury_metrics_view_1.cris_fatality_count,
+    crash_injury_metrics_view_1.motor_vehicle_fatality_count,
+    crash_injury_metrics_view_1.motor_vehicle_sus_serious_injry_count,
+    crash_injury_metrics_view_1.motorcycle_fatality_count,
+    crash_injury_metrics_view_1.motorcycle_sus_serious_count,
+    crash_injury_metrics_view_1.bicycle_fatality_count,
+    crash_injury_metrics_view_1.bicycle_sus_serious_injry_count,
+    crash_injury_metrics_view_1.pedestrian_fatality_count,
+    crash_injury_metrics_view_1.pedestrian_sus_serious_injry_count,
+    crash_injury_metrics_view_1.micromobility_fatality_count,
+    crash_injury_metrics_view_1.micromobility_sus_serious_injry_count,
+    crash_injury_metrics_view_1.other_fatality_count,
+    crash_injury_metrics_view_1.other_sus_serious_injry_count,
+    crash_injury_metrics_view_1.crash_injry_sev_id,
+    crash_injury_metrics_view_1.years_of_life_lost,
+    crash_injury_metrics_view_1.est_comp_cost_crash_based,
+    crash_injury_metrics_view_1.est_total_person_comp_cost
+FROM crash_injury_metrics_view AS crash_injury_metrics_view_1
+WHERE crashes.id = crash_injury_metrics_view_1.id
+LIMIT 1) AS crash_injury_metrics_view ON true
+LEFT JOIN lookups.collsn ON crashes.fhe_collsn_id = collsn.id
+WHERE
+    crashes.is_deleted = false
+    AND crashes.crash_timestamp >= (now() - '5 years'::interval)::date
+UNION ALL
+SELECT
+    aab.form_id AS cris_crash_id,
+    'NON-CR3'::text AS type,
+    aab.location_id,
+    aab.case_id::text AS case_id,
+    aab.date::text AS crash_date,
+    concat(aab.hour, ':00:00') AS crash_time,
+    (
+        SELECT
+            CASE date_part('dow'::text, aab.date)
+                WHEN 0 THEN 'SUN'::text
+                WHEN 1 THEN 'MON'::text
+                WHEN 2 THEN 'TUE'::text
+                WHEN 3 THEN 'WED'::text
+                WHEN 4 THEN 'THU'::text
+                WHEN 5 THEN 'FRI'::text
+                WHEN 6 THEN 'SAT'::text
+                ELSE 'Unknown'::text
+            END AS "case"
+    ) AS day_of_week,
+    0 AS crash_sev_id,
+    aab.latitude,
+    aab.longitude,
+    aab.address AS address_primary,
+    ''::text AS address_secondary,
+    0 AS non_injry_count,
+    0 AS nonincap_injry_count,
+    0 AS poss_injry_count,
+    0 AS sus_serious_injry_count,
+    0 AS tot_injry_count,
+    0 AS unkn_injry_count,
+    0 AS vz_fatality_count,
+    aab.est_comp_cost_crash_based,
+    ''::text AS collsn_desc,
+    ''::text AS movement_desc,
+    ''::text AS travel_direction,
+    ''::text AS veh_body_styl_desc,
+    ''::text AS veh_unit_desc
+FROM atd_apd_blueform AS aab
+WHERE aab.date >= (now() - '5 years'::interval)::date;

--- a/database/migrations/default/1734981892414_location_crashes_record_locator/up.sql
+++ b/database/migrations/default/1734981892414_location_crashes_record_locator/up.sql
@@ -6,6 +6,7 @@ SELECT
     'CR3'::text AS type,
     crashes.location_id,
     crashes.case_id,
+    crashes.crash_timestamp::timestamptz,
     to_char(
         (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
         'YYYY-MM-DD'::text
@@ -96,11 +97,12 @@ WHERE
     AND crashes.crash_timestamp >= (now() - '5 years'::interval)::date
 UNION ALL
 SELECT
-    aab.form_id as record_locator,
+    null as record_locator,
     aab.form_id AS cris_crash_id,
     'NON-CR3'::text AS type,
     aab.location_id,
     aab.case_id::text AS case_id,
+    ((aab.date + make_interval(hours => aab.hour))::timestamp AT TIME ZONE 'America/Chicago' AT TIME ZONE 'UTC')::timestamptz AS crash_timestamp,
     aab.date::text AS crash_date,
     concat(aab.hour, ':00:00') AS crash_time,
     (

--- a/database/migrations/default/1734981892414_location_crashes_record_locator/up.sql
+++ b/database/migrations/default/1734981892414_location_crashes_record_locator/up.sql
@@ -1,0 +1,138 @@
+DROP VIEW IF EXISTS public.location_crashes_view;
+CREATE VIEW public.location_crashes_view AS
+SELECT
+    crashes.record_locator,
+    crashes.cris_crash_id,
+    'CR3'::text AS type,
+    crashes.location_id,
+    crashes.case_id,
+    to_char(
+        (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
+        'YYYY-MM-DD'::text
+    ) AS crash_date,
+    to_char(
+        (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
+        'HH24:MI:SS'::text
+    ) AS crash_time,
+    upper(
+        to_char(
+            (crashes.crash_timestamp AT TIME ZONE 'US/Central'::text),
+            'dy'::text
+        )
+    ) AS day_of_week,
+    crash_injury_metrics_view.crash_injry_sev_id AS crash_sev_id,
+    crashes.latitude,
+    crashes.longitude,
+    crashes.address_primary,
+    crashes.address_secondary,
+    crash_injury_metrics_view.non_injry_count,
+    crash_injury_metrics_view.nonincap_injry_count,
+    crash_injury_metrics_view.poss_injry_count,
+    crash_injury_metrics_view.sus_serious_injry_count,
+    crash_injury_metrics_view.tot_injry_count,
+    crash_injury_metrics_view.unkn_injry_count,
+    crash_injury_metrics_view.vz_fatality_count,
+    crash_injury_metrics_view.est_comp_cost_crash_based,
+    collsn.label AS collsn_desc,
+    crash_units.movement_desc,
+    crash_units.travel_direction,
+    crash_units.veh_body_styl_desc,
+    crash_units.veh_unit_desc
+FROM crashes
+LEFT JOIN LATERAL (SELECT
+    units.crash_pk,
+    string_agg(movt.label, ','::text) AS movement_desc,
+    string_agg(trvl_dir.label, ','::text) AS travel_direction,
+    string_agg(veh_body_styl.label, ','::text) AS veh_body_styl_desc,
+    string_agg(unit_desc.label, ','::text) AS veh_unit_desc
+FROM units
+LEFT JOIN lookups.movt AS movt ON units.movement_id = movt.id
+LEFT JOIN
+    lookups.trvl_dir AS trvl_dir
+    ON units.veh_trvl_dir_id = trvl_dir.id
+LEFT JOIN
+    lookups.veh_body_styl AS veh_body_styl
+    ON units.veh_body_styl_id = veh_body_styl.id
+LEFT JOIN
+    lookups.unit_desc AS unit_desc
+    ON units.unit_desc_id = unit_desc.id
+WHERE crashes.id = units.crash_pk
+GROUP BY units.crash_pk) AS crash_units ON true
+LEFT JOIN LATERAL (SELECT
+    crash_injury_metrics_view_1.id,
+    crash_injury_metrics_view_1.cris_crash_id,
+    crash_injury_metrics_view_1.unkn_injry_count,
+    crash_injury_metrics_view_1.nonincap_injry_count,
+    crash_injury_metrics_view_1.poss_injry_count,
+    crash_injury_metrics_view_1.non_injry_count,
+    crash_injury_metrics_view_1.sus_serious_injry_count,
+    crash_injury_metrics_view_1.tot_injry_count,
+    crash_injury_metrics_view_1.fatality_count,
+    crash_injury_metrics_view_1.vz_fatality_count,
+    crash_injury_metrics_view_1.law_enf_fatality_count,
+    crash_injury_metrics_view_1.cris_fatality_count,
+    crash_injury_metrics_view_1.motor_vehicle_fatality_count,
+    crash_injury_metrics_view_1.motor_vehicle_sus_serious_injry_count,
+    crash_injury_metrics_view_1.motorcycle_fatality_count,
+    crash_injury_metrics_view_1.motorcycle_sus_serious_count,
+    crash_injury_metrics_view_1.bicycle_fatality_count,
+    crash_injury_metrics_view_1.bicycle_sus_serious_injry_count,
+    crash_injury_metrics_view_1.pedestrian_fatality_count,
+    crash_injury_metrics_view_1.pedestrian_sus_serious_injry_count,
+    crash_injury_metrics_view_1.micromobility_fatality_count,
+    crash_injury_metrics_view_1.micromobility_sus_serious_injry_count,
+    crash_injury_metrics_view_1.other_fatality_count,
+    crash_injury_metrics_view_1.other_sus_serious_injry_count,
+    crash_injury_metrics_view_1.crash_injry_sev_id,
+    crash_injury_metrics_view_1.years_of_life_lost,
+    crash_injury_metrics_view_1.est_comp_cost_crash_based,
+    crash_injury_metrics_view_1.est_total_person_comp_cost
+FROM crash_injury_metrics_view AS crash_injury_metrics_view_1
+WHERE crashes.id = crash_injury_metrics_view_1.id
+LIMIT 1) AS crash_injury_metrics_view ON true
+LEFT JOIN lookups.collsn ON crashes.fhe_collsn_id = collsn.id
+WHERE
+    crashes.is_deleted = false
+    AND crashes.crash_timestamp >= (now() - '5 years'::interval)::date
+UNION ALL
+SELECT
+    aab.form_id as record_locator,
+    aab.form_id AS cris_crash_id,
+    'NON-CR3'::text AS type,
+    aab.location_id,
+    aab.case_id::text AS case_id,
+    aab.date::text AS crash_date,
+    concat(aab.hour, ':00:00') AS crash_time,
+    (
+        SELECT
+            CASE date_part('dow'::text, aab.date)
+                WHEN 0 THEN 'SUN'::text
+                WHEN 1 THEN 'MON'::text
+                WHEN 2 THEN 'TUE'::text
+                WHEN 3 THEN 'WED'::text
+                WHEN 4 THEN 'THU'::text
+                WHEN 5 THEN 'FRI'::text
+                WHEN 6 THEN 'SAT'::text
+                ELSE 'Unknown'::text
+            END AS "case"
+    ) AS day_of_week,
+    0 AS crash_sev_id,
+    aab.latitude,
+    aab.longitude,
+    aab.address AS address_primary,
+    ''::text AS address_secondary,
+    0 AS non_injry_count,
+    0 AS nonincap_injry_count,
+    0 AS poss_injry_count,
+    0 AS sus_serious_injry_count,
+    0 AS tot_injry_count,
+    0 AS unkn_injry_count,
+    0 AS vz_fatality_count,
+    aab.est_comp_cost_crash_based,
+    ''::text AS collsn_desc,
+    ''::text AS movement_desc,
+    ''::text AS travel_direction,
+    ''::text AS veh_body_styl_desc,
+    ''::text AS veh_unit_desc
+FROM atd_apd_blueform AS aab
+WHERE aab.date >= (now() - '5 years'::interval)::date;


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/19979
* https://github.com/cityofaustin/atd-data-tech/issues/19980

This PR adds the crashes list to the location details page. I decided to combine the CR3 and non-cr3 crashes into a single table. This feels like a nice improvement over the dual table experience in the old VZE. What do you think?

<img width="1302" alt="Screenshot 2024-12-23 at 3 17 05 PM" src="https://github.com/user-attachments/assets/ee256406-8274-4b38-93f1-712f6292fb40" />

## Testing

**URL to test:** Local

**Steps to test:**

1. Start your local stack - you'll need to apply migrations and metadata for this one

```shell
# from /database
hasura migrate apply
hasura metadata apply
```

2. Navigation to a location details page and check out that new crashes list. try searching and sorting. Nice!

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
