### PR TITLE
Repaint maps when collapsing the sidebar

### DIFF
--- a/app/components/CrashMap.tsx
+++ b/app/components/CrashMap.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useMemo,
   Dispatch,
   SetStateAction,
   MutableRefObject,
@@ -13,7 +12,6 @@ import MapGL, {
   ViewStateChangeEvent,
   MapRef,
 } from "react-map-gl";
-import debounce from "lodash/debounce";
 import { DEFAULT_MAP_PAN_ZOOM, DEFAULT_MAP_PARAMS } from "@/configs/map";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { MapAerialSourceAndLayer } from "./MapAerialSourceAndLayer";
@@ -58,19 +56,13 @@ export const CrashMap = ({
   editCoordinates,
   setEditCoordinates,
 }: CrashMapProps) => {
-  const debouncedSetCoordinates = useMemo(
-    () =>
-      debounce((latitude: number, longitude: number) => {
-        setEditCoordinates({ latitude, longitude });
-      }, 25),
-    [setEditCoordinates]
-  );
-
   const onDrag = useCallback(
     (e: ViewStateChangeEvent) => {
-      debouncedSetCoordinates(e.viewState.latitude, e.viewState.longitude);
+      const latitude = e.viewState.latitude;
+      const longitude = e.viewState.longitude;
+      setEditCoordinates({ latitude, longitude });
     },
-    [debouncedSetCoordinates]
+    [setEditCoordinates]
   );
 
   useEffect(() => {

--- a/app/components/CrashMap.tsx
+++ b/app/components/CrashMap.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   Dispatch,
   SetStateAction,
   MutableRefObject,
@@ -12,6 +13,7 @@ import MapGL, {
   ViewStateChangeEvent,
   MapRef,
 } from "react-map-gl";
+import debounce from "lodash/debounce";
 import { DEFAULT_MAP_PAN_ZOOM, DEFAULT_MAP_PARAMS } from "@/configs/map";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { MapAerialSourceAndLayer } from "./MapAerialSourceAndLayer";
@@ -56,13 +58,19 @@ export const CrashMap = ({
   editCoordinates,
   setEditCoordinates,
 }: CrashMapProps) => {
+  const debouncedSetCoordinates = useMemo(
+    () =>
+      debounce((latitude: number, longitude: number) => {
+        setEditCoordinates({ latitude, longitude });
+      }, 25),
+    [setEditCoordinates]
+  );
+
   const onDrag = useCallback(
     (e: ViewStateChangeEvent) => {
-      const latitude = e.viewState.latitude;
-      const longitude = e.viewState.longitude;
-      setEditCoordinates({ latitude, longitude });
+      debouncedSetCoordinates(e.viewState.latitude, e.viewState.longitude);
     },
-    [setEditCoordinates]
+    [debouncedSetCoordinates]
   );
 
   useEffect(() => {

--- a/app/components/CrashMap.tsx
+++ b/app/components/CrashMap.tsx
@@ -1,9 +1,9 @@
 import {
   useCallback,
-  useRef,
   useEffect,
   Dispatch,
   SetStateAction,
+  MutableRefObject,
 } from "react";
 import MapGL, {
   FullscreenControl,
@@ -22,6 +22,10 @@ export interface LatLon {
 }
 
 interface CrashMapProps {
+  /**
+   * Ref object which will hold the mapbox instance
+   */
+  mapRef: MutableRefObject<MapRef | null>;
   /**
    * The initial latitude - used when not editing
    */
@@ -45,14 +49,13 @@ interface CrashMapProps {
  * Map component which renders an editable point marker
  */
 export const CrashMap = ({
+  mapRef,
   savedLatitude,
   savedLongitude,
   isEditing,
   editCoordinates,
   setEditCoordinates,
 }: CrashMapProps) => {
-  const mapRef = useRef<MapRef | null>(null);
-
   const onDrag = useCallback(
     (e: ViewStateChangeEvent) => {
       const latitude = e.viewState.latitude;
@@ -71,6 +74,7 @@ export const CrashMap = ({
       });
     }
   }, [isEditing, setEditCoordinates, savedLatitude, savedLongitude]);
+
   return (
     <MapGL
       ref={mapRef}

--- a/app/components/CrashMapCard.tsx
+++ b/app/components/CrashMapCard.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
+import { MapRef } from "react-map-gl";
 import { CrashMap } from "@/components/CrashMap";
 import { useMutation } from "@/utils/graphql";
+import { useResizeObserver } from "@/utils/map";
 import { LatLon } from "@/components/CrashMap";
 
 interface CrashMapCardProps {
@@ -23,6 +25,11 @@ export default function CrashMapCard({
   onSaveCallback,
   mutation,
 }: CrashMapCardProps) {
+  const mapRef = useRef<MapRef | null>(null);
+  const mapContainerRef = useResizeObserver<HTMLDivElement>(() => {
+    mapRef.current?.resize();
+  });
+
   const [isEditingCoordinates, setIsEditingCoordinates] = useState(false);
   const [editCoordinates, setEditCoordinates] = useState<LatLon>({
     latitude: 0,
@@ -30,16 +37,22 @@ export default function CrashMapCard({
   });
   const { mutate, loading: isMutating } = useMutation(mutation);
 
+  /**
+   * Trigger resize() when the map container size changes - this ensures that
+   * the map repaints when the sidebar is collased/expanded.
+   */
+
   return (
     <Card>
       <Card.Header>Location</Card.Header>
-      <Card.Body className="p-1 crash-header-card-body">
+      <Card.Body className="p-1 crash-header-card-body" ref={mapContainerRef}>
         <CrashMap
           savedLatitude={savedLatitude}
           savedLongitude={savedLongitude}
           isEditing={isEditingCoordinates}
           editCoordinates={editCoordinates}
           setEditCoordinates={setEditCoordinates}
+          mapRef={mapRef}
         />
       </Card.Body>
       <Card.Footer>

--- a/app/components/CrashMapCard.tsx
+++ b/app/components/CrashMapCard.tsx
@@ -26,6 +26,10 @@ export default function CrashMapCard({
   mutation,
 }: CrashMapCardProps) {
   const mapRef = useRef<MapRef | null>(null);
+  /**
+   * Trigger resize() when the map container size changes - this ensures that
+   * the map repaints when the sidebar is collased/expanded.
+   */
   const mapContainerRef = useResizeObserver<HTMLDivElement>(() => {
     mapRef.current?.resize();
   });
@@ -36,11 +40,6 @@ export default function CrashMapCard({
     longitude: 0,
   });
   const { mutate, loading: isMutating } = useMutation(mutation);
-
-  /**
-   * Trigger resize() when the map container size changes - this ensures that
-   * the map repaints when the sidebar is collased/expanded.
-   */
 
   return (
     <Card>

--- a/app/components/LocationMap.tsx
+++ b/app/components/LocationMap.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from "react";
+import { useRef, useMemo, MutableRefObject } from "react";
 import MapGL, {
   FullscreenControl,
   NavigationControl,
@@ -14,6 +14,10 @@ import { MultiPolygon } from "@/types/geojson";
 import { LineLayerSpecification } from "mapbox-gl";
 
 interface LocationMapProps {
+  /**
+   * Ref object which will hold the mapbox instance
+   */
+  mapRef: MutableRefObject<MapRef | null>;
   polygon: MultiPolygon;
   locationId: string;
 }
@@ -46,8 +50,11 @@ const usePolygonFeature = (polygon: MultiPolygon, locationId: string) =>
 /**
  * Map component which renders an editable point marker
  */
-export const LocationMap = ({ polygon, locationId }: LocationMapProps) => {
-  const mapRef = useRef<MapRef | null>(null);
+export const LocationMap = ({
+  mapRef,
+  polygon,
+  locationId,
+}: LocationMapProps) => {
   const [polygonFeature, centerFeature] = usePolygonFeature(
     polygon,
     locationId

--- a/app/components/LocationMap.tsx
+++ b/app/components/LocationMap.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo, MutableRefObject } from "react";
+import { useMemo, MutableRefObject } from "react";
 import MapGL, {
   FullscreenControl,
   NavigationControl,

--- a/app/components/LocationMapCard.tsx
+++ b/app/components/LocationMapCard.tsx
@@ -12,7 +12,7 @@ export default function LocationMapCard({ location }: { location: Location }) {
   const mapRef = useRef<MapRef | null>(null);
   /**
    * Trigger resize() when the map container size changes - this ensures that
-   * the map repaints when the sidebar is collased/expanded.
+   * the map repaints when the sidebar is collapsed/expanded.
    */
   const mapContainerRef = useResizeObserver<HTMLDivElement>(() => {
     mapRef.current?.resize();

--- a/app/components/LocationMapCard.tsx
+++ b/app/components/LocationMapCard.tsx
@@ -1,18 +1,28 @@
+import { useEffect, useRef } from "react";
 import Card from "react-bootstrap/Card";
+import { MapRef } from "react-map-gl";
+import { useResizeObserver } from "@/utils/map";
 import { LocationMap } from "./LocationMap";
 import { Location } from "@/types/locations";
+
 /**
  * Card component that renders the crash map and edit controls
  */
 export default function LocationMapCard({ location }: { location: Location }) {
+  const mapRef = useRef<MapRef | null>(null);
+  const mapContainerRef = useResizeObserver<HTMLDivElement>(() => {
+    mapRef.current?.resize();
+  });
+
   return (
     <Card>
       <Card.Header>Location</Card.Header>
-      <Card.Body className="p-1 crash-header-card-body">
+      <Card.Body className="p-1 crash-header-card-body" ref={mapContainerRef}>
         {location.geometry && (
           <LocationMap
             polygon={location.geometry}
             locationId={location.location_id}
+            mapRef={mapRef}
           />
         )}
       </Card.Body>

--- a/app/components/LocationMapCard.tsx
+++ b/app/components/LocationMapCard.tsx
@@ -10,6 +10,10 @@ import { Location } from "@/types/locations";
  */
 export default function LocationMapCard({ location }: { location: Location }) {
   const mapRef = useRef<MapRef | null>(null);
+  /**
+   * Trigger resize() when the map container size changes - this ensures that
+   * the map repaints when the sidebar is collased/expanded.
+   */
   const mapContainerRef = useResizeObserver<HTMLDivElement>(() => {
     mapRef.current?.resize();
   });

--- a/app/components/LocationMapCard.tsx
+++ b/app/components/LocationMapCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import Card from "react-bootstrap/Card";
 import { MapRef } from "react-map-gl";
 import { useResizeObserver } from "@/utils/map";

--- a/app/utils/map.ts
+++ b/app/utils/map.ts
@@ -19,9 +19,9 @@ export function useResizeObserver<T extends HTMLElement>(
     const observer = new ResizeObserver(() => {
       // This timeout has a debouncing effect that prevents
       // the map from flashing on the screen during sidebar
-      // animation. A more roboust implementation would clear the
+      // animation. A more robust implementation would clear the
       // previous timeout interval but the performance hit
-      // seems neglibile
+      // seems negligible
       setTimeout(() => {
         callback();
       }, debounceDelay);

--- a/app/utils/map.ts
+++ b/app/utils/map.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Resize observer hook that can be used to trigger resize() when the
+ * map container size changes
+ * 
+ * @example
+ * const mapContainerRef = useResizeObserver<HTMLDivElement>(() => {
+    mapRef.current?.resize();
+  });
+ */
+export function useResizeObserver<T extends HTMLElement>(
+  callback: () => void,
+  debounceDelay: number = 50
+) {
+  const containerRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    const observer = new ResizeObserver(() => {
+      // This timeout has a debouncing effect that prevents
+      // the map from flashing on the screen during sidebar
+      // animation. A more roboust implementation would clear the
+      // previous timeout interval but the performance hit
+      // seems neglibile
+      setTimeout(() => {
+        callback();
+      }, debounceDelay);
+    });
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => {
+      if (containerRef.current) {
+        observer.unobserve(containerRef.current);
+      }
+    };
+  }, [callback, debounceDelay]);
+
+  return containerRef;
+}


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20765

## Testing

**URL to test:** Netlify

1. Expand the sidebar and then navigate the crash details page
2. Collapse the sidebar and observe that the bug described in [the issue](https://github.com/cityofaustin/atd-data-tech/issues/20765) does not occur
3. Edit the crash location to ensure the map component is working normally
4. Repeat these steps on the location details page

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
