### PR TITLE
Fatalities list - add related record columns and filter cards

### DIFF
--- a/app/components/Table.tsx
+++ b/app/components/Table.tsx
@@ -28,6 +28,7 @@ export default function Table<T extends Record<string, unknown>>({
           {columns.map((col) => (
             <th
               key={String(col.path)}
+              className="text-nowrap"
               style={{ cursor: col.sortable ? "pointer" : "auto" }}
               onClick={() => {
                 if (col.sortable) {
@@ -58,7 +59,7 @@ export default function Table<T extends Record<string, unknown>>({
           <tr key={i}>
             {columns.map((col) => (
               // todo: is no-wrap / side-scrolling ok?
-              <td key={String(col.path)} style={{ whiteSpace: "nowrap" }}>
+              <td key={String(col.path)} style={col.style}>
                 {renderColumnValue(row, col)}
               </td>
             ))}

--- a/app/components/TableWrapper.tsx
+++ b/app/components/TableWrapper.tsx
@@ -242,6 +242,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
       {queryConfig.exportable && (
         <TableExportModal<T>
           exportFilename={queryConfig.exportFilename}
+          columns={columns}
           onClose={() => setShowExportModal(false)}
           query={exportQuery}
           show={showExportModal}

--- a/app/configs/crashesListViewTable.ts
+++ b/app/configs/crashesListViewTable.ts
@@ -172,7 +172,7 @@ const crashesListViewfilterCards: FilterGroup[] = [
           },
         ],
       },
-      // todo: "Other" sitch
+      // todo: "Other" switch
     ],
   },
   {

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -44,19 +44,27 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     label: "Crash Date",
     sortable: true,
     valueFormatter: formatDate,
+    style: { whiteSpace: "nowrap" },
   },
   {
     path: "location",
     label: "Location",
     sortable: true,
+    style: { whiteSpace: "nowrap" },
   },
   {
     path: "victim_name",
     label: "Victim Name",
     sortable: true,
+    style: { whiteSpace: "nowrap" },
   },
   {
     path: "recommendation.rec_text",
     label: "FRB Recommendation",
+    style: { minWidth: "400px" },
+  },
+  {
+    path: "engineering_area.atd_engineer_areas",
+    label: "Engineering Area",
   },
 ];

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -31,7 +31,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
   },
   {
     path: "ytd_fatality",
-    label: "YTD Fatalities",
+    label: "YTD Fatality",
     sortable: true,
   },
   {

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -62,9 +62,11 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     path: "recommendation.rec_text",
     label: "FRB Recommendation",
     style: { minWidth: "400px" },
+    sortable: true,
   },
   {
     path: "engineering_area.atd_engineer_areas",
     label: "Engineering Area",
+    sortable: true,
   },
 ];

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -26,12 +26,12 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
   },
   {
     path: "law_enforcement_ytd_fatality_num",
-    label: "Law Enforcement Number",
+    label: "LE #",
     sortable: true,
   },
   {
     path: "ytd_fatal_crash",
-    label: "YTD Fatal Crashes",
+    label: "YTD Fatal Crash",
     sortable: true,
   },
   {
@@ -54,5 +54,9 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     path: "victim_name",
     label: "Victim Name",
     sortable: true,
+  },
+  {
+    path: "recommendation.rec_text",
+    label: "FRB Recommendation",
   },
 ];

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -59,6 +59,12 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     style: { whiteSpace: "nowrap" },
   },
   {
+    path: "recommendation.atd__recommendation_status_lkp.rec_status_desc",
+    label: "FRB Status",
+    style: { minWidth: "400px" },
+    sortable: true,
+  },
+  {
     path: "recommendation.rec_text",
     label: "FRB Recommendation",
     style: { minWidth: "400px" },

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -61,7 +61,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
   {
     path: "recommendation.atd__recommendation_status_lkp.rec_status_desc",
     label: "FRB Status",
-    style: { minWidth: "400px" },
+    style: { whiteSpace: "nowrap" },
     sortable: true,
   },
   {

--- a/app/configs/fatalitiesListViewColumns.tsx
+++ b/app/configs/fatalitiesListViewColumns.tsx
@@ -25,11 +25,6 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     sortable: true,
   },
   {
-    path: "law_enforcement_ytd_fatality_num",
-    label: "LE #",
-    sortable: true,
-  },
-  {
     path: "ytd_fatal_crash",
     label: "YTD Fatal Crash",
     sortable: true,
@@ -37,6 +32,11 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
   {
     path: "ytd_fatality",
     label: "YTD Fatalities",
+    sortable: true,
+  },
+  {
+    path: "law_enforcement_ytd_fatality_num",
+    label: "LE #",
     sortable: true,
   },
   {

--- a/app/configs/fatalitiesListViewTable.ts
+++ b/app/configs/fatalitiesListViewTable.ts
@@ -2,11 +2,265 @@ import {
   getYearsAgoDate,
   makeDateFilters,
 } from "@/components/TableDateSelector";
-import { fatalitiesListViewColumns } from "@/configs/fatalitiesListViewColumns";
 import { QueryConfig, FilterGroup } from "@/types/queryBuilder";
 import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
 
-const fatalitiesListViewFilterCards: FilterGroup[] = [];
+const fatalitiesListViewFilterCards: FilterGroup[] = [
+  {
+    id: "unit_type_filter_card",
+    label: "Unit Type",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "motor_vehicle",
+        label: "Motor vehicle",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unit_description",
+            column: "unit_desc_id",
+            operator: "_eq",
+            value: 1,
+            relationshipName: "unit",
+          },
+          {
+            id: "vehicle_body_style",
+            column: "veh_body_styl_id",
+            operator: "_nin",
+            value: [71, 90],
+            relationshipName: "unit",
+          },
+        ],
+      },
+      {
+        id: "motorcycle",
+        label: "Motorcycle",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unit_description",
+            column: "unit_desc_id",
+            operator: "_eq",
+            value: 1,
+            relationshipName: "unit",
+          },
+          {
+            id: "vehicle_body_style",
+            column: "veh_body_styl_id",
+            operator: "_in",
+            value: [71, 90],
+            relationshipName: "unit",
+          },
+        ],
+      },
+      {
+        id: "cyclist",
+        label: "Cyclist",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unit_description",
+            column: "unit_desc_id",
+            operator: "_eq",
+            value: 3,
+            relationshipName: "unit",
+          },
+        ],
+      },
+      {
+        id: "pedestrian",
+        label: "Pedestrian",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unit_description",
+            column: "unit_desc_id",
+            operator: "_eq",
+            value: 4,
+            relationshipName: "unit",
+          },
+        ],
+      },
+      {
+        id: "scooter_rider",
+        label: "E-scooter rider",
+        groupOperator: "_or",
+        filters: [
+          {
+            id: "unit_description",
+            column: "unit_desc_id",
+            operator: "_eq",
+            value: 77,
+            relationshipName: "unit",
+          },
+          {
+            id: "vehicle_body_style",
+            column: "veh_body_styl_id",
+            operator: "_eq",
+            value: 177,
+            relationshipName: "unit",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "recommendation_status_filter_card",
+    label: "Status",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "open_short_term",
+        label: "Open - short-term",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "open_short_term",
+            column: "recommendation_status_id",
+            operator: "_eq",
+            value: 1,
+            relationshipName: "recommendation",
+          },
+        ],
+      },
+      {
+        id: "open_long_term",
+        label: "Open - long-term",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "open_long_term",
+            column: "recommendation_status_id",
+            operator: "_eq",
+            value: 2,
+            relationshipName: "recommendation",
+          },
+        ],
+      },
+      {
+        id: "closed_no_action_rec",
+        label: "Closed - No action recommended",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "closed_no_action_rec",
+            column: "recommendation_status_id",
+            operator: "_eq",
+            value: 3,
+            relationshipName: "recommendation",
+          },
+        ],
+      },
+      {
+        id: "closed_rec_implemented",
+        label: "Closed - Recommendation implemented",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "closed_rec_implemented",
+            column: "recommendation_status_id",
+            operator: "_eq",
+            value: 4,
+            relationshipName: "recommendation",
+          },
+        ],
+      },
+      {
+        id: "closed_no_action_taken",
+        label: "Closed - No action taken",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "closed_no_action_taken",
+            column: "recommendation_status_id",
+            operator: "_eq",
+            value: 5,
+            relationshipName: "recommendation",
+          },
+        ],
+      },
+      {
+        id: "none",
+        label: "None",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "none",
+            column: "recommendation_status_id",
+            operator: "_is_null",
+            value: true,
+            relationshipName: "recommendation",
+          },
+        ],
+      },
+    ],
+  },
+
+  {
+    id: "roadway_system",
+    label: "Roadway system",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "on_system",
+        label: "On-system",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "onsys_fl_true",
+            column: "onsys_fl",
+            operator: "_eq",
+            value: true,
+            relationshipName: "crash",
+          },
+        ],
+      },
+      {
+        id: "off_system",
+        label: "Off-system",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "onsys_fl_false",
+            column: "onsys_fl",
+            operator: "_eq",
+            value: false,
+            relationshipName: "crash",
+          },
+        ],
+      },
+      // it appears that this column is never null but we're carrying this filter forward from
+      // an earlier version of the VZE
+      {
+        id: "unknown",
+        label: "Unknown",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unknown",
+            column: "onsys_fl",
+            operator: "_is_null",
+            value: true,
+            relationshipName: "crash",
+          },
+        ],
+      },
+    ],
+  },
+];
 
 export const fatalitiesListViewQueryConfig: QueryConfig = {
   exportable: true,

--- a/app/types/engineeringArea.ts
+++ b/app/types/engineeringArea.ts
@@ -1,0 +1,4 @@
+export type EngineeringArea = {
+  engineering_area_id: number;
+  atd_engineer_areas: string;
+};

--- a/app/types/fatalitiesList.ts
+++ b/app/types/fatalitiesList.ts
@@ -1,3 +1,5 @@
+import { Recommendation } from "./recommendation";
+
 export type fatalitiesListRow = {
   year: number;
   record_locator: string;
@@ -8,4 +10,5 @@ export type fatalitiesListRow = {
   crash_date_ct: string;
   location: string | null;
   victim_name: string | null;
+  recommendation: Recommendation | null;
 };

--- a/app/types/fatalitiesList.ts
+++ b/app/types/fatalitiesList.ts
@@ -1,4 +1,5 @@
 import { Recommendation } from "./recommendation";
+import { EngineeringArea } from "./engineeringArea";
 
 export type fatalitiesListRow = {
   year: number;
@@ -11,4 +12,5 @@ export type fatalitiesListRow = {
   location: string | null;
   victim_name: string | null;
   recommendation: Recommendation | null;
+  engineering_area: EngineeringArea | null;
 };

--- a/app/types/queryBuilder.ts
+++ b/app/types/queryBuilder.ts
@@ -126,7 +126,7 @@ export interface QueryConfig {
    */
   offset: number;
   /**
-   * The column name to be used in the `order_by` directive
+   * The column name to be used in the `order_by` argument
    */
   sortColName: string;
   /**

--- a/app/types/types.ts
+++ b/app/types/types.ts
@@ -54,8 +54,12 @@ export interface ColDataCardDef<T extends Record<string, unknown>> {
     record: T,
     onCancel: () => void,
     mutation: string,
-    onSaveCallback: () => Promise<void>,
+    onSaveCallback: () => Promise<void>
   ) => ReactNode;
+  /**
+   * Styles to be applied to the component's containing element
+   */
+  style?: React.CSSProperties;
 }
 
 export interface MutationVariables extends Variables {


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/20790

## Testing

**URL to test:** Local or netlify

1. Navigate to the fatalities page. You might need to hit the **Reset** button in the filter section to refresh your filters.
2. Test all of the filter card switches
3. Check out the table and observe that it is loading as expected
4. Test sorting all columns
5. Click the **download** button, save the CSV, and make sure it loads correctly in your favorite editor

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
