### PR TITLE
Fix year rollover time of day chart bug

### DIFF
--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viewer",
-  "version": "1.44.1",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "viewer",
-      "version": "1.44.1",
+      "version": "2.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -94,7 +94,8 @@ const calculateHourBlockTotals = (records, crashType) => {
  * @returns {String} The query url for the Socrata query
  */
 const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
-  const yearsAgoDate = format(sub(new Date(), { years: activeTab }), "yyyy");
+  // subtract years ago (based on activeTab) from current year
+  const yearsAgoDate = format(sub(parseISO(summaryCurrentYearStartDate), { years: activeTab }), "yyyy");
   let queryUrl =
     activeTab === 0
       ? `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_timestamp_ct between '${summaryCurrentYearStartDate}T00:00:00' and '${summaryCurrentYearEndDate}T23:59:59'`


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20471

## Testing

https://deploy-preview-1648--atd-vzv-staging.netlify.app/


**Steps to test:**

Scroll down to the "By Time of Day" chart and click through the different tabs. 2023 and 2024 have different heatmaps. Compare that to staging (https://visionzero.austin.gov/viewer/) where they do not. 

The code was pulling the current year from today's date and not the current year from the data. so it was off by a year on the tabs. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
