### PR TITLE
Crash details: Ability to download CR3 PDF

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -41,6 +41,7 @@ npm run dev
 ## Working features
 
 - Crashes list
+  - create crash record button
   - filter by preset date range
   - filter by custom date range
   - filter using search input and selecting a field to search on
@@ -52,8 +53,9 @@ npm run dev
   - loading spinner apperas in pagination controls when fetching data
   - sortable table columns with icon indicating sort direction
 - Crash details page
+  - Delete crash record button if temporary
   - Crash map: crash map displays crash location with nearmap aerials
-  - Crash map: ability to edit crash location  
+  - Crash map: ability to edit crash location
   - Crash diagram: diagrams render
   - Crash diagram: info alert shows when no diagram is available and is temp record
   - Crash diagram: danger alert shows when no diagram is available and is not temp record
@@ -66,14 +68,15 @@ npm run dev
   - Crash data card: edit a text input
   - Crash data card: edit a number input
   - Crash data card: nullify a value (e.g. street name) by clearing its input and saving it
+  - Crash data card: swap addresses
   - FRB Recommendations
     - Create recommendation
     - Edit recommendation
   - Related records - units: click field to edit it
   - Related records - charges
   - Related records - people
-      - name edit component
-  - Change log: change log works normally with details modal. But it is not collapsible (yet).
+    - name edit component
+  - Change log: change log works normally with details modal. It is collapseable
 - Sidebar
   - is expandable and open/closed state is preserved in localstorage
 - Locations list
@@ -84,11 +87,12 @@ npm run dev
   - Location polygon map
   - Location data card displays the location ID, crash counts and comp costs
   - combined cr3 and noncr3 crashes list
-- Navabar:
+- Navbar:
   - Vision Zero logo displays on left side
+  - Crash search
   - Avatar image displays on right side with dropdown items
     - email address (disabled/not clickable)
-    - sighout link
+    - signout link
     - external links to report a bug, request enhancement, and TxDOT's CR3 codesheet
 - Users
   - user list view
@@ -96,10 +100,8 @@ npm run dev
   - add a new user
   - edit a user
   - delete a user
-- create crash records
-  - view + search for temp records
-  - create crash record form
-  
+  - copy user emails
+
 ## Todo
 
 - permissions-based features:
@@ -108,29 +110,20 @@ npm run dev
   - etc. see <Can/> component from VZE
 - crash details
   - crash injury widgets
-  - swap addresses
   - notes
   - misc column editing + placement
   - Crash map: show coordinates and enable editing by tying into input
   - crash diagram: zoom/tilt control
-  - Change log: collapseable
 - table
   - advanced filters: test them and add "Other" unit type filter
   - export
   - record counts
-- Top nav component
-  - navigation crash search
 - locations
   - export records
 - location details
   - crash charts and widgets
-- create crash record
-  - delete crash record
-  - hide page from read-only users
 - upload non-cr3
 - dashboard
-- users
-  - copy user emails
 - login page: make it look nice
 - versioned localstorage
 - error boundary (see Moped's for reference)

--- a/app/app/crashes/[record_locator]/page.tsx
+++ b/app/app/crashes/[record_locator]/page.tsx
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { notFound } from "next/navigation";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import Card from "react-bootstrap/Card";
 import CrashMapCard from "@/components/CrashMapCard";
 import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
 import { UPDATE_UNIT } from "@/queries/unit";

--- a/app/app/crashes/[record_locator]/page.tsx
+++ b/app/app/crashes/[record_locator]/page.tsx
@@ -14,6 +14,7 @@ import CrashHeader from "@/components/CrashHeader";
 import CrashLocationBanner from "@/components/CrashLocationBanner";
 import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
+import CrashNarrativeCard from "@/components/CrashNarrativeCard";
 import DataCard from "@/components/DataCard";
 import RelatedRecordTable from "@/components/RelatedRecordTable";
 import ChangeLog from "@/components/ChangeLog";
@@ -88,12 +89,7 @@ export default function CrashDetailsPage({
           <CrashDiagramCard crash={crash} />
         </Col>
         <Col sm={12} md={6} lg={4} className="mb-3">
-          <Card>
-            <Card.Header>Narrative</Card.Header>
-            <Card.Body className="crash-header-card-body">
-              <Card.Text>{crash.investigator_narrative || ""}</Card.Text>
-            </Card.Body>
-          </Card>
+          <CrashNarrativeCard crash={crash} />
         </Col>
       </Row>
       <Row>

--- a/app/components/CrashInjuryIndicators.tsx
+++ b/app/components/CrashInjuryIndicators.tsx
@@ -34,7 +34,7 @@ const CrashInjuryIndicators = ({
     <div className="fs-6 d-flex align-items-center bg-light rounded-3 px-3">
       <InjuryBadge
         value={injuries.vz_fatality_count}
-        label="Fatalies"
+        label="Fatalities"
         className="me-3"
       />
       <InjuryBadge

--- a/app/components/CrashNarrativeCard.tsx
+++ b/app/components/CrashNarrativeCard.tsx
@@ -1,0 +1,53 @@
+import Card from "react-bootstrap/Card";
+import Button from "react-bootstrap/Button";
+import { FaFilePdf } from "react-icons/fa6";
+
+import AlignedLabel from "@/components/AlignedLabel";
+import { Crash } from "@/types/crashes";
+import { useToken } from "@/utils/auth";
+
+export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
+  const token = useToken();
+
+  const onDownloadCR3 = async () => {
+    const requestUrl = `${process.env.NEXT_PUBLIC_CR3_API_DOMAIN}/cr3/download/${crash.id}`;
+
+    fetch(requestUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new Error("Request failed");
+        }
+      })
+      .then((data) => {
+        const win = window.open(data.message, "_blank");
+        win.focus();
+      })
+      .catch((error) => {
+        // Handle any errors that occurred during the request
+        console.error(error);
+      });
+  };
+
+  return (
+    <Card>
+      <Card.Header className="d-flex justify-content-between">
+        Narrative
+        <Button size="sm" onClick={onDownloadCR3}>
+          <AlignedLabel>
+            <FaFilePdf className="me-2" />
+            <span>Download CR3</span>
+          </AlignedLabel>
+        </Button>
+      </Card.Header>
+      <Card.Body className="crash-header-card-body">
+        <Card.Text>{crash.investigator_narrative || ""}</Card.Text>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/app/components/CrashNarrativeCard.tsx
+++ b/app/components/CrashNarrativeCard.tsx
@@ -26,7 +26,7 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
       })
       .then((data) => {
         const win = window.open(data.message, "_blank");
-        win.focus();
+        win?.focus();
       })
       .catch((error) => {
         // Handle any errors that occurred during the request

--- a/app/utils/users.ts
+++ b/app/utils/users.ts
@@ -58,7 +58,7 @@ export function useUsersInfinite(token: string | null) {
 /**
  * Hook to fetch a single user
  */
-export function useUser(userId?: string, token?: string | null ) {
+export function useUser(userId?: string, token?: string | null) {
   const url = `${process.env.NEXT_PUBLIC_CR3_API_DOMAIN}/user/get_user/${userId}`;
   return useSWR<User | UserAPIError>(
     token && userId ? url : null,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20632

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Locally - this wont work in netlify

**Steps to test:**
1. Follow the instructions in `api/` to start your local api or make sure your cr3 api endpoint in `env.local` is pointing to the staging endpoint.
2. Go the a crash details page, see the download cr3 button in the crash narrative card. It should be disabled if we dont have a cr3 for that crash (except in staging there is a discrepancy bc we may have that cr3 in the prod S3 bucket but not in the staging bucket, but `crashes.cr3_stored_fl` only checks if its in prod. So if this happens you will just get an error message)
3. Test downloading the cr3 for a crash, it should also open in a new tab. If you are using the staging api you may face the discrepancy above, so here are some crash ids that we do have in the staging bucket that you can test: 19998979, 20025780, 20018566

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
