### PR TITLE
Update crash details page <title>

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -32,6 +32,7 @@ import {
   scrollToElementOnKeyPress,
   useKeyboardShortcut,
 } from "@/utils/shortcuts";
+import { formatAddresses } from "@/utils/formatters";
 
 const typename = "crashes";
 
@@ -72,9 +73,7 @@ export default function CrashDetailsPage({
   // When data is loaded or updated this sets the title of the page inside the HTML head element
   useEffect(() => {
     if (!!data) {
-      document.title = `${data[0].cris_crash_id} - ${data[0].address_primary ? data[0].address_primary : ""} ${
-        data[0].address_secondary ? "& " + data[0].address_secondary : ""
-      }`;
+      document.title = `${data[0].cris_crash_id} - ${formatAddresses(data[0])}`;
     }
   }, [data]);
 

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -83,6 +83,9 @@ export default function CrashDetailsPage({
 
   return (
     <>
+      <title>{`${crash.cris_crash_id} - ${crash.address_primary ? crash.address_primary : ""} ${
+        crash.address_secondary ? "& " + crash.address_secondary : ""
+      }`}</title>
       <CrashHeader crash={crash} />
       {
         // show alert if crash on private drive or outside of Austin full purpose

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { notFound } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 
@@ -69,6 +69,15 @@ export default function CrashDetailsPage({
     await refetch();
   }, [refetch]);
 
+  // When data is loaded or updated this sets the title of the page inside the HTML head element
+  useEffect(() => {
+    if (!!data) {
+      document.title = `${data[0].cris_crash_id} - ${data[0].address_primary ? data[0].address_primary : ""} ${
+        data[0].address_secondary ? "& " + data[0].address_secondary : ""
+      }`;
+    }
+  }, [data]);
+
   if (!data) {
     // todo: loading spinner (would be nice to use a spinner inside cards)
     return;
@@ -83,9 +92,6 @@ export default function CrashDetailsPage({
 
   return (
     <>
-      <title>{`${crash.cris_crash_id} - ${crash.address_primary ? crash.address_primary : ""} ${
-        crash.address_secondary ? "& " + crash.address_secondary : ""
-      }`}</title>
       <CrashHeader crash={crash} />
       {
         // show alert if crash on private drive or outside of Austin full purpose

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -1,5 +1,6 @@
 import { Crash } from "@/types/crashes";
-import CrashInjuryIndicators from "./CrashInjuryIndicators";
+import CrashInjuryIndicators from "@/components/CrashInjuryIndicators";
+import { formatAddresses } from "@/utils/formatters";
 
 interface CrashHeaderProps {
   crash: Crash;
@@ -12,9 +13,7 @@ export default function CrashHeader({ crash }: CrashHeaderProps) {
   return (
     <div className="d-flex justify-content-between mb-3">
       <span className="fs-3 fw-bold text-uppercase">
-        {`${crash.address_primary ? crash.address_primary : ""} ${
-          crash.address_secondary ? "& " + crash.address_secondary : ""
-        }`}
+        {formatAddresses(crash)}
       </span>
       {crash.crash_injury_metrics_view && (
         <CrashInjuryIndicators injuries={crash.crash_injury_metrics_view} />

--- a/editor/components/CrashRecommendationCard.tsx
+++ b/editor/components/CrashRecommendationCard.tsx
@@ -124,14 +124,7 @@ export default function CrashRecommendationCard({
           created_by: user?.email,
           recommendations_partners: [],
         };
-  }, [recommendation]);
-
-  /**
-   * Reset the form values after the recommendation is saved
-   */
-  useEffect(() => {
-    reset(defaultValues);
-  }, [defaultValues]);
+  }, [recommendation, crash_pk, user]);
 
   const {
     register,
@@ -143,6 +136,13 @@ export default function CrashRecommendationCard({
   } = useForm<RecommendationFormInputs>({
     defaultValues,
   });
+
+  /**
+   * Reset the form values after the recommendation is saved
+   */
+  useEffect(() => {
+    reset(defaultValues);
+  }, [defaultValues, reset]);
 
   const { mutate } = useMutation(
     recommendation

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vision-zero-editor",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "ATD Vision Zero Editor",
   "author": "TPW Data & Technology Services",
   "license": "MIT",

--- a/editor/utils/formatters.ts
+++ b/editor/utils/formatters.ts
@@ -1,4 +1,5 @@
 import { format, parseISO } from "date-fns";
+import { Crash } from "@/types/crashes";
 
 /**
  * Format a number as a string with a dollar sign
@@ -35,4 +36,13 @@ export const formatDate = (value: unknown): string => {
  */
 export const formatFileTimestamp = (date: Date): string => {
   return format(date, "yyyy-MM-dd h.mm.ss a");
+};
+
+/**
+ * Format primary and secondary addresses as: E MARTIN LUTHER KING JR BLVD & CHICON ST
+ */
+export const formatAddresses = (crash: Crash): string => {
+  return `${crash.address_primary ? crash.address_primary : ""} ${
+    crash.address_secondary ? "& " + crash.address_secondary : ""
+  }`;
 };

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewer",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "homepage": "/viewer",
   "description": "Vision Zero Viewer",
   "author": "Austin Transportation & Public Works - Data & Technology Services",


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21537

At first i tried implementing this by creating a `layout.tsx` page in the `app/crashes/[record_locator]` folder and exporting metadata title from there like [this comment](https://stackoverflow.com/a/76935731) explains 

But since i need to use data from the client component crash details page for the title it made most sense to just use the `<title>` component in the details page for this. 

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1742--atd-vze-staging.netlify.app/editor/crashes)

**Steps to test:**
1. Go to a crash details page, see that the title in your tab is a combo of the {cris crash id} - {primary address & secondary address}
2. Edit the address somehow on the page, the title in your tab should update as well

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
