### PR TITLE
Add moar keyboard shortcuts to crash details page

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -33,6 +33,9 @@ const shortcutKeyLookup = {
   A: "address",
   U: "units",
   P: "people",
+  C: "charges",
+  N: "notes",
+  F: "fatality",
 };
 
 // Handles scrolling down to element on key press
@@ -193,7 +196,7 @@ export default function CrashDetailsPage({
           />
         </Col>
       </Row>
-      <Row>
+      <Row id="charges">
         <Col sm={12} className="mb-3">
           <RelatedRecordTable
             records={crash.charges_cris || []}
@@ -205,7 +208,7 @@ export default function CrashDetailsPage({
           />
         </Col>
       </Row>
-      <Row>
+      <Row id="notes">
         <Col sm={12} className="mb-3">
           <CrashNotesCard
             notes={crash.crash_notes || []}
@@ -215,7 +218,7 @@ export default function CrashDetailsPage({
           />
         </Col>
       </Row>
-      <Row>
+      <Row id="fatality">
         <Col sm={12} md={6} className="mb-3">
           <CrashRecommendationCard
             recommendation={crash.recommendation}

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -24,6 +24,7 @@ import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
 import { UPDATE_PERSON } from "@/queries/person";
 import { UPDATE_UNIT } from "@/queries/unit";
 import { Crash } from "@/types/crashes";
+import { ShortcutKeyLookup } from "@/types/keyboardShortcuts";
 import { useQuery } from "@/utils/graphql";
 import {
   scrollToElementOnKeyPress,
@@ -33,7 +34,7 @@ import {
 const typename = "crashes";
 
 // Lookup object that maps key shortcuts to the associated DOM element id to scroll to
-const shortcutKeyLookup = [
+const shortcutKeyLookup: ShortcutKeyLookup[] = [
   { key: "A", elementId: "address" },
   { key: "U", elementId: "units" },
   { key: "P", elementId: "people" },

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -1,53 +1,46 @@
 "use client";
-import { useCallback } from "react";
 import { notFound } from "next/navigation";
-import Row from "react-bootstrap/Row";
+import { useCallback } from "react";
 import Col from "react-bootstrap/Col";
-import CrashMapCard from "@/components/CrashMapCard";
-import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
-import { UPDATE_UNIT } from "@/queries/unit";
-import { UPDATE_PERSON } from "@/queries/person";
-import { useQuery } from "@/utils/graphql";
-import CrashHeader from "@/components/CrashHeader";
-import CrashLocationBanner from "@/components/CrashLocationBanner";
-import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
-import CrashDiagramCard from "@/components/CrashDiagramCard";
-import CrashNarrativeCard from "@/components/CrashNarrativeCard";
-import DataCard from "@/components/DataCard";
-import CrashNotesCard from "@/components/CrashNotesCard";
-import RelatedRecordTable from "@/components/RelatedRecordTable";
+import Row from "react-bootstrap/Row";
+
 import ChangeLog from "@/components/ChangeLog";
-import { crashDataCards } from "@/configs/crashDataCard";
-import { unitRelatedRecordCols } from "@/configs/unitRelatedRecordTable";
-import { chargeRelatedRecordCols } from "@/configs/chargeRelatedRecordTable";
-import { peopleRelatedRecordCols } from "@/configs/peopleRelatedRecordTable";
-import { Crash } from "@/types/crashes";
+import CrashDiagramCard from "@/components/CrashDiagramCard";
+import CrashHeader from "@/components/CrashHeader";
+import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
+import CrashLocationBanner from "@/components/CrashLocationBanner";
+import CrashMapCard from "@/components/CrashMapCard";
+import CrashNarrativeCard from "@/components/CrashNarrativeCard";
+import CrashNotesCard from "@/components/CrashNotesCard";
 import CrashRecommendationCard from "@/components/CrashRecommendationCard";
 import CrashSwapAddressButton from "@/components/CrashSwapAddressButton";
-import { useKeyboardShortcut } from "@/utils/shortcuts";
+import DataCard from "@/components/DataCard";
+import RelatedRecordTable from "@/components/RelatedRecordTable";
+import { chargeRelatedRecordCols } from "@/configs/chargeRelatedRecordTable";
+import { crashDataCards } from "@/configs/crashDataCard";
+import { peopleRelatedRecordCols } from "@/configs/peopleRelatedRecordTable";
+import { unitRelatedRecordCols } from "@/configs/unitRelatedRecordTable";
+import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
+import { UPDATE_PERSON } from "@/queries/person";
+import { UPDATE_UNIT } from "@/queries/unit";
+import { Crash } from "@/types/crashes";
+import { useQuery } from "@/utils/graphql";
+import {
+  scrollToElementOnKeyPress,
+  useKeyboardShortcut,
+} from "@/utils/shortcuts";
 
 const typename = "crashes";
 
 // Lookup object that maps key shortcuts to the associated DOM element id to scroll to
-const shortcutKeyLookup = {
-  A: "address",
-  U: "units",
-  P: "people",
-  C: "charges",
-  N: "notes",
-  F: "fatality",
-};
-
-// Handles scrolling down to element on key press
-const onKeyPress = (event: KeyboardEvent) => {
-  const shortcutKey = event.key.toUpperCase();
-  const elementId =
-    // Type assertion to indicate that shortcutKey is not of type string but
-    // is a union type containing the keys of our object shortcutKeyLookup
-    shortcutKeyLookup[shortcutKey as keyof typeof shortcutKeyLookup];
-  const element = document.getElementById(elementId);
-  element?.scrollIntoView();
-};
+const shortcutKeyLookup = [
+  { key: "A", elementId: "address" },
+  { key: "U", elementId: "units" },
+  { key: "P", elementId: "people" },
+  { key: "C", elementId: "charges" },
+  { key: "N", elementId: "notes" },
+  { key: "F", elementId: "fatality" },
+];
 
 export default function CrashDetailsPage({
   params,
@@ -57,7 +50,7 @@ export default function CrashDetailsPage({
   const recordLocator = params.record_locator;
 
   // Call hook to watch out for the use of keyboard shortcuts
-  useKeyboardShortcut(Object.keys(shortcutKeyLookup), onKeyPress);
+  useKeyboardShortcut(shortcutKeyLookup, scrollToElementOnKeyPress);
 
   const { data, error, refetch, isValidating } = useQuery<Crash>({
     query: recordLocator ? GET_CRASH : null,

--- a/editor/components/SidebarLayout.tsx
+++ b/editor/components/SidebarLayout.tsx
@@ -12,14 +12,10 @@ import { routes } from "@/configs/routes";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
 import AppFooter from "@/components/AppFooter";
-import { scrollToTop, useKeyboardShortcut } from "@/utils/shortcuts";
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 const localStorageKey = "sidebarCollapsed";
-
-// Keyboard shortcut to scroll to top of page
-const shortcutKey = [{ key: "T" }];
 
 /**
  * The app sidebar component
@@ -30,9 +26,6 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
     useAuth0();
   const pathName = usePathname();
   const segments = useSelectedLayoutSegments();
-
-  // Call hook to watch out for the use of keyboard shortcuts
-  useKeyboardShortcut(shortcutKey, scrollToTop);
 
   const toggleSidebar = useCallback(
     () =>
@@ -75,7 +68,7 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div style={{ overflow: "hidden" }} className="d-flex">
+    <div style={{ height: "100vh", overflow: "hidden" }} className="d-flex">
       {/* Sidebar */}
       <div
         className={`bg-dark app-sidebar app-sidebar-${

--- a/editor/components/SidebarLayout.tsx
+++ b/editor/components/SidebarLayout.tsx
@@ -12,10 +12,14 @@ import { routes } from "@/configs/routes";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import AppBreadCrumb from "@/components/AppBreadCrumb";
 import AppFooter from "@/components/AppFooter";
+import { scrollToTop, useKeyboardShortcut } from "@/utils/shortcuts";
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 const localStorageKey = "sidebarCollapsed";
+
+// Keyboard shortcut to scroll to top of page
+const shortcutKey = [{ key: "T" }];
 
 /**
  * The app sidebar component
@@ -26,6 +30,9 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
     useAuth0();
   const pathName = usePathname();
   const segments = useSelectedLayoutSegments();
+
+  // Call hook to watch out for the use of keyboard shortcuts
+  useKeyboardShortcut(shortcutKey, scrollToTop);
 
   const toggleSidebar = useCallback(
     () =>
@@ -68,7 +75,7 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
   }
 
   return (
-    <div style={{ height: "100vh", overflow: "hidden" }} className="d-flex">
+    <div style={{ overflow: "hidden" }} className="d-flex">
       {/* Sidebar */}
       <div
         className={`bg-dark app-sidebar app-sidebar-${

--- a/editor/types/keyboardShortcuts.ts
+++ b/editor/types/keyboardShortcuts.ts
@@ -2,5 +2,5 @@
 // for use as a keyboard shortcut
 export type ShortcutKeyLookup = {
   key: string;
-  elementId?: string;
+  elementId: string;
 };

--- a/editor/types/keyboardShortcuts.ts
+++ b/editor/types/keyboardShortcuts.ts
@@ -1,5 +1,7 @@
-// Type for mapping a key to an element id
-// for use as a keyboard shortcut
+/**
+ * Type for mapping a key to an element id
+ * for use as a keyboard shortcut
+ */
 export type ShortcutKeyLookup = {
   key: string;
   elementId: string;

--- a/editor/types/keyboardShortcuts.ts
+++ b/editor/types/keyboardShortcuts.ts
@@ -1,0 +1,6 @@
+// Type for mapping a key to an element id
+// for use as a keyboard shortcut
+export type ShortcutKeyLookup = {
+  key: string;
+  elementId?: string;
+};

--- a/editor/utils/shortcuts.ts
+++ b/editor/utils/shortcuts.ts
@@ -4,14 +4,14 @@ import { ShortcutKeyLookup } from "@/types/keyboardShortcuts";
 /**
  * Custom hook for adding keyboard shortcuts.
  *
- * The shift key must be used in conjunction with the array of keys passed
- * and the focused element can't be an input or text area
+ * The shift key must be used in conjunction with the shortcut keys
+ * and the focused element can't be an input, text area, or select
  * in order to fire the handleKeyPress callback.
+ * @param shortcutKeyLookup - Array of lookup objects mapping keys to their shortcut element ids
+ * @param callback - Callback that handles what happens when the keys are pressed
  */
 export const useKeyboardShortcut = (
-  // Array of keys that should trigger the callback when used alongside the shift key
   shortcutKeyLookup: ShortcutKeyLookup[],
-  // Callback that handles what happens when the keys are pressed
   callback: (
     event: KeyboardEvent,
     shortcutKeyLookup: ShortcutKeyLookup[]
@@ -27,11 +27,11 @@ export const useKeyboardShortcut = (
       const shortcutKeys = shortcutKeyLookup.map((shortcut) => shortcut.key);
       // Type guard to access tagName property, see https://iifx.dev/en/articles/156175355
       if (event.target instanceof Element) {
-        // Don't trigger callback if focused element is an input or textarea
+        // Don't trigger callback if focused element is an input, textarea or select
         if (targetsToDisable.includes(event.target.tagName)) {
           return;
         }
-        // Check if key in shortcutKeys array and used in conjunction with shift key
+        // Check if key is in shortcutKeys array and used in conjunction with shift key
         if (
           shortcutKeys.some(
             (key) =>
@@ -53,11 +53,14 @@ export const useKeyboardShortcut = (
   }, [handleKeyPress]);
 };
 
-// Handles scrolling down to element on key press
+/**
+ * Handles scrolling down to element on key press
+ */
 export const scrollToElementOnKeyPress = (
   event: KeyboardEvent,
   shortcutKeyLookup: ShortcutKeyLookup[]
 ) => {
+  // toUpperCase makes sure the scroll is still triggered when user has caps lock on
   const eventKey = event.key.toUpperCase();
   const elementId =
     shortcutKeyLookup &&

--- a/editor/utils/shortcuts.ts
+++ b/editor/utils/shortcuts.ts
@@ -14,7 +14,7 @@ export const useKeyboardShortcut = (
   // Callback that handles what happens when the keys are pressed
   callback: (
     event: KeyboardEvent,
-    shortcutKeyLookup?: ShortcutKeyLookup[]
+    shortcutKeyLookup: ShortcutKeyLookup[]
   ) => void
 ) => {
   const callbackRef = useRef(callback);
@@ -56,7 +56,7 @@ export const useKeyboardShortcut = (
 // Handles scrolling down to element on key press
 export const scrollToElementOnKeyPress = (
   event: KeyboardEvent,
-  shortcutKeyLookup?: ShortcutKeyLookup[]
+  shortcutKeyLookup: ShortcutKeyLookup[]
 ) => {
   const eventKey = event.key.toUpperCase();
   const elementId =
@@ -64,9 +64,4 @@ export const scrollToElementOnKeyPress = (
     shortcutKeyLookup.find((shortcut) => eventKey === shortcut.key)?.elementId;
   const element = document.getElementById(String(elementId));
   element?.scrollIntoView({ behavior: "instant" });
-};
-
-// Handles scrolling to top of page
-export const scrollToTop = () => {
-  window.scrollTo({ top: 0, left: 0, behavior: "instant" });
 };

--- a/editor/utils/shortcuts.ts
+++ b/editor/utils/shortcuts.ts
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, useRef, useEffect } from "react";
+import { ShortcutKeyLookup } from "@/types/keyboardShortcuts";
 
 /**
  * Custom hook for adding keyboard shortcuts.
@@ -9,9 +10,12 @@ import { useCallback, useLayoutEffect, useRef, useEffect } from "react";
  */
 export const useKeyboardShortcut = (
   // Array of keys that should trigger the callback when used alongside the shift key
-  shortcutKeys: string[],
+  shortcutKeyLookup: ShortcutKeyLookup[],
   // Callback that handles what happens when the keys are pressed
-  callback: (event: KeyboardEvent) => void
+  callback: (
+    event: KeyboardEvent,
+    shortcutKeyLookup?: ShortcutKeyLookup[]
+  ) => void
 ) => {
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {
@@ -20,6 +24,7 @@ export const useKeyboardShortcut = (
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
       const targetsToDisable = ["INPUT", "TEXTAREA", "SELECT"];
+      const shortcutKeys = shortcutKeyLookup.map((shortcut) => shortcut.key);
       // Type guard to access tagName property, see https://iifx.dev/en/articles/156175355
       if (event.target instanceof Element) {
         // Don't trigger callback if focused element is an input or textarea
@@ -34,11 +39,11 @@ export const useKeyboardShortcut = (
               event.key.toUpperCase() === key.toUpperCase()
           )
         ) {
-          callbackRef.current(event);
+          callbackRef.current(event, shortcutKeyLookup);
         }
       }
     },
-    [shortcutKeys]
+    [shortcutKeyLookup]
   );
   useEffect(() => {
     if (document) {
@@ -46,4 +51,22 @@ export const useKeyboardShortcut = (
       return () => document.removeEventListener("keydown", handleKeyPress);
     }
   }, [handleKeyPress]);
+};
+
+// Handles scrolling down to element on key press
+export const scrollToElementOnKeyPress = (
+  event: KeyboardEvent,
+  shortcutKeyLookup?: ShortcutKeyLookup[]
+) => {
+  const eventKey = event.key.toUpperCase();
+  const elementId =
+    shortcutKeyLookup &&
+    shortcutKeyLookup.find((shortcut) => eventKey === shortcut.key)?.elementId;
+  const element = document.getElementById(String(elementId));
+  element?.scrollIntoView({ behavior: "instant" });
+};
+
+// Handles scrolling to top of page
+export const scrollToTop = () => {
+  window.scrollTo({ top: 0, left: 0, behavior: "instant" });
 };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21381

I also played around with adding a scroll to top shortcut using Shift + T for all pages. I did not update the Address cards as mentioned in the issue, but do yall think i should?

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Locally

**Steps to test:**
1. Test all the shortcuts using Shift + [letter]. A for address, U for units, P for people, C for charges, N for notes, F for FRB recommendations.
---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
