### PR TITLE
Persist navigation search field in local storage and make default search field Case ID

### DIFF
--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -9,12 +9,18 @@ import { CRASH_NAV_SEARCH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { useQuery } from "@/utils/graphql";
 
+const navSearchLocalStorageKey = "navBarSearchField";
+
 /**
  * Allows users to search for and route to a crash by
  * typing in its crash id or case id
  */
 export default function NavBarSearch() {
-  const [searchField, setSearchField] = useState("record_locator");
+  const [searchField, setSearchField] = useState<"case_id" | "record_locator">(
+    localStorage.getItem(navSearchLocalStorageKey) === "record_locator"
+      ? "record_locator"
+      : "case_id"
+  );
   const [searchValue, setSearchValue] = useState("");
   const [searchClicked, setSearchClicked] = useState(false);
 
@@ -43,6 +49,10 @@ export default function NavBarSearch() {
       }
     }
   }, [searchClicked, data, router]);
+
+  useEffect(() => {
+    localStorage.setItem(navSearchLocalStorageKey, searchField);
+  }, [searchField]);
 
   const onSearch = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21688

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1743--atd-vze-staging.netlify.app/editor/crashes)

**Steps to test:**
1. Open up netlify, the default search field should be Case ID.
2. Test switching back and forth from case id to crash id, refreshing, your chosen field should persist now

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
