### PR TITLE
Create crash records

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -93,7 +93,10 @@ npm run dev
   - add a new user
   - edit a user
   - delete a user
-
+- create crash records
+  - view + search for temp records
+  - create crash record form
+  
 ## Todo
 
 - permissions-based features:
@@ -124,6 +127,8 @@ npm run dev
   - noncr3 crashes list
   - crash charts and widgets
 - create crash record
+  - delete crash record
+  - hide page from read-only users
 - upload non-cr3
 - dashboard
 - users

--- a/app/app/crashes/[record_locator]/page.tsx
+++ b/app/app/crashes/[record_locator]/page.tsx
@@ -11,6 +11,7 @@ import { useQuery } from "@/utils/graphql";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
 import CrashHeader from "@/components/CrashHeader";
 import CrashLocationBanner from "@/components/CrashLocationBanner";
+import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
 import DataCard from "@/components/DataCard";
 import RelatedRecordTable from "@/components/RelatedRecordTable";
@@ -65,6 +66,10 @@ export default function CrashDetailsPage({
         (crash.private_dr_fl || !crash.in_austin_full_purpose) && (
           <CrashLocationBanner privateDriveFlag={crash.private_dr_fl} />
         )
+      }
+      {
+        // show alert if crash is a temp record
+        crash.is_temp_record && <CrashIsTemporaryBanner crashId={crash.id} />
       }
       <Row>
         <Col sm={12} md={6} lg={4} className="mb-3">

--- a/app/app/create-crash-record/page.tsx
+++ b/app/app/create-crash-record/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
 import AlignedLabel from "@/components/AlignedLabel";
@@ -9,8 +8,7 @@ import CreateCrashRecordModal from "@/components/CreateCrashRecordModal";
 import TableWrapper from "@/components/TableWrapper";
 import { FaCirclePlus } from "react-icons/fa6";
 import { tempCrashesListViewQueryConfig } from "@/configs/tempCrashesTable";
-import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
-import { Crash } from "@/types/crashes";
+import { tempCrashesListViewColumns } from "@/configs/tempCrashesListViewColumns";
 
 const localStorageKey = "tempCrashesListViewQueryConfig";
 
@@ -40,7 +38,7 @@ export default function CreateCrashRecord() {
           </div>
           {/* todo: create column array for this page */}
           <TableWrapper
-            columns={crashesListViewColumns}
+            columns={tempCrashesListViewColumns}
             initialQueryConfig={tempCrashesListViewQueryConfig}
             localStorageKey={localStorageKey}
             refetch={refetch}

--- a/app/app/create-crash-record/page.tsx
+++ b/app/app/create-crash-record/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Button from "react-bootstrap/Button";
+import Card from "react-bootstrap/Card";
+import AlignedLabel from "@/components/AlignedLabel";
+import AppBreadCrumb from "@/components/AppBreadCrumb";
+import CreateCrashRecordModal from "@/components/CreateCrashRecordModal";
+import TableWrapper from "@/components/TableWrapper";
+import { FaCirclePlus } from "react-icons/fa6";
+import { tempCrashesListViewQueryConfig } from "@/configs/tempCrashesTable";
+import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
+import { Crash } from "@/types/crashes";
+
+const localStorageKey = "tempCrashesListViewQueryConfig";
+
+export default function CreateCrashRecord() {
+  const [refetch, setRefetch] = useState(false);
+  const [showNewUserModal, setShowNewUserModal] = useState(false);
+  const onCloseModal = () => setShowNewUserModal(false);
+
+  const onSaveCallback = useCallback(() => {
+    setRefetch((prev) => !prev);
+    setShowNewUserModal(false);
+  }, [setRefetch]);
+
+  return (
+    <>
+      <AppBreadCrumb />
+      <Card>
+        <Card.Header className="fs-5 fw-bold">Temporary records</Card.Header>
+        <Card.Body>
+          <div>
+            <Button className="me-2" onClick={() => setShowNewUserModal(true)}>
+              <AlignedLabel>
+                <FaCirclePlus className="me-2" />
+                <span>Create crash record</span>
+              </AlignedLabel>
+            </Button>
+          </div>
+          {/* todo: create column array for this page */}
+          <TableWrapper
+            columns={crashesListViewColumns}
+            initialQueryConfig={tempCrashesListViewQueryConfig}
+            localStorageKey={localStorageKey}
+            refetch={refetch}
+          />
+        </Card.Body>
+      </Card>
+      <CreateCrashRecordModal
+        onClose={onCloseModal}
+        show={showNewUserModal}
+        onSubmitCallback={onSaveCallback}
+      />
+    </>
+  );
+}

--- a/app/app/create-crash-record/page.tsx
+++ b/app/app/create-crash-record/page.tsx
@@ -36,7 +36,6 @@ export default function CreateCrashRecord() {
               </AlignedLabel>
             </Button>
           </div>
-          {/* todo: create column array for this page */}
           <TableWrapper
             columns={tempCrashesListViewColumns}
             initialQueryConfig={tempCrashesListViewQueryConfig}

--- a/app/components/CrashIsTemporaryBanner.tsx
+++ b/app/components/CrashIsTemporaryBanner.tsx
@@ -1,0 +1,68 @@
+import { useRouter } from "next/navigation";
+import { useAuth0 } from "@auth0/auth0-react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Spinner from "react-bootstrap/Spinner";
+import { FaTrash, FaTriangleExclamation } from "react-icons/fa6";
+import AlignedLabel from "./AlignedLabel";
+import { useMutation } from "@/utils/graphql";
+import { DELETE_CRIS_CRASH } from "@/queries/crash";
+
+interface CrashIsTemporaryBannerProps {
+  crashId: number;
+}
+
+/**
+ * Banner that alerts the user when viewing a "temporary" crash record, aka
+ * a crash record that was manually created through the UI
+ */
+export default function CrashIsTemporaryBanner({
+  crashId,
+}: CrashIsTemporaryBannerProps) {
+  const { user } = useAuth0();
+  const { mutate, loading: isMutating } = useMutation(DELETE_CRIS_CRASH);
+  const router = useRouter();
+
+  return (
+    <Alert
+      variant="warning"
+      className="d-flex justify-content-between align-items-center"
+    >
+      <span className="d-flex align-items-center">
+        <FaTriangleExclamation className="me-2 d-none d-lg-inline" />
+        <span className="me-3">
+          This crash record was created by the Vision Zero team and serves as a
+          placeholder until the CR3 report is received from TxDOT. It may be
+          deleted at any time.
+        </span>
+      </span>
+      <span>
+        <Button
+          variant="danger"
+          onClick={async () => {
+            if (
+              window.confirm(
+                "Are you sure you want to delete this crash record?"
+              )
+            ) {
+              await mutate({ id: crashId, updated_by: user?.email });
+              router.push("/create-crash-record");
+            }
+          }}
+          disabled={isMutating}
+        >
+          <AlignedLabel>
+            {isMutating ? (
+              <Spinner size="sm" />
+            ) : (
+              <>
+                <FaTrash className="me-2" />
+                <span>Delete</span>
+              </>
+            )}
+          </AlignedLabel>
+        </Button>
+      </span>
+    </Alert>
+  );
+}

--- a/app/components/CrashLocationBanner.tsx
+++ b/app/components/CrashLocationBanner.tsx
@@ -1,4 +1,6 @@
 import Alert from "react-bootstrap/Alert";
+import { FaTriangleExclamation } from "react-icons/fa6";
+import AlignedLabel from "./AlignedLabel";
 
 interface CrashLocationBannerProps {
   /**
@@ -15,10 +17,16 @@ export default function CrashLocationBanner({
 }: CrashLocationBannerProps) {
   return (
     <Alert variant="warning">
-      This crash is not included in Vision Zero statistical reporting because{" "}
-      {privateDriveFlag
-        ? "it occurred on a private drive"
-        : "it is located outside of the Austin full purpose jurisdiction"}
+      <AlignedLabel>
+        <FaTriangleExclamation className="me-2 d-none d-lg-inline" />
+        <span className="me-3">
+          This crash is not included in Vision Zero statistical reporting
+          because{" "}
+          {privateDriveFlag
+            ? "it occurred on a private drive"
+            : "it is located outside of the Austin full purpose jurisdiction"}
+        </span>
+      </AlignedLabel>
     </Alert>
   );
 }

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -1,0 +1,371 @@
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Card from "react-bootstrap/Card";
+import Form from "react-bootstrap/Form";
+import Modal from "react-bootstrap/Modal";
+import Spinner from "react-bootstrap/Spinner";
+import AlignedLabel from "@/components/AlignedLabel";
+import FormControlDatePicker from "@/components/FormControlDatePicker";
+import { FaCirclePlus, FaCircleMinus } from "react-icons/fa6";
+import { useForm, SubmitHandler, useFieldArray } from "react-hook-form";
+import { useQuery, useMutation } from "@/utils/graphql";
+import { UNIT_TYPES_QUERY } from "@/queries/unit";
+import { CREATE_CRASH } from "@/queries/crash";
+import { LookupTableOption } from "@/types/relationships";
+import { Crash } from "@/types/crashes";
+import { useAuth0 } from "@auth0/auth0-react";
+
+interface CreateCrashModalProps {
+  /**
+   * A callback fired when either the modal backdrop is clicked, or the
+   * escape key is pressed
+   */
+  onClose: () => void;
+  /**
+   * An async callback fired after the user form is successfully submitted
+   */
+  onSubmitCallback: (crash: Crash) => Promise<void>;
+  /**
+   * If the modal should be visible or hidden
+   */
+  show: boolean;
+}
+
+type UnitInputs = {
+  unit_desc_id: string;
+  fatality_count: number;
+  injury_count: number;
+};
+
+type CrashInputs = {
+  case_id: string;
+  crash_timestamp: string;
+  created_by: string;
+  cris_schema_version: "2023";
+  is_temp_record: boolean;
+  private_dr_fl: boolean;
+  rpt_city_id: number;
+  rpt_sec_street_name: string;
+  rpt_street_name: string;
+  units_cris: UnitInputs[];
+  updated_by: string;
+};
+
+const DEFAULT_UNIT: UnitInputs = {
+  unit_desc_id: "",
+  fatality_count: 0,
+  injury_count: 0,
+};
+
+const DEFAULT_FORM_VALUES: CrashInputs = {
+  case_id: "",
+  crash_timestamp: "",
+  created_by: "",
+  cris_schema_version: "2023",
+  is_temp_record: true,
+  private_dr_fl: false,
+  rpt_city_id: 22,
+  rpt_sec_street_name: "",
+  rpt_street_name: "",
+  units_cris: [{ ...DEFAULT_UNIT }],
+  updated_by: "",
+};
+
+/**
+ * Construct a unit record with people records such
+ * that it can be included in a crash insert mutation
+ */
+const makeUnitRecord = (unit: UnitInputs, index: number, userEmail: string) => {
+  const unitRecord = {
+    unit_nbr: index + 1,
+    unit_desc_id: unit.unit_desc_id,
+    cris_schema_version: "2023",
+    updated_by: userEmail,
+    created_by: userEmail,
+    people_cris: {
+      data: [],
+    },
+  };
+
+  const unitNumber = index + 1;
+
+  // create fatal injuries
+  for (let i = 0; i < Number(unit.fatality_count); i++) {
+    unitRecord.people_cris.data.push({
+      prsn_nbr: i + 1,
+      unit_nbr: unitNumber,
+      prsn_injry_sev_id: 4,
+      cris_schema_version: "2023",
+      is_primary_person: true,
+      updated_by: userEmail,
+      created_by: userEmail,
+    });
+  }
+
+  // create other injuries
+  for (let i = 0; i < Number(unit.injury_count); i++) {
+    unitRecord.people_cris.data.push({
+      prsn_nbr: unit.fatality_count + i + 1,
+      unit_nbr: unitNumber,
+      prsn_injry_sev_id: 1,
+      cris_schema_version: "2023",
+      is_primary_person: true,
+      updated_by: userEmail,
+      created_by: userEmail,
+    });
+  }
+  return unitRecord;
+};
+
+/**
+ * Modal form component used for creating a temporary crash record
+ */
+export default function CreateCrashRecordModal({
+  onClose,
+  onSubmitCallback,
+  show,
+}: CreateCrashModalProps) {
+  const { user } = useAuth0();
+  const { data: unitTypes, isLoading: isLoadingUnitTypes } =
+    useQuery<LookupTableOption>({
+      query: UNIT_TYPES_QUERY,
+      typename: "lookups_unit_desc",
+    });
+  const { mutate, loading: isSubmitting } = useMutation(CREATE_CRASH);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+    reset,
+  } = useForm<CrashInputs>({
+    defaultValues: {
+      ...DEFAULT_FORM_VALUES,
+      created_by: user?.email || "",
+      updated_by: user?.email || "",
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "units_cris",
+  });
+
+  const onSubmit: SubmitHandler<CrashInputs> = async (data) => {
+    const crash: Record<string, unknown> = data;
+    crash.units_cris = {
+      data: data.units_cris.map((unit, i) =>
+        makeUnitRecord(unit, i, user?.email || "")
+      ),
+    };
+
+    const responseData = await mutate<{
+      insert_crashes_cris: { returning: Crash[] };
+    }>({ crash });
+
+    if (responseData && responseData.insert_crashes_cris) {
+      await onSubmitCallback(responseData.insert_crashes_cris?.returning[0]);
+    }
+    reset();
+  };
+
+  return (
+    <Modal
+      show={show}
+      onHide={() => {
+        reset();
+        onClose();
+      }}
+      animation={false}
+      backdrop="static"
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>Create crash record</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form onSubmit={handleSubmit(onSubmit)} id="userForm">
+          <Form.Group className="mb-3">
+            <Form.Label>Case ID</Form.Label>
+            <Form.Control
+              {...register("case_id", { required: true })}
+              autoComplete="off"
+              data-1p-ignore
+              placeholder="Case ID"
+              isInvalid={Boolean(errors.case_id)}
+              autoFocus
+            />
+            <Form.Control.Feedback>Required</Form.Control.Feedback>
+            <Form.Control.Feedback type="invalid">
+              Case ID is required
+            </Form.Control.Feedback>
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label>Crash date</Form.Label>
+            <FormControlDatePicker<CrashInputs>
+              name="crash_timestamp"
+              control={control}
+              isInvalid={Boolean(errors?.crash_timestamp)}
+              {...{ rules: { required: true } }}
+            />
+            <Form.Control.Feedback
+              type="invalid"
+              style={{
+                // manually control date picker feedback
+                display: Boolean(errors?.crash_timestamp) ? "block" : "none",
+              }}
+            >
+              Crash date is required
+            </Form.Control.Feedback>
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label>Primary address</Form.Label>
+            <Form.Control
+              {...register("rpt_street_name", {
+                required: true,
+                setValueAs: (v) => v?.trim() || null,
+              })}
+              autoComplete="off"
+              data-1p-ignore
+              placeholder="ex: W 4TH ST"
+              isInvalid={Boolean(errors.rpt_street_name)}
+            />
+            <Form.Control.Feedback type="invalid">
+              Primary address is required
+            </Form.Control.Feedback>
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label>Secondary address</Form.Label>
+            <Form.Control
+              {...register("rpt_sec_street_name", {
+                setValueAs: (v) => v?.trim() || null,
+              })}
+              autoComplete="off"
+              data-1p-ignore
+              placeholder="ex: 100 S CONGRESS AVE"
+              isInvalid={Boolean(errors.rpt_street_name)}
+            />
+          </Form.Group>
+          {fields.map((field, index) => {
+            return (
+              <Card className="mb-3" key={index}>
+                <Card.Header className="d-flex justify-content-between">
+                  <span>Unit</span>
+                  {fields.length > 1 && (
+                    <Button
+                      size="sm"
+                      variant="outline-danger"
+                      onClick={() => remove(index)}
+                    >
+                      <AlignedLabel>
+                        <FaCircleMinus className="me-2" />
+                        <span>Remove</span>
+                      </AlignedLabel>
+                    </Button>
+                  )}
+                </Card.Header>
+                <Card.Body>
+                  <Form.Group className="mb-3">
+                    <Form.Label>Unit type</Form.Label>
+                    {unitTypes && (
+                      <Form.Select
+                        {...register(`units_cris.${index}.unit_desc_id`, {
+                          // coerce to number or null
+                          required: true,
+                          setValueAs: (v) => Number(v) || null,
+                        })}
+                        isInvalid={Boolean(
+                          errors.units_cris?.[index]?.unit_desc_id
+                        )}
+                      >
+                        <option value="">Select...</option>
+                        {unitTypes.map((option) => (
+                          <option key={option.id} value={String(option.id)}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </Form.Select>
+                    )}
+                    <Form.Control.Feedback type="invalid">
+                      Unit type is required
+                    </Form.Control.Feedback>
+                    {isLoadingUnitTypes && <Spinner size="sm" />}
+                  </Form.Group>
+                  <Form.Group className="mb-3">
+                    <Form.Label>Fatlity count</Form.Label>
+                    {unitTypes && (
+                      <Form.Control
+                        {...register(`units_cris.${index}.fatality_count`, {
+                          required: true,
+                          setValueAs: (v) => Number(v),
+                        })}
+                        isInvalid={Boolean(
+                          errors.units_cris?.[index]?.fatality_count
+                        )}
+                      />
+                    )}
+                    <Form.Control.Feedback type="invalid">
+                      Fatality count is required
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                  <Form.Group className="mb-3">
+                    <Form.Label>Injury count</Form.Label>
+                    {unitTypes && (
+                      <Form.Control
+                        {...register(`units_cris.${index}.injury_count`, {
+                          required: true,
+                          setValueAs: (v) => Number(v),
+                        })}
+                        isInvalid={Boolean(
+                          errors.units_cris?.[index]?.injury_count
+                        )}
+                      />
+                    )}
+                    <Form.Control.Feedback type="invalid">
+                      Injury count is required
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                </Card.Body>
+              </Card>
+            );
+          })}
+          <div className="text-end">
+            <Button
+              size="sm"
+              variant="outline-primary"
+              onClick={() => append({ ...DEFAULT_UNIT })}
+            >
+              <AlignedLabel>
+                <FaCirclePlus className="me-2" />
+                Add unit
+              </AlignedLabel>
+            </Button>
+          </div>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        {!isSubmitting && (
+          <Button
+            variant="secondary"
+            onClick={() => {
+              reset();
+              onClose();
+            }}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          variant="primary"
+          type="submit"
+          form="userForm"
+          disabled={isSubmitting}
+        >
+          {isSubmitting && <Spinner size="sm" />}
+          {!isSubmitting && <span>Create crash record</span>}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -9,7 +9,7 @@ import { FaCirclePlus, FaCircleMinus } from "react-icons/fa6";
 import { useForm, SubmitHandler, useFieldArray } from "react-hook-form";
 import { useQuery, useMutation } from "@/utils/graphql";
 import { UNIT_TYPES_QUERY } from "@/queries/unit";
-import { CREATE_CRASH } from "@/queries/crash";
+import { CREATE_CRIS_CRASH } from "@/queries/crash";
 import { LookupTableOption } from "@/types/relationships";
 import { Crash } from "@/types/crashes";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -132,7 +132,7 @@ export default function CreateCrashRecordModal({
       query: UNIT_TYPES_QUERY,
       typename: "lookups_unit_desc",
     });
-  const { mutate, loading: isSubmitting } = useMutation(CREATE_CRASH);
+  const { mutate, loading: isSubmitting } = useMutation(CREATE_CRIS_CRASH);
 
   const {
     register,

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -166,7 +166,7 @@ export default function CreateCrashRecordModal({
     }>({ crash });
 
     if (responseData && responseData.insert_crashes_cris) {
-    onSubmitCallback();
+      onSubmitCallback();
     }
     reset();
   };
@@ -186,7 +186,7 @@ export default function CreateCrashRecordModal({
       </Modal.Header>
       <Modal.Body>
         <Form onSubmit={handleSubmit(onSubmit)} id="userForm">
-            {/* Case Id */}
+          {/* Case Id */}
           <Form.Group className="mb-3">
             <Form.Label>Case ID</Form.Label>
             <Form.Control
@@ -227,7 +227,7 @@ export default function CreateCrashRecordModal({
             <Form.Control
               {...register("rpt_street_name", {
                 required: true,
-                setValueAs: (v) => v?.trim() || null,
+                setValueAs: (v) => v?.trim().toUpperCase() || null,
               })}
               autoComplete="off"
               data-1p-ignore
@@ -243,7 +243,7 @@ export default function CreateCrashRecordModal({
             <Form.Label>Secondary address</Form.Label>
             <Form.Control
               {...register("rpt_sec_street_name", {
-                setValueAs: (v) => v?.trim() || null,
+                setValueAs: (v) => v?.trim().toUpperCase() || null,
               })}
               autoComplete="off"
               data-1p-ignore
@@ -302,16 +302,21 @@ export default function CreateCrashRecordModal({
                     {unitTypes && (
                       <Form.Control
                         {...register(`units_cris.${index}.fatality_count`, {
-                          required: true,
-                          setValueAs: (v) => Number(v),
+                          required: "Fatality count is required",
+                          min: { value: 0, message: "Cannot be less than 0" },
+                          pattern: {
+                            value: /^\d+$/,
+                            message: "Must be a number",
+                          },
                         })}
                         isInvalid={Boolean(
                           errors.units_cris?.[index]?.fatality_count
                         )}
+                        inputMode="numeric"
                       />
                     )}
                     <Form.Control.Feedback type="invalid">
-                      Fatality count is required
+                      {errors?.units_cris?.[index]?.fatality_count?.message}
                     </Form.Control.Feedback>
                   </Form.Group>
                   <Form.Group className="mb-3">
@@ -319,16 +324,21 @@ export default function CreateCrashRecordModal({
                     {unitTypes && (
                       <Form.Control
                         {...register(`units_cris.${index}.injury_count`, {
-                          required: true,
-                          setValueAs: (v) => Number(v),
+                          required: "Injury count is required",
+                          min: { value: 0, message: "Cannot be less than 0" },
+                          pattern: {
+                            value: /^\d+$/,
+                            message: "Must be a number",
+                          },
                         })}
                         isInvalid={Boolean(
                           errors.units_cris?.[index]?.injury_count
                         )}
+                        inputMode="numeric"
                       />
                     )}
                     <Form.Control.Feedback type="invalid">
-                      Injury count is required
+                      {errors?.units_cris?.[index]?.injury_count?.message}
                     </Form.Control.Feedback>
                   </Form.Group>
                 </Card.Body>

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -248,7 +248,7 @@ export default function CreateCrashRecordModal({
               autoComplete="off"
               data-1p-ignore
               placeholder="ex: 100 S CONGRESS AVE"
-              isInvalid={Boolean(errors.rpt_street_name)}
+              isInvalid={Boolean(errors.rpt_sec_street_name)}
             />
           </Form.Group>
           {/* Repeatable unit inputs */}

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -186,6 +186,7 @@ export default function CreateCrashRecordModal({
       </Modal.Header>
       <Modal.Body>
         <Form onSubmit={handleSubmit(onSubmit)} id="userForm">
+            {/* Case Id */}
           <Form.Group className="mb-3">
             <Form.Label>Case ID</Form.Label>
             <Form.Control
@@ -201,6 +202,7 @@ export default function CreateCrashRecordModal({
               Case ID is required
             </Form.Control.Feedback>
           </Form.Group>
+          {/* Crash date */}
           <Form.Group className="mb-3">
             <Form.Label>Crash date</Form.Label>
             <FormControlDatePicker<CrashInputs>
@@ -219,6 +221,7 @@ export default function CreateCrashRecordModal({
               Crash date is required
             </Form.Control.Feedback>
           </Form.Group>
+          {/* Primary address */}
           <Form.Group className="mb-3">
             <Form.Label>Primary address</Form.Label>
             <Form.Control
@@ -235,6 +238,7 @@ export default function CreateCrashRecordModal({
               Primary address is required
             </Form.Control.Feedback>
           </Form.Group>
+          {/* Secondary address */}
           <Form.Group className="mb-3">
             <Form.Label>Secondary address</Form.Label>
             <Form.Control
@@ -247,6 +251,7 @@ export default function CreateCrashRecordModal({
               isInvalid={Boolean(errors.rpt_street_name)}
             />
           </Form.Group>
+          {/* Repeatable unit inputs */}
           {fields.map((field, index) => {
             return (
               <Card className="mb-3" key={index}>

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -298,7 +298,7 @@ export default function CreateCrashRecordModal({
                     {isLoadingUnitTypes && <Spinner size="sm" />}
                   </Form.Group>
                   <Form.Group className="mb-3">
-                    <Form.Label>Fatlity count</Form.Label>
+                    <Form.Label>Fatality count</Form.Label>
                     {unitTypes && (
                       <Form.Control
                         {...register(`units_cris.${index}.fatality_count`, {

--- a/app/components/FormControlDatePicker.tsx
+++ b/app/components/FormControlDatePicker.tsx
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  useFormContext,
+  ControllerProps,
+  FieldValues,
+  Path,
+  Control,
+} from "react-hook-form";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+
+interface FormControlDatePickerProps<TFormValues extends FieldValues> {
+  name: Path<TFormValues>;
+  control: Control<TFormValues>;
+  controllerProps?: Partial<ControllerProps>;
+  isInvalid?: boolean;
+}
+
+/**
+ * Date picker component for react-hook-form
+ */
+export default function FormControlDatePickerr<
+  TFormValues extends FieldValues
+>({
+  name,
+  control,
+  isInvalid,
+  ...controllerProps
+}: FormControlDatePickerProps<TFormValues>) {
+  return (
+    <Controller
+      name={name}
+      control={control}
+      {...controllerProps}
+      render={({ field: { onChange, value } }) => (
+        <DatePicker
+          className={`form-control ${isInvalid ? "is-invalid" : ""}`}
+          wrapperClassName={`form-control`}
+          toggleCalendarOnIconClick
+          onChange={onChange}
+          selected={value}
+          showIcon
+          showTimeSelect
+          dateFormat="MM/dd/yyyy h:mm aa"
+          timeFormat="h:mm aa"
+          timeIntervals={15}
+        />
+      )}
+    />
+  );
+}

--- a/app/components/FormControlDatePicker.tsx
+++ b/app/components/FormControlDatePicker.tsx
@@ -31,7 +31,7 @@ interface FormControlDatePickerProps<TFormValues extends FieldValues> {
 /**
  * Date picker component for react-hook-form
  */
-export default function FormControlDatePickerr<
+export default function FormControlDatePicker<
   TFormValues extends FieldValues
 >({
   name,

--- a/app/components/FormControlDatePicker.tsx
+++ b/app/components/FormControlDatePicker.tsx
@@ -9,9 +9,22 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
 interface FormControlDatePickerProps<TFormValues extends FieldValues> {
+  /**
+   * The field name
+   */
   name: Path<TFormValues>;
+  /**
+   * The react-hook-form `control`
+   */
   control: Control<TFormValues>;
+  /**
+   * Additional optional controller props
+   */
   controllerProps?: Partial<ControllerProps>;
+  /**
+   * Optional invalid state while will cause the `is-invalid` css class
+   * to be applied
+   */
   isInvalid?: boolean;
 }
 

--- a/app/components/FormControlDatePicker.tsx
+++ b/app/components/FormControlDatePicker.tsx
@@ -1,6 +1,5 @@
 import {
   Controller,
-  useFormContext,
   ControllerProps,
   FieldValues,
   Path,

--- a/app/components/FormControlDatePicker.tsx
+++ b/app/components/FormControlDatePicker.tsx
@@ -56,6 +56,7 @@ export default function FormControlDatePicker<
           dateFormat="MM/dd/yyyy h:mm aa"
           timeFormat="h:mm aa"
           timeIntervals={15}
+          placeholderText="1/1/2025 00:00"
         />
       )}
     />

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -13,7 +13,7 @@ import {
   FaLocationDot,
   FaAngleRight,
   FaUserGroup,
-  FaCirclePlus
+  FaCirclePlus,
 } from "react-icons/fa6";
 import AppNavBar from "./AppNavBar";
 import SideBarListItem from "./SideBarListItem";
@@ -56,10 +56,10 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
    * Hook which refreshes the user's token and redirects to the Auth0 login page
    * if the user's session expires. The hook re-runs every time the app route
    * changes and on a 5-minute loop.
-   * 
+   *
    * Note that the token has a short lifespan
    * (10 hrs at the time of writing) vs the user session, which is currently
-   * set to 3 days (of inactivity) up to a max of 7 days. 
+   * set to 3 days (of inactivity) up to a max of 7 days.
    */
   useEffect(() => {
     const refreshToken = async () => {

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -13,6 +13,7 @@ import {
   FaLocationDot,
   FaAngleRight,
   FaUserGroup,
+  FaCirclePlus
 } from "react-icons/fa6";
 import AppNavBar from "./AppNavBar";
 import SideBarListItem from "./SideBarListItem";
@@ -162,6 +163,13 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
                 Icon={FaLocationDot}
                 label="Locations"
                 href="/locations"
+              />
+              <SideBarListItem
+                isCollapsed={isCollapsed}
+                isCurrentPage={segments.includes("create-crash-record")}
+                Icon={FaCirclePlus}
+                label="Create crash"
+                href="/create-crash-record"
               />
               <SideBarListItem
                 isCollapsed={isCollapsed}

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -13,7 +13,7 @@ import {
   FaLocationDot,
   FaAngleRight,
   FaUserGroup,
-  FaCirclePlus,
+  FaFileCirclePlus,
 } from "react-icons/fa6";
 import AppNavBar from "./AppNavBar";
 import SideBarListItem from "./SideBarListItem";
@@ -167,7 +167,7 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
               <SideBarListItem
                 isCollapsed={isCollapsed}
                 isCurrentPage={segments.includes("create-crash-record")}
-                Icon={FaCirclePlus}
+                Icon={FaFileCirclePlus}
                 label="Create crash"
                 href="/create-crash-record"
               />

--- a/app/components/TableWrapper.tsx
+++ b/app/components/TableWrapper.tsx
@@ -20,6 +20,7 @@ interface TableProps<T extends Record<string, unknown>> {
   columns: ColDataCardDef<T>[];
   initialQueryConfig: QueryConfig;
   localStorageKey: string;
+  refetch?: boolean;
 }
 
 /**
@@ -30,6 +31,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   initialQueryConfig,
   columns,
   localStorageKey,
+  refetch: _refetch,
 }: TableProps<T>) {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [areFiltersDirty, setAreFiltersDirty] = useState(false);
@@ -44,7 +46,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
 
   const query = useQueryBuilder(queryConfig);
 
-  const { data, isLoading, error } = useQuery<T>({
+  const { data, isLoading, error, refetch } = useQuery<T>({
     // dont fire first query until localstorage is loaded
     query: isLocalStorageLoaded ? query : null,
     typename: queryConfig.tableName,
@@ -104,6 +106,12 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   }, [queryConfig, initialQueryConfig]);
 
   /**
+   * Hook to trigger refetch
+   */
+  useEffect(() => {
+    refetch();
+  }, [_refetch, refetch]);
+  /**
    * wait until the localstorage hook resolves to render anything
    * to prevent filter UI elements from jump
    */
@@ -126,11 +134,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
                   setSearchSettings={setSearchSettings}
                 />
               </Col>
-              <Col
-                xs={12}
-                md="auto"
-                className="align-items-center"
-              >
+              <Col xs={12} md="auto" className="align-items-center">
                 <TableDateSelector
                   queryConfig={queryConfig}
                   setQueryConfig={setQueryConfig}

--- a/app/configs/tempCrashesListViewColumns.tsx
+++ b/app/configs/tempCrashesListViewColumns.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { formatDate } from "@/utils/formatters";
+import { ColDataCardDef } from "@/types/types";
+import { Crash } from "@/types/crashes";
+
+export const tempCrashesListViewColumns: ColDataCardDef<Crash>[] = [
+  {
+    path: "record_locator",
+    label: "Crash ID",
+    sortable: true,
+    valueRenderer: (record: Crash) => (
+      <Link href={`/crashes/${record.record_locator}`}>
+        {record.record_locator}
+      </Link>
+    ),
+  },
+  {
+    path: "case_id",
+    label: "Case ID",
+    sortable: true,
+  },
+  {
+    path: "crash_timestamp",
+    label: "Date",
+    sortable: true,
+    valueFormatter: formatDate,
+  },
+  {
+    path: "address_primary",
+    label: "Address",
+    sortable: true,
+  },
+  {
+    path: "updated_by",
+    label: "Updated by",
+    sortable: true,
+  },
+  {
+    path: "updated_at",
+    label: "Updated at",
+    sortable: true,
+    valueFormatter: formatDate,
+  },
+];

--- a/app/configs/tempCrashesTable.ts
+++ b/app/configs/tempCrashesTable.ts
@@ -4,7 +4,7 @@ import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 
 const columns = tempCrashesListViewColumns.map((col) => String(col.path));
 
-const crashesListViewfilterCards: FilterGroup[] = [
+const tempCrashesListViewfilterCards: FilterGroup[] = [
   {
     id: "temp_record_filter",
     label: "Temp records",
@@ -53,5 +53,5 @@ export const tempCrashesListViewQueryConfig: QueryConfig = {
     { label: "Case ID", value: "case_id" },
     { label: "Address", value: "address_primary" },
   ],
-  filterCards: crashesListViewfilterCards,
+  filterCards: tempCrashesListViewfilterCards,
 };

--- a/app/configs/tempCrashesTable.ts
+++ b/app/configs/tempCrashesTable.ts
@@ -1,0 +1,51 @@
+import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
+import { QueryConfig, FilterGroup } from "@/utils/queryBuilder";
+import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
+
+const columns = crashesListViewColumns.map((col) => String(col.path));
+
+const crashesListViewfilterCards: FilterGroup[] = [
+  {
+    id: "temp_record_filter",
+    label: "Temp record",
+    groupOperator: "_and",
+    filterGroups: [
+      {
+        id: "is_temp_record",
+        label: "Is temp record",
+        groupOperator: "_and",
+        enabled: true,
+        inverted: false,
+        filters: [
+          {
+            id: "is_temp_record",
+            column: "is_temp_record",
+            operator: "_eq",
+            value: true,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const tempCrashesListViewQueryConfig: QueryConfig = {
+  columns,
+  tableName: "crashes_list_view",
+  limit: DEFAULT_QUERY_LIMIT,
+  offset: 0,
+  sortColName: "crash_timestamp",
+  sortAsc: false,
+  searchFilter: {
+    id: "search",
+    value: "",
+    column: "case_id",
+    operator: "_ilike",
+    wildcard: true,
+  },
+  searchFields: [
+    { label: "Case ID", value: "case_id" },
+    { label: "Address", value: "address_primary" },
+  ],
+  filterCards: crashesListViewfilterCards,
+};

--- a/app/configs/tempCrashesTable.ts
+++ b/app/configs/tempCrashesTable.ts
@@ -1,13 +1,13 @@
-import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
+import { tempCrashesListViewColumns } from "./tempCrashesListViewColumns";
 import { QueryConfig, FilterGroup } from "@/utils/queryBuilder";
 import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 
-const columns = crashesListViewColumns.map((col) => String(col.path));
+const columns = tempCrashesListViewColumns.map((col) => String(col.path));
 
 const crashesListViewfilterCards: FilterGroup[] = [
   {
     id: "temp_record_filter",
-    label: "Temp record",
+    label: "Temp records",
     groupOperator: "_and",
     filterGroups: [
       {
@@ -23,6 +23,12 @@ const crashesListViewfilterCards: FilterGroup[] = [
             operator: "_eq",
             value: true,
           },
+          {
+            id: "is_deleted",
+            column: "is_deleted",
+            operator: "_eq",
+            value: false,
+          },
         ],
       },
     ],
@@ -31,7 +37,7 @@ const crashesListViewfilterCards: FilterGroup[] = [
 
 export const tempCrashesListViewQueryConfig: QueryConfig = {
   columns,
-  tableName: "crashes_list_view",
+  tableName: "crashes",
   limit: DEFAULT_QUERY_LIMIT,
   offset: 0,
   sortColName: "crash_timestamp",

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -225,3 +225,13 @@ export const UPDATE_CRASH = gql`
     }
   }
 `;
+
+export const CREATE_CRASH = gql`
+  mutation CreateCrash($crash: crashes_cris_insert_input!) {
+    insert_crashes_cris(objects: [$crash]) {
+      returning {
+        id
+      }
+    }
+  }
+`;

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -226,11 +226,40 @@ export const UPDATE_CRASH = gql`
   }
 `;
 
-export const CREATE_CRASH = gql`
+export const CREATE_CRIS_CRASH = gql`
   mutation CreateCrash($crash: crashes_cris_insert_input!) {
     insert_crashes_cris(objects: [$crash]) {
       returning {
         id
+      }
+    }
+  }
+`;
+
+export const DELETE_CRIS_CRASH = gql`
+  mutation SoftDeleteCrisCrash($id: Int!, $updated_by: String!) {
+    update_crashes_cris(
+      where: { id: { _eq: $id }, is_temp_record: { _eq: true } }
+      _set: { is_deleted: true, updated_by: $updated_by }
+    ) {
+      affected_rows
+      returning {
+        id
+      }
+    }
+    update_units_cris(
+      where: { crash_pk: { _eq: $id } }
+      _set: { is_deleted: true, updated_by: $updated_by }
+    ) {
+      affected_rows
+    }
+    update_people_cris(
+      where: { units_cris: { crash_pk: { _eq: $id } } }
+      _set: { is_deleted: true, updated_by: $updated_by }
+    ) {
+      returning {
+        id
+        unit_id
       }
     }
   }

--- a/app/queries/unit.ts
+++ b/app/queries/unit.ts
@@ -7,3 +7,12 @@ export const UPDATE_UNIT = gql`
     }
   }
 `;
+
+export const UNIT_TYPES_QUERY = gql`
+  query UnitTypes {
+    lookups_unit_desc {
+      id
+      label
+    }
+  }
+`;


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/19985
* https://github.com/cityofaustin/atd-data-tech/issues/19986

<img width="563" alt="Screenshot 2025-01-03 at 11 04 43 AM" src="https://github.com/user-attachments/assets/8f15bc2d-8788-467e-a0e9-aaaa974a0012" />

Note these two related features which are out of scope:

* Ability to delete temporary crash records - https://github.com/cityofaustin/vision-zero/pull/1644
* Hide this page from read-only users - https://github.com/cityofaustin/atd-data-tech/issues/20302


## Testing

**URL to test:** Local

1. Use the **Create crash** sidebar link to navigate to this new page
2. Use the **Create crash record** button to open the form. Create a few crash records while also testing the required fields validation. The required fields are Case ID, Crash date, primary address, and all three fields on each unit card.
3. Try adding and removing additional units while you're using the form.
4. Verify that the table refreshes after you submit the form.
5. Visit the crash details page and verify that the number and types of units created are correct, and that a person record is created for each injury.
6. On the temp crashers table, test the search and filter functionality.
7. I'd like to hide the filters altogether by adding a new prop called `staticFilters` (or something like that). I am holding off on that because there are other branches out there with changes to the table component's props.

---
#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
