### PR TITLE
Set hours on date filter to be end of day

### DIFF
--- a/editor/components/TableDateSelector.tsx
+++ b/editor/components/TableDateSelector.tsx
@@ -99,6 +99,8 @@ export default function TableDateSelector({
             className="form-control"
             onChange={(date) => {
               if (date) {
+                // set the hours to the beginning of the date selected
+                date.setHours(0, 0, 0, 0);
                 setCustomDateRange({
                   start: date,
                   end: customDateRange.end,

--- a/editor/components/TableDateSelector.tsx
+++ b/editor/components/TableDateSelector.tsx
@@ -117,6 +117,8 @@ export default function TableDateSelector({
             className="form-control"
             onChange={(date) => {
               if (date) {
+                // set the hours to the end of the date selected
+                date.setHours(23, 59, 59, 999);
                 setCustomDateRange({
                   start: customDateRange.start,
                   end: date,

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -35,7 +35,7 @@ export default function TablePaginationControls({
 
   const pageLeftButtonDisabled =
     recordCount === 0 || queryConfig.offset === 0 || isLoading;
-  const pageRightButtonDisabled = recordCount < queryConfig.limit || isLoading;
+  const pageRightButtonDisabled = recordCount <= queryConfig.limit || isLoading;
 
   return (
     <ButtonToolbar>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/21206

John did the [triaging](https://github.com/cityofaustin/atd-data-tech/issues/21206) and found that the date filter is using the current timestamp. I added a line in the filters onChange to set the hours as the end of the day. 

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-1720--atd-vze-staging.netlify.app/editor/crashes

**Steps to test:**

This may be a quirky one to test, just because its involving time. But if you go into [staging](https://visionzero-staging.austinmobility.io/editor/crashes) and filter down to crashes between 8/16/24 and 8/16/24, depending on the time of day that you are testing, you may get 0 results or 1 result. Because the current behavior is the timestamp will just set to whatever time it is now, for example when I check the network request I get `# date_end \n crash_timestamp: { _lte: \"2024-08-16T17:16:36.000Z\" } } ` . 

Running the same query on the deploy preview, the query says ` # date_end \n crash_timestamp: { _lte: \"2024-08-17T04:59:59.999Z\" } } ` which is central daylight time 8/16/24 11:59pm in UTC time. 

-- edited to add:
Another easy way to see the difference is in staging to filter crashes after and before 8/13/24, I just tested now and got only 11 records in the results, but on the preview branch there are 25

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
