### PR TITLE
Raise exceptions in the AFD and EMS ETLs

### DIFF
--- a/etl/afd_ems_import/README.md
+++ b/etl/afd_ems_import/README.md
@@ -6,6 +6,7 @@
 For local development, you may find that the `docker-compose.yml` eases the work
 of having to collect the correct arguments to the docker invocation. After creating
 a .env file, you can run these scripts with:
+
 ```
 $ docker compose run import afd
 $ docker compose run import ems

--- a/etl/afd_ems_import/README.md
+++ b/etl/afd_ems_import/README.md
@@ -3,6 +3,8 @@
 
 ### Invocation
 
+You will need to be on COA VPN to develop this ETL, because the scripts requires access to our credential server.
+
 For local development, you may find that the `docker-compose.yml` eases the work
 of having to collect the correct arguments to the docker invocation. After creating
 a .env file, you can run these scripts with:

--- a/etl/afd_ems_import/README.md
+++ b/etl/afd_ems_import/README.md
@@ -3,7 +3,7 @@
 
 ### Invocation
 
-You will need to be on COA VPN to develop this ETL, because the scripts requires access to our credential server.
+You will need to be on COA VPN to develop this ETL, because the scripts require access to our credential server.
 
 For local development, you may find that the `docker-compose.yml` eases the work
 of having to collect the correct arguments to the docker invocation. After creating

--- a/etl/afd_ems_import/README.md
+++ b/etl/afd_ems_import/README.md
@@ -7,8 +7,8 @@ For local development, you may find that the `docker-compose.yml` eases the work
 of having to collect the correct arguments to the docker invocation. After creating
 a .env file, you can run these scripts with:
 ```
-$ docker compose run -it import afd
-$ docker compose run -it import ems
+$ docker compose run import afd
+$ docker compose run import ems
 ```
 
 In production, they will be run from a DAG which handles starting the containers with

--- a/etl/afd_ems_import/afd_incident_upload.py
+++ b/etl/afd_ems_import/afd_incident_upload.py
@@ -350,6 +350,7 @@ def upload_data_to_postgres(data, age_cutoff):
                 print(f"Values: {values}")
                 print(f"Error: {error}")
                 pg.rollback()
+                raise error
 
     return True
 

--- a/etl/afd_ems_import/ems_incident_upload.py
+++ b/etl/afd_ems_import/ems_incident_upload.py
@@ -514,6 +514,7 @@ def upload_data_to_postgres(data, age_cutoff):
                 print(f"Values: {values}")
                 print(f"Error: {error}")
                 pg.rollback()
+                raise error
 
     return True
 


### PR DESCRIPTION
## Associated issues
* https://github.com/cityofaustin/atd-data-tech/issues/20715

## Testing

Requires VPN

1. Set up your `.env` file—you can copy the `OP` values out of your local Airflow setup
2. Connect to VPN
3. I'm not sure the best way to force this to throw an error. I added this line right above [L345](https://github.com/cityofaustin/vision-zero/blob/4d033b3e2a2a27fba00f20919a6043c191330a86/etl/afd_ems_import/afd_incident_upload.py#L345):

```python
raise ValueError("Something broke")
```

4. Run the ETLs and see them break

```
docker compose build
docker compose run import afd
docker compose run import ems
```

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
