### PR TITLE
Add role-based feature visibility

### DIFF
--- a/app/app/crashes/page.tsx
+++ b/app/app/crashes/page.tsx
@@ -12,7 +12,7 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import TableWrapper from "@/components/TableWrapper";
 const localStorageKey = "crashesListViewQueryConfig";
 
-const allowedRoles = ["vz-admin", "editor"];
+const allowedCreateCrashRecordRoles = ["vz-admin", "editor"];
 
 export default function Crashes() {
   const [refetch, setRefetch] = useState(false);
@@ -30,7 +30,7 @@ export default function Crashes() {
       <Card>
         <Card.Header className="fs-5 fw-bold d-flex justify-content-between">
           Crashes
-          <PermissionsRequired allowedRoles={allowedRoles}>
+          <PermissionsRequired allowedRoles={allowedCreateCrashRecordRoles}>
             <Button className="me-2" onClick={() => setShowNewUserModal(true)}>
               <AlignedLabel>
                 <FaCirclePlus className="me-2" />

--- a/app/app/crashes/page.tsx
+++ b/app/app/crashes/page.tsx
@@ -8,8 +8,11 @@ import CreateCrashRecordModal from "@/components/CreateCrashRecordModal";
 import { FaCirclePlus } from "react-icons/fa6";
 import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
 import { crashesListViewQueryConfig } from "@/configs/crashesListViewTable";
+import PermissionsRequired from "@/components/PermissionsRequired";
 import TableWrapper from "@/components/TableWrapper";
 const localStorageKey = "crashesListViewQueryConfig";
+
+const allowedRoles = ["vz-admin", "editor"];
 
 export default function Crashes() {
   const [refetch, setRefetch] = useState(false);
@@ -27,12 +30,14 @@ export default function Crashes() {
       <Card>
         <Card.Header className="fs-5 fw-bold d-flex justify-content-between">
           Crashes
-          <Button className="me-2" onClick={() => setShowNewUserModal(true)}>
-            <AlignedLabel>
-              <FaCirclePlus className="me-2" />
-              <span>Create crash record</span>
-            </AlignedLabel>
-          </Button>
+          <PermissionsRequired allowedRoles={allowedRoles}>
+            <Button className="me-2" onClick={() => setShowNewUserModal(true)}>
+              <AlignedLabel>
+                <FaCirclePlus className="me-2" />
+                <span>Create crash record</span>
+              </AlignedLabel>
+            </Button>
+          </PermissionsRequired>
         </Card.Header>
         <Card.Body>
           <TableWrapper

--- a/app/app/users/[user_id]/page.tsx
+++ b/app/app/users/[user_id]/page.tsx
@@ -17,7 +17,7 @@ import { useUser } from "@/utils/users";
 import { User } from "@/types/users";
 import { formatDateTime } from "@/utils/formatters";
 
-const allowedRoles = ["vz-admin"];
+const allowedUserEditRoles = ["vz-admin"];
 
 type UserColumn = {
   name: keyof User;
@@ -119,7 +119,7 @@ export default function UserDetails({
               {!user && <Spinner variant="primary" />}
               <div className="mb-3">
                 {user && (
-                  <PermissionsRequired allowedRoles={allowedRoles}>
+                  <PermissionsRequired allowedRoles={allowedUserEditRoles}>
                     <Button
                       className="me-2"
                       onClick={() => setShowEditUserModal(true)}

--- a/app/app/users/[user_id]/page.tsx
+++ b/app/app/users/[user_id]/page.tsx
@@ -11,10 +11,13 @@ import { FaUserEdit, FaUserAltSlash } from "react-icons/fa";
 import AlignedLabel from "@/components/AlignedLabel";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
 import UserModal from "@/components/UserModal";
+import PermissionsRequired from "@/components/PermissionsRequired";
 import { useToken, formatRoleName } from "@/utils/auth";
 import { useUser } from "@/utils/users";
 import { User } from "@/types/users";
 import { formatDateTime } from "@/utils/formatters";
+
+const allowedRoles = ["vz-admin"];
 
 type UserColumn = {
   name: keyof User;
@@ -116,7 +119,7 @@ export default function UserDetails({
               {!user && <Spinner variant="primary" />}
               <div className="mb-3">
                 {user && (
-                  <>
+                  <PermissionsRequired allowedRoles={allowedRoles}>
                     <Button
                       className="me-2"
                       onClick={() => setShowEditUserModal(true)}
@@ -147,7 +150,7 @@ export default function UserDetails({
                         </AlignedLabel>
                       )}
                     </Button>
-                  </>
+                  </PermissionsRequired>
                 )}
               </div>
               {user && (

--- a/app/app/users/page.tsx
+++ b/app/app/users/page.tsx
@@ -9,10 +9,13 @@ import Table from "react-bootstrap/Table";
 import { FaUserPlus, FaCopy } from "react-icons/fa6";
 import AlignedLabel from "@/components/AlignedLabel";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
+import PermissionsRequired from "@/components/PermissionsRequired";
 import UserModal from "@/components/UserModal";
 import { useUsersInfinite } from "@/utils/users";
 import { User } from "@/types/users";
 import { useToken, formatRoleName } from "@/utils/auth";
+
+const allowedRoles = ["vz-admin"];
 
 export default function Users() {
   const token = useToken();
@@ -45,15 +48,17 @@ export default function Users() {
           <div className="mb-3 d-flex align-items-center">
             {!isLoading && (
               <>
-                <Button
-                  className="me-2"
-                  onClick={() => setShowNewUserModal(true)}
-                >
-                  <AlignedLabel>
-                    <FaUserPlus className="me-2" />
-                    <span>Add user</span>
-                  </AlignedLabel>
-                </Button>
+                <PermissionsRequired allowedRoles={allowedRoles}>
+                  <Button
+                    className="me-2"
+                    onClick={() => setShowNewUserModal(true)}
+                  >
+                    <AlignedLabel>
+                      <FaUserPlus className="me-2" />
+                      <span>Add user</span>
+                    </AlignedLabel>
+                  </Button>
+                </PermissionsRequired>
                 <Button>
                   {/* todo: https://github.com/cityofaustin/atd-data-tech/issues/20121 */}
                   <AlignedLabel>

--- a/app/app/users/page.tsx
+++ b/app/app/users/page.tsx
@@ -15,7 +15,7 @@ import { useUsersInfinite } from "@/utils/users";
 import { User } from "@/types/users";
 import { useToken, formatRoleName } from "@/utils/auth";
 
-const allowedRoles = ["vz-admin"];
+const allowedCreateUserRoles = ["vz-admin"];
 
 export default function Users() {
   const token = useToken();
@@ -48,7 +48,7 @@ export default function Users() {
           <div className="mb-3 d-flex align-items-center">
             {!isLoading && (
               <>
-                <PermissionsRequired allowedRoles={allowedRoles}>
+                <PermissionsRequired allowedRoles={allowedCreateUserRoles}>
                   <Button
                     className="me-2"
                     onClick={() => setShowNewUserModal(true)}

--- a/app/components/AppNavBar.tsx
+++ b/app/components/AppNavBar.tsx
@@ -2,7 +2,7 @@ import Container from "react-bootstrap/Container";
 import Navbar from "react-bootstrap/Navbar";
 import Image from "react-bootstrap/Image";
 import Dropdown from "react-bootstrap/Dropdown";
-import { User } from "@auth0/auth0-react";
+import { User, LogoutOptions } from "@auth0/auth0-react";
 import {
   FaRightFromBracket,
   FaUserLarge,
@@ -16,7 +16,7 @@ import AlignedLabel from "./AlignedLabel";
 
 type NavBarProps = {
   user: User;
-  logout: () => void;
+  logout: (options?: LogoutOptions) => void;
 };
 
 /**
@@ -52,7 +52,12 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
                 Account
               </AlignedLabel>
             </Dropdown.Item>
-            <Dropdown.Item eventKey="2" onClick={() => logout()}>
+            <Dropdown.Item
+              eventKey="2"
+              onClick={() =>
+                logout({ logoutParams: { returnTo: window.location.origin } })
+              }
+            >
               <AlignedLabel>
                 <FaRightFromBracket className="me-3" />
                 Sign out

--- a/app/components/PermissionsRequired.tsx
+++ b/app/components/PermissionsRequired.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { hasRole } from "@/utils/auth";
+
+interface PermissionsRequiredProps {
+  children: ReactNode;
+  allowedRoles?: string[];
+}
+
+/**
+ * Component wrapper that renders `null` if the user does not have one of the
+ * allwed roles. If the allowedRoles array is undefined then the permission
+ * check is skipped
+ */
+export default function PermissionsRequired({
+  children,
+  allowedRoles,
+}: PermissionsRequiredProps) {
+  const { user } = useAuth0();
+  if (!allowedRoles || (user && hasRole(allowedRoles, user))) {
+    return children;
+  }
+  return null;
+}

--- a/app/components/PermissionsRequired.tsx
+++ b/app/components/PermissionsRequired.tsx
@@ -9,7 +9,7 @@ interface PermissionsRequiredProps {
 
 /**
  * Component wrapper that renders `null` if the user does not have one of the
- * allwed roles. If the allowedRoles array is undefined then the permission
+ * allowed roles. If the allowedRoles array is undefined then the permission
  * check is skipped
  */
 export default function PermissionsRequired({

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -92,7 +92,10 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
             </div>
             <ListGroup variant="flush">
               {routes.map((route) => (
-                <PermissionsRequired allowedRoles={route.allowedRoles}>
+                <PermissionsRequired
+                  allowedRoles={route.allowedRoles}
+                  key={route.path}
+                >
                   <SideBarListItem
                     isCollapsed={isCollapsed}
                     isCurrentPage={segments.includes(route.path)}

--- a/app/components/SidebarLayout.tsx
+++ b/app/components/SidebarLayout.tsx
@@ -7,17 +7,13 @@ import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import ListGroup from "react-bootstrap/ListGroup";
-import {
-  FaShieldHeart,
-  FaGaugeHigh,
-  FaLocationDot,
-  FaAngleRight,
-  FaUserGroup,
-  FaCloudArrowUp,
-} from "react-icons/fa6";
-import AppNavBar from "./AppNavBar";
-import SideBarListItem from "./SideBarListItem";
-import LoginContainer from "./LoginContainer";
+import { FaAngleRight } from "react-icons/fa6";
+import AppNavBar from "@/components/AppNavBar";
+import SideBarListItem from "@/components/SideBarListItem";
+import LoginContainer from "@/components/LoginContainer";
+import { routes } from "@/configs/routes";
+import PermissionsRequired from "@/components/PermissionsRequired";
+
 const localStorageKey = "sidebarCollapsed";
 
 /**
@@ -95,41 +91,17 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
               </Button>
             </div>
             <ListGroup variant="flush">
-              <SideBarListItem
-                isCollapsed={isCollapsed}
-                isCurrentPage={segments.includes("dashboard")}
-                Icon={FaGaugeHigh}
-                label="Dashboard"
-                href="/dashboard"
-              />
-              <SideBarListItem
-                isCollapsed={isCollapsed}
-                isCurrentPage={segments.includes("crashes")}
-                Icon={FaShieldHeart}
-                label="Crashes"
-                href="/crashes"
-              />
-              <SideBarListItem
-                isCollapsed={isCollapsed}
-                isCurrentPage={segments.includes("locations")}
-                Icon={FaLocationDot}
-                label="Locations"
-                href="/locations"
-              />
-              <SideBarListItem
-                isCollapsed={isCollapsed}
-                isCurrentPage={segments.includes("upload-non-cr3")}
-                Icon={FaCloudArrowUp}
-                label="Upload Non-CR3"
-                href="/upload-non-cr3"
-              />
-              <SideBarListItem
-                isCollapsed={isCollapsed}
-                isCurrentPage={segments.includes("users")}
-                Icon={FaUserGroup}
-                label="Users"
-                href="/users"
-              />
+              {routes.map((route) => (
+                <PermissionsRequired allowedRoles={route.allowedRoles}>
+                  <SideBarListItem
+                    isCollapsed={isCollapsed}
+                    isCurrentPage={segments.includes(route.path)}
+                    Icon={route.icon}
+                    label={route.label}
+                    href={`/${route.path}`}
+                  />
+                </PermissionsRequired>
+              ))}
             </ListGroup>
           </div>
         </div>

--- a/app/configs/routes.ts
+++ b/app/configs/routes.ts
@@ -7,7 +7,7 @@ import {
 } from "react-icons/fa6";
 import { IconType } from "react-icons";
 
-type Route = {
+interface Route {
   path: string;
   label: string;
   icon: IconType;

--- a/app/configs/routes.ts
+++ b/app/configs/routes.ts
@@ -1,0 +1,44 @@
+import {
+  FaShieldHeart,
+  FaGaugeHigh,
+  FaLocationDot,
+  FaUserGroup,
+  FaCloudArrowUp,
+} from "react-icons/fa6";
+import { IconType } from "react-icons";
+
+type Route = {
+  path: string;
+  label: string;
+  icon: IconType;
+  allowedRoles?: string[];
+};
+
+export const routes: Route[] = [
+  {
+    path: "dashboard",
+    label: "Dashboard",
+    icon: FaGaugeHigh,
+  },
+  {
+    path: "crashes",
+    label: "Crashes",
+    icon: FaShieldHeart,
+  },
+  {
+    path: "locations",
+    label: "Locations",
+    icon: FaLocationDot,
+  },
+  {
+    path: "upload-non-cr3",
+    label: "Upload Non-CR3",
+    icon: FaCloudArrowUp,
+    allowedRoles: ["editor", "vz-admin"],
+  },
+  {
+    path: "users",
+    label: "Users",
+    icon: FaUserGroup,
+  },
+];

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -39,7 +39,7 @@ export const getHasuraRoleName = (roles?: string[]): string => {
 };
 
 /**
- * Check if a user has any of the provide the role names
+ * Check if a user has any of the provided role names
  * @param {string[]} roles - an array of roles to check for
  * @param {CustomUser} user - the user object
  * @returns True if the user has any of the provided roles

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -40,8 +40,8 @@ export const getHasuraRoleName = (roles?: string[]): string => {
 
 /**
  * Check if a user has any of the provided role names
- * @param {string[]} roles - an array of roles to check for
- * @param {CustomUser} user - the user object
+ * @param roles - an array of roles to check for
+ * @param user - the user object
  * @returns True if the user has any of the provided roles
  */
 export const hasRole = (roles: string[], user: CustomUser) =>

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -38,6 +38,9 @@ export const getHasuraRoleName = (roles?: string[]): string => {
   }
 };
 
+export const hasRole = (roles: string[], user: CustomUser) =>
+  roles.includes(getHasuraRoleName(getRolesArray(user)));
+
 export const formatRoleName = (role: string): string => {
   switch (role) {
     case "readonly":

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -38,6 +38,12 @@ export const getHasuraRoleName = (roles?: string[]): string => {
   }
 };
 
+/**
+ * Check if a user has any of the provide the role names
+ * @param {string[]} roles - an array of roles to check for
+ * @param {CustomUser} user - the user object
+ * @returns True if the user has any of the provided roles
+ */
 export const hasRole = (roles: string[], user: CustomUser) =>
   roles.includes(getHasuraRoleName(getRolesArray(user)));
 


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20302

Here's the first iteration of restricting access to VZE features based on user role. In the interest of avoiding code conflicts I have excluded the crash details page from this work.

## Testing

**URL to test:** Local



1. Start your local VZE, and also start the user API following the readme in `/api`. Once you have your env set up you should be able to run `docker compose up` and be on your way. Let me know if you need help.

2. You're going to test the VZE with three user accounts whose 1pass entries are named as follows:
* Vision Zero Editor (VZE) Test User: VZ Admin
* Vision Zero Editor (VZE) Test User: Editor
* Vision Zero Editor (VZE) Test User: Read-only

Please test all of the pages/features listed below and verify that the app matches this matrix 👇 

feature | admin | edtior | read-only
-- | -- | -- | --
Upload Non-CR3 page | visible | visible | hidden
Users page - user list | visible | visible | visible
Users page - add user button | visible | hidden | hidden
User details page | visible | visible | visible
User details page - edit and delete user buttons | visible | hidden | hidden
Crashes page - create crash record button | visible | visible | hidden

To summarize these rules: Read-only users can edit nothing. Editors can edit everything except users. Admins can edit everything.

That's it! nice!


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
