### PR TITLE
Crash details: configure lookup tables for light condition, roadway part, and roadway system

### DIFF
--- a/app/configs/crashDataCard.tsx
+++ b/app/configs/crashDataCard.tsx
@@ -18,7 +18,7 @@ export const crashDataCards = {
     crashesColumns.toll_road_fl,
   ],
   other: [
-    crashesColumns.light_cond_id,
+    crashesColumns.light_cond,
     crashesColumns.crash_speed_limit,
     crashesColumns.obj_struck,
     crashesColumns.law_enforcement_ytd_fatality_num,

--- a/app/configs/crashDataCard.tsx
+++ b/app/configs/crashDataCard.tsx
@@ -29,7 +29,7 @@ export const crashDataCards = {
     crashesColumns.rpt_street_name,
     crashesColumns.rpt_street_sfx,
     crashesColumns.rpt_street_desc,
-    crashesColumns.rpt_road_part_id,
+    crashesColumns.road_part,
     crashesColumns.rpt_rdwy_sys_id,
     crashesColumns.rpt_hwy_num,
   ],

--- a/app/configs/crashDataCard.tsx
+++ b/app/configs/crashDataCard.tsx
@@ -39,8 +39,8 @@ export const crashDataCards = {
     crashesColumns.rpt_sec_street_name,
     crashesColumns.rpt_sec_street_sfx,
     crashesColumns.rpt_sec_street_desc,
-    crashesColumns.rpt_sec_road_part_id,
-    crashesColumns.rpt_sec_rdwy_sys_id,
+    crashesColumns.road_part_sec,
+    crashesColumns.rwy_sys_sec,
     crashesColumns.rpt_sec_hwy_num,
   ],
 };

--- a/app/configs/crashDataCard.tsx
+++ b/app/configs/crashDataCard.tsx
@@ -30,7 +30,7 @@ export const crashDataCards = {
     crashesColumns.rpt_street_sfx,
     crashesColumns.rpt_street_desc,
     crashesColumns.road_part,
-    crashesColumns.rpt_rdwy_sys_id,
+    crashesColumns.rwy_sys,
     crashesColumns.rpt_hwy_num,
   ],
   address_secondary: [

--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -180,18 +180,6 @@ export const crashesColumns = {
     editable: true,
     inputType: "text",
   },
-  // rpt_sec_rdwy_sys_id: {
-  //   path: "rpt_sec_rdwy_sys_id",
-  //   label: "Roadway system",
-  //   editable: true,
-  //   inputType: "number",
-  // },
-  // rpt_sec_road_part_id: {
-  //   path: "rpt_sec_road_part_id",
-  //   label: "Roadway part",
-  //   editable: true,
-  //   inputType: "number",
-  // },
   rwy_sys_sec: {
     path: "rwy_sys_sec.label",
     label: "Roadway system",

--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -67,11 +67,18 @@ export const crashesColumns = {
     editable: true,
     inputType: "text",
   },
-  light_cond_id: {
-    path: "light_cond_id",
+  light_cond: {
+    path: "light_cond.label",
     label: "Light condition",
     editable: true,
-    inputType: "number",
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "light_cond",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "light_cond_id",
+    }
   },
   longitude: {
     path: "longitude",

--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -180,17 +180,43 @@ export const crashesColumns = {
     editable: true,
     inputType: "text",
   },
-  rpt_sec_rdwy_sys_id: {
-    path: "rpt_sec_rdwy_sys_id",
+  // rpt_sec_rdwy_sys_id: {
+  //   path: "rpt_sec_rdwy_sys_id",
+  //   label: "Roadway system",
+  //   editable: true,
+  //   inputType: "number",
+  // },
+  // rpt_sec_road_part_id: {
+  //   path: "rpt_sec_road_part_id",
+  //   label: "Roadway part",
+  //   editable: true,
+  //   inputType: "number",
+  // },
+  rwy_sys_sec: {
+    path: "rwy_sys_sec.label",
     label: "Roadway system",
     editable: true,
-    inputType: "number",
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "rwy_sys",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "rpt_sec_rdwy_sys_id",
+    }
   },
-  rpt_sec_road_part_id: {
-    path: "rpt_sec_road_part_id",
+  road_part_sec: {
+    path: "road_part_sec.label",
     label: "Roadway part",
     editable: true,
-    inputType: "number",
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "road_part",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "rpt_sec_road_part_id",
+    }
   },
   rpt_sec_street_desc: {
     path: "rpt_sec_street_desc",

--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -148,11 +148,18 @@ export const crashesColumns = {
     editable: true,
     inputType: "number",
   },
-  rpt_road_part_id: {
-    path: "rpt_road_part_id",
+  road_part: {
+    path: "road_part.label",
     label: "Roadway part",
     editable: true,
-    inputType: "number",
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "road_part",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "rpt_road_part_id",
+    }
   },
   rpt_sec_block_num: {
     path: "rpt_sec_block_num",

--- a/app/configs/crashesColumns.tsx
+++ b/app/configs/crashesColumns.tsx
@@ -142,11 +142,18 @@ export const crashesColumns = {
     editable: true,
     inputType: "text",
   },
-  rpt_rdwy_sys_id: {
-    path: "rpt_rdwy_sys_id",
+  rwy_sys: {
+    path: "rwy_sys.label",
     label: "Roadway system",
     editable: true,
-    inputType: "number",
+    inputType: "select",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "rwy_sys",
+      idColumnName: "id",
+      labelColumnName: "label",
+      foreignKey: "rpt_rdwy_sys_id",
+    }
   },
   road_part: {
     path: "road_part.label",

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -63,7 +63,15 @@ export const GET_CRASH = gql`
       rpt_sec_street_name
       rpt_sec_street_desc
       rpt_sec_road_part_id
+      road_part_sec {
+        id
+        label
+      }
       rpt_sec_rdwy_sys_id
+      rwy_sys_sec {
+        id
+        label
+      }
       rpt_sec_hwy_num
       rpt_sec_street_pfx
       rpt_sec_street_sfx

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -45,6 +45,10 @@ export const GET_CRASH = gql`
       rpt_street_name
       rpt_street_desc
       rpt_road_part_id
+      road_part {
+        id
+        label
+      }
       rpt_rdwy_sys_id
       rpt_hwy_num
       rpt_street_pfx

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -50,6 +50,10 @@ export const GET_CRASH = gql`
         label
       }
       rpt_rdwy_sys_id
+      rwy_sys {
+        id
+        label
+      }
       rpt_hwy_num
       rpt_street_pfx
       rpt_street_name

--- a/app/queries/crash.ts
+++ b/app/queries/crash.ts
@@ -28,6 +28,10 @@ export const GET_CRASH = gql`
         label
       }
       light_cond_id
+      light_cond {
+        id
+        label
+      }
       wthr_cond_id
       obj_struck {
         id

--- a/app/types/crashes.ts
+++ b/app/types/crashes.ts
@@ -41,6 +41,7 @@ export type Crash = {
   city: LookupTableOption | null;
   rpt_hwy_num: string | null;
   rpt_rdwy_sys_id: number | null;
+  rwy_sys: LookupTableOption | null;
   rpt_road_part_id: number | null;
   road_part: LookupTableOption | null;
   rpt_sec_block_num: string | null;

--- a/app/types/crashes.ts
+++ b/app/types/crashes.ts
@@ -42,6 +42,7 @@ export type Crash = {
   rpt_hwy_num: string | null;
   rpt_rdwy_sys_id: number | null;
   rpt_road_part_id: number | null;
+  road_part: LookupTableOption | null;
   rpt_sec_block_num: string | null;
   rpt_sec_hwy_num: string | null;
   rpt_sec_rdwy_sys_id: number | null;

--- a/app/types/crashes.ts
+++ b/app/types/crashes.ts
@@ -26,6 +26,7 @@ export type Crash = {
   latitude: number | null;
   law_enforcement_ytd_fatality_num: string | null;
   light_cond_id: number | null;
+  light_cond: LookupTableOption | null;
   location_id: string | null;
   longitude: number | null;
   obj_struck_id: number | null;

--- a/app/types/crashes.ts
+++ b/app/types/crashes.ts
@@ -47,7 +47,9 @@ export type Crash = {
   rpt_sec_block_num: string | null;
   rpt_sec_hwy_num: string | null;
   rpt_sec_rdwy_sys_id: number | null;
+  rwy_sys_sec: LookupTableOption | null;
   rpt_sec_road_part_id: number | null;
+  road_part_sec: LookupTableOption | null;
   rpt_sec_street_desc: string | null;
   rpt_sec_street_name: string | null;
   rpt_sec_street_pfx: string | null;

--- a/database/metadata/databases/default/tables/public_crashes.yaml
+++ b/database/metadata/databases/default/tables/public_crashes.yaml
@@ -48,9 +48,15 @@ object_relationships:
   - name: road_part
     using:
       foreign_key_constraint_on: rpt_road_part_id
+  - name: road_part_sec
+    using:
+      foreign_key_constraint_on: rpt_sec_road_part_id
   - name: rwy_sys
     using:
       foreign_key_constraint_on: rpt_rdwy_sys_id
+  - name: rwy_sys_sec
+    using:
+      foreign_key_constraint_on: rpt_sec_rdwy_sys_id
   - name: traffic_cntl
     using:
       foreign_key_constraint_on: traffic_cntl_id

--- a/database/metadata/databases/default/tables/public_crashes.yaml
+++ b/database/metadata/databases/default/tables/public_crashes.yaml
@@ -45,6 +45,9 @@ object_relationships:
         table:
           name: recommendations
           schema: public
+  - name: road_part
+    using:
+      foreign_key_constraint_on: rpt_road_part_id
   - name: traffic_cntl
     using:
       foreign_key_constraint_on: traffic_cntl_id

--- a/database/metadata/databases/default/tables/public_crashes.yaml
+++ b/database/metadata/databases/default/tables/public_crashes.yaml
@@ -48,6 +48,9 @@ object_relationships:
   - name: road_part
     using:
       foreign_key_constraint_on: rpt_road_part_id
+  - name: rwy_sys
+    using:
+      foreign_key_constraint_on: rpt_rdwy_sys_id
   - name: traffic_cntl
     using:
       foreign_key_constraint_on: traffic_cntl_id

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vision-zero-editor",
-  "version": "2.4.1",
+  "version": "2.4.3",
   "homepage": "./",
   "description": "ATD Vision Zero Editor",
   "author": "ATD Data & Technology Services",

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viewer",
-  "version": "1.44.1",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "viewer",
-      "version": "1.44.1",
+      "version": "2.4.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewer",
-  "version": "2.4.1",
+  "version": "2.4.3",
   "homepage": "/viewer",
   "description": "Vision Zero Viewer",
   "author": "Austin Transportation & Public Works - Data & Technology Services",

--- a/viewer/src/views/summary/CrashesByTimeOfDay.js
+++ b/viewer/src/views/summary/CrashesByTimeOfDay.js
@@ -94,7 +94,8 @@ const calculateHourBlockTotals = (records, crashType) => {
  * @returns {String} The query url for the Socrata query
  */
 const getFatalitiesByYearsAgoUrl = (activeTab, crashType) => {
-  const yearsAgoDate = format(sub(new Date(), { years: activeTab }), "yyyy");
+  // subtract years ago (based on activeTab) from current year
+  const yearsAgoDate = format(sub(parseISO(summaryCurrentYearStartDate), { years: activeTab }), "yyyy");
   let queryUrl =
     activeTab === 0
       ? `${crashEndpointUrl}?$where=${crashType.queryStringCrash} AND crash_timestamp_ct between '${summaryCurrentYearStartDate}T00:00:00' and '${summaryCurrentYearEndDate}T23:59:59'`


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/20430

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
local!

**Steps to test:**

Now instead of the foreign keys, you should be able to see the labels for light condition and the roadway part and roadway systems for both primary address and secondary addresses. (Light condition is on the "other" card)

![Screenshot 2025-01-06 at 4 53 19 PM](https://github.com/user-attachments/assets/ab56f4f4-1bda-4f7f-9e52-1e8387d1a829)

When you click to edit, a dropdown appears with the selections (with the crash's selection already selected! )


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
