### PR TITLE
Add location ID and geocode provider to map card header + footer

### DIFF
--- a/app/app/crashes/[record_locator]/page.tsx
+++ b/app/app/crashes/[record_locator]/page.tsx
@@ -82,6 +82,8 @@ export default function CrashDetailsPage({
             crashId={crash.id}
             onSaveCallback={onSaveCallback}
             mutation={UPDATE_CRASH}
+            locationId={crash.location_id}
+            isManualGeocode={crash.crashes_list_view.is_manual_geocode}
           />
         </Col>
         <Col sm={12} md={6} lg={4} className="mb-3">

--- a/app/components/CrashMapCard.tsx
+++ b/app/components/CrashMapCard.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import Link from "next/link";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
 import { MapRef } from "react-map-gl";
@@ -13,6 +14,8 @@ interface CrashMapCardProps {
   crashId: number;
   onSaveCallback: () => Promise<void>;
   mutation: string;
+  locationId: string | null;
+  isManualGeocode: boolean | null;
 }
 
 /**
@@ -24,6 +27,8 @@ export default function CrashMapCard({
   savedLongitude,
   onSaveCallback,
   mutation,
+  locationId,
+  isManualGeocode,
 }: CrashMapCardProps) {
   const mapRef = useRef<MapRef | null>(null);
   /**
@@ -41,9 +46,20 @@ export default function CrashMapCard({
   });
   const { mutate, loading: isMutating } = useMutation(mutation);
 
+  const hasCoordinates = !!savedLatitude && !!savedLongitude;
+
+  const hasLocation = !!locationId;
+
   return (
     <Card>
-      <Card.Header>Location</Card.Header>
+      <Card.Header>
+        Location:{" "}
+        {hasLocation ? (
+          <Link href={`/locations/${locationId}`}>{locationId}</Link>
+        ) : (
+          "unassigned"
+        )}
+      </Card.Header>
       <Card.Body className="p-1 crash-header-card-body" ref={mapContainerRef}>
         <CrashMap
           savedLatitude={savedLatitude}
@@ -57,7 +73,14 @@ export default function CrashMapCard({
       <Card.Footer>
         <div className="d-flex justify-content-between">
           <div>
-            <span>Geocode provider</span>
+            <span>
+              Location provider: {""}
+              {hasCoordinates
+                ? isManualGeocode
+                  ? "Manual Q/A"
+                  : "TxDOT CRIS"
+                : "No Primary Coordinates"}
+            </span>
           </div>
           <div>
             <Button

--- a/app/types/crashes.ts
+++ b/app/types/crashes.ts
@@ -1,10 +1,11 @@
-import { CrashInjuryMetric } from "./crashInjuryMetrics";
-import { LookupTableOption } from "./relationships";
-import { ChangeLogEntry } from "./changeLog";
-import { Unit } from "./unit";
-import { Charge } from "./charge";
-import { Person } from "./person";
-import { Recommendation } from "./recommendation";
+import { CrashInjuryMetric } from "@/types/crashInjuryMetrics";
+import { LookupTableOption } from "@/types/relationships";
+import { ChangeLogEntry } from "@/types/changeLog";
+import { Unit } from "@/types/unit";
+import { Charge } from "@/types/charge";
+import { Person } from "@/types/person";
+import { Recommendation } from "@/types/recommendation";
+import { CrashesListRow } from "@/types/crashesList";
 
 export type Crash = {
   active_school_zone_fl: boolean | null;
@@ -69,4 +70,5 @@ export type Crash = {
   units: Unit[] | null;
   charges_cris: Charge[] | null;
   people_list_view: Person[] | null;
+  crashes_list_view: CrashesListRow;
 };

--- a/app/types/crashesList.ts
+++ b/app/types/crashesList.ts
@@ -38,4 +38,5 @@ export type CrashesListRow = {
   unkn_injry_count: number | null;
   vz_fatality_count: number | null;
   wthr_cond_id: number | null;
+  is_manual_geocode: boolean | null;
 };

--- a/app/types/queryBuilder.ts
+++ b/app/types/queryBuilder.ts
@@ -1,5 +1,3 @@
-import { ColDataCardDef } from "@/types/types";
-
 /**
  * The types we currently support as filter values
  *
@@ -20,15 +18,15 @@ export interface Filter {
    * Hasura comparison operator, e.g. _eq, _gte
    */
   operator:
-    | "_gte"
-    | "_lte"
-    | "_gt"
-    | "_eq"
-    | "_neq"
-    | "_is_null"
-    | "_ilike"
-    | "_in"
-    | "_nin";
+  | "_gte"
+  | "_lte"
+  | "_gt"
+  | "_eq"
+  | "_neq"
+  | "_is_null"
+  | "_ilike"
+  | "_in"
+  | "_nin";
   /**
    * The filter value
    */

--- a/app/types/recommendation.ts
+++ b/app/types/recommendation.ts
@@ -55,7 +55,7 @@ export type RecommendationFormInputs = {
   rec_update?: string | null | undefined;
   recommendation_status_id?: number | null | undefined;
   recommendations_partners?:
-    | Partial<RecommendationPartner>[]
-    | null
-    | undefined;
+  | Partial<RecommendationPartner>[]
+  | null
+  | undefined;
 };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20700

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local or netlify

**Steps to test:**
1. Go to a crash, see the new location id and location provider fields on the crash map card.
2. Test editing a crash location and see the location id update and the location provider should also update to "Manual Q/A"
3. Test the hyperlinked location id

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
