### PR TITLE
Remove IP address info from user API and user details pages

### DIFF
--- a/editor/app/users/[user_id]/page.tsx
+++ b/editor/app/users/[user_id]/page.tsx
@@ -34,7 +34,6 @@ const COLUMNS: UserColumn[] = [
   },
   { name: "name", label: "Name" },
   { name: "email", label: "Email" },
-  { name: "last_ip", label: "Last IP address" },
   { name: "logins_count", label: "Login count" },
   {
     name: "created_at",

--- a/editor/types/users.ts
+++ b/editor/types/users.ts
@@ -15,7 +15,6 @@ export type User = {
   logins_count?: number;
   name: string;
   user_id: string;
-  last_ip?: string;
   updated_at?: string;
 };
 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/20751

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Go to your user details page, see that the Last IP address row is gone

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
