### PR TITLE
Crash details: make change log collapsible

### DIFF
--- a/app/components/ChangeLog.tsx
+++ b/app/components/ChangeLog.tsx
@@ -93,8 +93,7 @@ export default function ChangeLog({ logs }: { logs: ChangeLogEntry[] }) {
       activeKey={expandedItem}
       // on accordion click save new expanded item state to local storage
       onSelect={(eventKey) => {
-        const localStorageValue =
-          eventKey !== null ? recordHistoryItemName : String(null); // local storage value must be a string type
+        const localStorageValue = String(eventKey); // local storage value must be a string type
         localStorage.setItem(localStorageKey, localStorageValue);
         setExpandedItem(localStorageValue);
       }}

--- a/app/components/ChangeLog.tsx
+++ b/app/components/ChangeLog.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import Table from "react-bootstrap/Table";
 import Accordion from "react-bootstrap/Accordion";
 import { formatDateTime } from "@/utils/formatters";
-import ChangeLogDetails from "./ChangeLogDetails";
+import ChangeLogDetails from "@/components/ChangeLogDetails";
 import {
   ChangeLogEntry,
   ChangeLogDiff,
@@ -10,7 +10,8 @@ import {
 } from "@/types/changeLog";
 
 // used to track the accordion expanded state of the change log
-const localStorageKey = "expandedItem";
+const localStorageKey = "crashHistoryCardExpandedItem";
+const recordHistoryItemName = "recordHistory";
 
 const KEYS_TO_IGNORE = ["updated_at", "updated_by", "position"];
 
@@ -80,6 +81,7 @@ const isNewRecordEvent = (change: ChangeLogEntryEnriched) =>
 export default function ChangeLog({ logs }: { logs: ChangeLogEntry[] }) {
   const [selectedChange, setSelectedChange] =
     useState<ChangeLogEntryEnriched | null>(null);
+  // tracks the accordion expanded state, if null then the accordion is closed
   const [expandedItem, setExpandedItem] = useState<string | null>(
     localStorage.getItem(localStorageKey)
   );
@@ -88,15 +90,16 @@ export default function ChangeLog({ logs }: { logs: ChangeLogEntry[] }) {
 
   return (
     <Accordion
-      defaultActiveKey={expandedItem}
+      activeKey={expandedItem}
       // on accordion click save new expanded item state to local storage
-      onSelect={(e) => {
-        const localStorageValue = e !== null ? "0" : JSON.stringify(null); // local storage value must be a string type
+      onSelect={(eventKey) => {
+        const localStorageValue =
+          eventKey !== null ? recordHistoryItemName : String(null); // local storage value must be a string type
         localStorage.setItem(localStorageKey, localStorageValue);
         setExpandedItem(localStorageValue);
       }}
     >
-      <Accordion.Item eventKey="0">
+      <Accordion.Item eventKey={recordHistoryItemName}>
         <Accordion.Header>Record history</Accordion.Header>
         <Accordion.Body>
           <Table striped hover>

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -33,9 +33,9 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
 
   const toggleSidebar = useCallback(
     () =>
-      setIsCollapsed((prevSate) => {
-        localStorage.setItem(localStorageKey, String(!prevSate));
-        return !prevSate;
+      setIsCollapsed((prevState) => {
+        localStorage.setItem(localStorageKey, String(!prevState));
+        return !prevState;
       }),
     []
   );


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/19968

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local or netlify

**Steps to test:**
1. Go to a crash details page, scroll down to the change log. It should be collapsed on default first load.
2. Now expand it and refresh the page. The new state should have saved in local storage so on refresh it should still be expand it.
3. Collapse it and refresh again, making sure your state is saved. Go to other crashes and make sure the saved state is persisting.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
