### PR TITLE
Line breaks are hidden in the crash recommendation and notes

### DIFF
--- a/editor/components/CrashRecommendationCard.tsx
+++ b/editor/components/CrashRecommendationCard.tsx
@@ -259,7 +259,11 @@ export default function CrashRecommendationCard({
                 rows={6}
               />
             )}
-            {!isEditing && <p>{recommendation?.rec_update || "-"}</p>}
+            {!isEditing && (
+              <p style={{ whiteSpace: "pre-wrap" }}>
+                {recommendation?.rec_update || "-"}
+              </p>
+            )}
           </Form.Group>
         </Form>
       </Card.Body>

--- a/editor/components/CrashRecommendationCard.tsx
+++ b/editor/components/CrashRecommendationCard.tsx
@@ -241,7 +241,11 @@ export default function CrashRecommendationCard({
                 autoFocus={true}
               />
             )}
-            {!isEditing && <p>{recommendation?.rec_text || "-"}</p>}
+            {!isEditing && (
+              <p style={{ whiteSpace: "pre-wrap" }}>
+                {recommendation?.rec_text || "-"}
+              </p>
+            )}
           </Form.Group>
           <Form.Group className="mb-3">
             <Form.Label className="fw-bold">Updates</Form.Label>

--- a/editor/components/DataCardInput.tsx
+++ b/editor/components/DataCardInput.tsx
@@ -73,6 +73,7 @@ const DataCardInput = ({
             autoFocus
             size="sm"
             as="textarea"
+            rows={5}
             value={editValue}
             onChange={(e) => setEditValue(e.target.value)}
           />

--- a/editor/components/RelatedRecordTableRow.tsx
+++ b/editor/components/RelatedRecordTableRow.tsx
@@ -132,7 +132,11 @@ export default function RelatedRecordTableRow<
                 }
               }}
             >
-              {!isEditingThisColumn && renderColumnValue(record, col)}
+              {!isEditingThisColumn && (
+                <p style={{ whiteSpace: "pre-wrap" }}>
+                  {renderColumnValue(record, col)}
+                </p>
+              )}
               {isEditingThisColumn &&
                 col.customEditComponent &&
                 col.customEditComponent(

--- a/editor/configs/fatalitiesListViewColumns.tsx
+++ b/editor/configs/fatalitiesListViewColumns.tsx
@@ -67,7 +67,7 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
   {
     path: "recommendation.rec_text",
     label: "FRB Recommendation",
-    style: { minWidth: "400px" },
+    style: { minWidth: "400px", whiteSpace: "pre-wrap" },
     sortable: true,
   },
   {


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21010

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1709--atd-vze-staging.netlify.app/editor/crashes/20338972

**Steps to test:**
1. Go to a crash and add content to a note with line breaks. On save you should still see the line breaks, whether you are inside or outside of edit mode.
2. Repeat step 1 for the recommendation text
3. I also made the default height of the `textarea` for editing notes a little bigger, it felt a tad small before

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
