### PR TITLE
Update lookup table helper script to ignore coordination_partners

### DIFF
--- a/toolbox/get_lookup_table_changes/get_lookup_table_changes.py
+++ b/toolbox/get_lookup_table_changes/get_lookup_table_changes.py
@@ -17,7 +17,7 @@ CRIS_LOOKUP_FNAME = "lookups.xml"
 
 # veh_direction_of_force is referenced by CRIS but no longer provided in the CRIS extract
 # the other tables here are custom
-LOOKUP_TABLES_TO_IGNORE = ["veh_direction_of_force", "mode_category", "movt"]
+LOOKUP_TABLES_TO_IGNORE = ["veh_direction_of_force", "mode_category", "movt", "coordination_partners"]
 
 
 def get_vz_lookup_table_names():


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/21718

## Testing

**Steps to test:**
Could go above and beyond and run the lookup table helper script and make sure its not trying to delete the coord partners lookup table in the migrations it generates, i tested this and its worked fine. Or you can just make sure i didnt make a typo and yolo approve :shrug: 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
