### PR TITLE
Delete crash records

### DIFF
--- a/app/app/crashes/[record_locator]/page.tsx
+++ b/app/app/crashes/[record_locator]/page.tsx
@@ -11,6 +11,7 @@ import { useQuery } from "@/utils/graphql";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
 import CrashHeader from "@/components/CrashHeader";
 import CrashLocationBanner from "@/components/CrashLocationBanner";
+import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
 import DataCard from "@/components/DataCard";
 import RelatedRecordTable from "@/components/RelatedRecordTable";
@@ -65,6 +66,10 @@ export default function CrashDetailsPage({
         (crash.private_dr_fl || !crash.in_austin_full_purpose) && (
           <CrashLocationBanner privateDriveFlag={crash.private_dr_fl} />
         )
+      }
+      {
+        // show alert if crash is a temp record
+        crash.is_temp_record && <CrashIsTemporaryBanner crashId={crash.id} />
       }
       <Row>
         <Col sm={12} md={6} lg={4} className="mb-3">

--- a/app/components/CrashIsTemporaryBanner.tsx
+++ b/app/components/CrashIsTemporaryBanner.tsx
@@ -8,13 +8,8 @@ import { useMutation } from "@/utils/graphql";
 import { DELETE_CRIS_CRASH } from "@/queries/crash";
 
 interface CrashIsTemporaryBannerProps {
-  /**
-   * If the crash occurred on a private drive
-   */
   crashId: number;
 }
-
-// const onDelete = (crashId) = {}}
 
 /**
  * Banner that alerts the user when viewing a "temporary" crash record, aka

--- a/app/components/CrashIsTemporaryBanner.tsx
+++ b/app/components/CrashIsTemporaryBanner.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";

--- a/app/components/CrashIsTemporaryBanner.tsx
+++ b/app/components/CrashIsTemporaryBanner.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/navigation";
+import { useAuth0 } from "@auth0/auth0-react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
@@ -18,6 +19,7 @@ interface CrashIsTemporaryBannerProps {
 export default function CrashIsTemporaryBanner({
   crashId,
 }: CrashIsTemporaryBannerProps) {
+  const { user } = useAuth0();
   const { mutate, loading: isMutating } = useMutation(DELETE_CRIS_CRASH);
   const router = useRouter();
 
@@ -43,7 +45,7 @@ export default function CrashIsTemporaryBanner({
                 "Are you sure you want to delete this crash record?"
               )
             ) {
-              await mutate({ id: crashId });
+              await mutate({ id: crashId, updated_by: user?.email });
               router.push("/create-crash-record");
             }
           }}

--- a/app/components/CrashIsTemporaryBanner.tsx
+++ b/app/components/CrashIsTemporaryBanner.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Spinner from "react-bootstrap/Spinner";
+import { FaTrash, FaTriangleExclamation } from "react-icons/fa6";
+import AlignedLabel from "./AlignedLabel";
+import { useMutation } from "@/utils/graphql";
+import { DELETE_CRIS_CRASH } from "@/queries/crash";
+
+interface CrashIsTemporaryBannerProps {
+  /**
+   * If the crash occurred on a private drive
+   */
+  crashId: number;
+}
+
+// const onDelete = (crashId) = {}}
+
+/**
+ * Banner that alerts the user when viewing a "temporary" crash record, aka
+ * a crash record that was manually created through the UI
+ */
+export default function CrashIsTemporaryBanner({
+  crashId,
+}: CrashIsTemporaryBannerProps) {
+  const { mutate, loading: isMutating } = useMutation(DELETE_CRIS_CRASH);
+  const router = useRouter();
+
+  return (
+    <Alert
+      variant="warning"
+      className="d-flex justify-content-between align-items-center"
+    >
+      <span className="d-flex align-items-center">
+        <FaTriangleExclamation className="me-2 d-none d-lg-inline" />
+        <span className="me-3">
+          This crash record was created by the Vision Zero team and serves as a
+          placeholder until the CR3 report is received from TxDOT. It may be
+          deleted at any time.
+        </span>
+      </span>
+      <span>
+        <Button
+          variant="danger"
+          onClick={async () => {
+            if (
+              window.confirm(
+                "Are you sure you want to delete this crash record?"
+              )
+            ) {
+              await mutate({ id: crashId });
+              router.push("/create-crash-record");
+            }
+          }}
+          disabled={isMutating}
+        >
+          <AlignedLabel>
+            {isMutating ? (
+              <Spinner size="sm" />
+            ) : (
+              <>
+                <FaTrash className="me-2" />
+                <span>Delete</span>
+              </>
+            )}
+          </AlignedLabel>
+        </Button>
+      </span>
+    </Alert>
+  );
+}

--- a/app/components/CrashLocationBanner.tsx
+++ b/app/components/CrashLocationBanner.tsx
@@ -18,7 +18,7 @@ export default function CrashLocationBanner({
   return (
     <Alert variant="warning">
       <AlignedLabel>
-        <FaTriangleExclamation className="me-2" />
+        <FaTriangleExclamation className="me-2 d-none d-lg-inline" />
         <span className="me-3">
           This crash is not included in Vision Zero statistical reporting
           because{" "}

--- a/app/components/CrashLocationBanner.tsx
+++ b/app/components/CrashLocationBanner.tsx
@@ -1,4 +1,6 @@
 import Alert from "react-bootstrap/Alert";
+import { FaTriangleExclamation } from "react-icons/fa6";
+import AlignedLabel from "./AlignedLabel";
 
 interface CrashLocationBannerProps {
   /**
@@ -15,10 +17,16 @@ export default function CrashLocationBanner({
 }: CrashLocationBannerProps) {
   return (
     <Alert variant="warning">
-      This crash is not included in Vision Zero statistical reporting because{" "}
-      {privateDriveFlag
-        ? "it occurred on a private drive"
-        : "it is located outside of the Austin full purpose jurisdiction"}
+      <AlignedLabel>
+        <FaTriangleExclamation className="me-2" />
+        <span className="me-3">
+          This crash is not included in Vision Zero statistical reporting
+          because{" "}
+          {privateDriveFlag
+            ? "it occurred on a private drive"
+            : "it is located outside of the Austin full purpose jurisdiction"}
+        </span>
+      </AlignedLabel>
     </Alert>
   );
 }

--- a/app/components/CreateCrashRecordModal.tsx
+++ b/app/components/CreateCrashRecordModal.tsx
@@ -9,7 +9,7 @@ import { FaCirclePlus, FaCircleMinus } from "react-icons/fa6";
 import { useForm, SubmitHandler, useFieldArray } from "react-hook-form";
 import { useQuery, useMutation } from "@/utils/graphql";
 import { UNIT_TYPES_QUERY } from "@/queries/unit";
-import { CREATE_CRASH } from "@/queries/crash";
+import { CREATE_CRIS_CRASH } from "@/queries/crash";
 import { LookupTableOption } from "@/types/relationships";
 import { Crash } from "@/types/crashes";
 import { useAuth0 } from "@auth0/auth0-react";
@@ -132,7 +132,7 @@ export default function CreateCrashRecordModal({
       query: UNIT_TYPES_QUERY,
       typename: "lookups_unit_desc",
     });
-  const { mutate, loading: isSubmitting } = useMutation(CREATE_CRASH);
+  const { mutate, loading: isSubmitting } = useMutation(CREATE_CRIS_CRASH);
 
   const {
     register,

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -226,9 +226,23 @@ export const UPDATE_CRASH = gql`
   }
 `;
 
-export const CREATE_CRASH = gql`
+export const CREATE_CRIS_CRASH = gql`
   mutation CreateCrash($crash: crashes_cris_insert_input!) {
     insert_crashes_cris(objects: [$crash]) {
+      returning {
+        id
+      }
+    }
+  }
+`;
+
+export const DELETE_CRIS_CRASH = gql`
+  mutation DeleteCrisCrash($id: Int!) {
+    update_crashes_cris(
+      where: { id: { _eq: $id }, is_temp_record: { _eq: true } }
+      _set: { is_deleted: true }
+    ) {
+      affected_rows
       returning {
         id
       }

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -237,14 +237,29 @@ export const CREATE_CRIS_CRASH = gql`
 `;
 
 export const DELETE_CRIS_CRASH = gql`
-  mutation DeleteCrisCrash($id: Int!) {
+  mutation SoftDeleteCrisCrash($id: Int!, $updated_by: String!) {
     update_crashes_cris(
       where: { id: { _eq: $id }, is_temp_record: { _eq: true } }
-      _set: { is_deleted: true }
+      _set: { is_deleted: true, updated_by: $updated_by }
     ) {
       affected_rows
       returning {
         id
+      }
+    }
+    update_units_cris(
+      where: { crash_pk: { _eq: $id } }
+      _set: { is_deleted: true, updated_by: $updated_by }
+    ) {
+      affected_rows
+    }
+    update_people_cris(
+      where: { units_cris: { crash_pk: { _eq: $id } } }
+      _set: { is_deleted: true, updated_by: $updated_by }
+    ) {
+      returning {
+        id
+        unit_id
       }
     }
   }


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20433

<img width="1271" alt="Screenshot 2024-12-31 at 12 29 32 PM" src="https://github.com/user-attachments/assets/581b7156-3408-4601-9820-4329f2427d5e" />

I switched this up a bit from the old VZE, which had the delete button in the temp crashes list. Now the delete button is embedded in an alert banner at the top of the crash details page. A future enhancement will hide this button from non-editors.

I am making this change for these reasons:

1. It avoids the need to add a custom row action feature to our grid table
2. I assume it's customary to view the crash details before you delete the crash
4. Like i mentioned [here](https://github.com/cityofaustin/vision-zero/pull/1643#discussion_r1898711553), I am still hoping we can do away with the "Create crash record" page and use the normal crashes list.

## Testing

**URL to test:** Local

1. Create a crash record, as described [here](https://github.com/cityofaustin/vision-zero/pull/1643)
2. Navigate to the crash details page and delete your crash. Observe you are redirected to the `/create-crash-record` page.
3. Navigate back to the crash details page for the crash you deleted. You should be promptly redirected to the `404` page
4. Visit the crash details for a non-temporary crash. Verify that the banner + delete button are not visible.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
