### PR TITLE
Remove IT Supervisor handling from VZE

### DIFF
--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -25,15 +25,9 @@ export const getRolesArray = (user: CustomUser | undefined) =>
  */
 export const getHasuraRoleName = (roles?: string[]): string => {
   if (!roles) {
+    // this would be there result of a malformed/corrupted user account -
+    // check this user's raw JSON in the Auth0 user database
     return "";
-  } else if (roles.includes("vz-admin")) {
-    // todo
-    // If user has more than one role, it is because they have `itSupervisor` and `vz-admin`
-    // `vz-admin` is the Hasura role name, `itSupervisor` is a legacy role that was previously
-    // used to enable a user to create and edit other admins. this app will do away with
-    // that behavior: any admin can create and modify other admins. A follow-up task is
-    // to clean up the Auth0 user database that references `itSupervisor`
-    return "vz-admin";
   } else {
     return roles[0] || "";
   }
@@ -59,8 +53,6 @@ export const formatRoleName = (role: string): string => {
       return "Editor";
     case "vz-admin":
       return "Admin";
-    case "itSupervisor":
-      return "IT Supervisor";
     default:
       return role;
   }

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -25,7 +25,7 @@ export const getRolesArray = (user: CustomUser | undefined) =>
  */
 export const getHasuraRoleName = (roles?: string[]): string => {
   if (!roles) {
-    // this would be there result of a malformed/corrupted user account -
+    // this would be the result of a malformed/corrupted user account -
     // check this user's raw JSON in the Auth0 user database
     return "";
   } else {


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/21341

In addition to the code change in this PR, I made the following changes in Auth0:

* Update the three accounts in our user database that had the `ITSupervisor` role. They are now `vz-admin`.
* Removed the portion of our post-login action that checks for the `ITSupervisor` role and conditionally adds `vz-admin` to the roles array.

## Testing

**URL to test:** Netlify

The three accounts in 1pass are named as follows:

- Vision Zero Editor (VZE) Test User: Read-only
- Vision Zero Editor (VZE) Test User: Editor
- Vision Zero Editor (VZE) Test User: VZ Admin

Login to the app as each of our three test accounts and verify that pages load normally for you. Observe that as an editor and admin you can edit a crash. 

As an admin, notice that you have the **Add user** button available on the **Users** page. As an editor and readonly, notice that this option is not available.




---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
