### PR TITLE
Fixes FRB form state bugginess

### DIFF
--- a/editor/components/CrashRecommendationCard.tsx
+++ b/editor/components/CrashRecommendationCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
 import Form from "react-bootstrap/Form";
@@ -106,15 +106,8 @@ export default function CrashRecommendationCard({
       typename: "partners",
     });
 
-  const {
-    register,
-    reset,
-    handleSubmit,
-    formState: { isDirty },
-    setValue,
-    watch,
-  } = useForm<RecommendationFormInputs>({
-    defaultValues: recommendation
+  const defaultValues = useMemo(() => {
+    return recommendation
       ? {
           rec_text: recommendation.rec_text,
           rec_update: recommendation.rec_update,
@@ -130,7 +123,25 @@ export default function CrashRecommendationCard({
           crash_pk,
           created_by: user?.email,
           recommendations_partners: [],
-        },
+        };
+  }, [recommendation]);
+
+  /**
+   * Reset the form values after the recommendation is saved
+   */
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues]);
+
+  const {
+    register,
+    reset,
+    handleSubmit,
+    formState: { isDirty },
+    setValue,
+    watch,
+  } = useForm<RecommendationFormInputs>({
+    defaultValues,
   });
 
   const { mutate } = useMutation(


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/21690

As you can see in Rose's [screencap](https://github.com/cityofaustin/vision-zero/pull/1738#pullrequestreview-2703212292), the FRB form would get confused if you edited a recommendation multiple times. 

## Testing

**URL to test:** Local or [netlify](https://deploy-preview-1739--atd-vze-staging.netlify.app/)

Fill in an the FRB recommendation text for a crash that doesn't have one. Select **Active Transportation Division** as the only patner and save.

Edit the recommendation by deselecting **Active Transportation Division** and save the form.

☝️ repeat these steps on staging to see the bug, in which the save button is disabled.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
