### PR TITLE
Fixes the VZV By Year & Month chart

### DIFF
--- a/viewer/src/views/summary/CrashesByYearAverage.js
+++ b/viewer/src/views/summary/CrashesByYearAverage.js
@@ -36,12 +36,8 @@ const CrashesByYearAverage = ({ avgData, currentYearData }) => {
       };
     };
 
-    const isDataFetched = !!avgData.length && !!currentYearData.length;
-
-    if (isDataFetched) {
-      const formattedData = formatChartData(avgData, currentYearData);
-      setChartData(formattedData);
-    }
+    const formattedData = formatChartData(avgData, currentYearData);
+    setChartData(formattedData);
   }, [avgData, currentYearData]);
 
   return (

--- a/viewer/src/views/summary/CrashesByYearCumulative.js
+++ b/viewer/src/views/summary/CrashesByYearCumulative.js
@@ -59,12 +59,8 @@ const CrashesByYearCumulative = ({ avgData, currentYearData }) => {
       };
     };
 
-    const isDataFetched = !!avgData.length && !!currentYearData.length;
-
-    if (isDataFetched) {
-      const formattedData = formatChartData(avgData, currentYearData);
-      setChartData(formattedData);
-    }
+    const formattedData = formatChartData(avgData, currentYearData);
+    setChartData(formattedData);
   }, [avgData, currentYearData]);
 
   return (


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20643

Thank you @chiaberry for flagging this and running down the problem. I went ahead and pushed up the fix i came up with based on our Slack convo 🙏 

## Testing

**URL to test:** Netlify

Test out that By Year & Month chart by toggling back and forth between the **Fatalities**, **Serious Injuries**, and **All** filters as well as the **Monthly** and **Cumulative** views.


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
