### PR TITLE
Create EMS list view

### DIFF
--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -5,3 +5,73 @@ object_relationships:
   - name: crash
     using:
       foreign_key_constraint_on: crash_pk
+  - name: injry_sev
+    using:
+      foreign_key_constraint_on: patient_injry_sev
+select_permissions:
+  - role: editor
+    permission:
+      columns:
+        - apd_incident_numbers
+        - crash_match_status
+        - crash_pk
+        - id
+        - incident_location_address
+        - incident_problem
+        - incident_received_datetime
+        - matched_crash_pks
+        - mvc_form_position_in_vehicle
+        - patient_injry_sev
+        - pcr_patient_age
+        - pcr_patient_gender
+        - pcr_patient_race
+        - person_id
+        - travel_mode
+        - updated_at
+      filter: {}
+      allow_aggregations: true
+    comment: ""
+  - role: readonly
+    permission:
+      columns:
+        - apd_incident_numbers
+        - crash_match_status
+        - crash_pk
+        - id
+        - incident_location_address
+        - incident_problem
+        - incident_received_datetime
+        - matched_crash_pks
+        - mvc_form_position_in_vehicle
+        - patient_injry_sev
+        - pcr_patient_age
+        - pcr_patient_gender
+        - pcr_patient_race
+        - person_id
+        - travel_mode
+        - updated_at
+      filter: {}
+      allow_aggregations: true
+    comment: ""
+  - role: vz-admin
+    permission:
+      columns:
+        - apd_incident_numbers
+        - crash_match_status
+        - crash_pk
+        - id
+        - incident_location_address
+        - incident_problem
+        - incident_received_datetime
+        - matched_crash_pks
+        - mvc_form_position_in_vehicle
+        - patient_injry_sev
+        - pcr_patient_age
+        - pcr_patient_gender
+        - pcr_patient_race
+        - person_id
+        - travel_mode
+        - updated_at
+      filter: {}
+      allow_aggregations: true
+    comment: ""

--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -17,6 +17,7 @@ select_permissions:
         - crash_pk
         - id
         - incident_location_address
+        - incident_number
         - incident_problem
         - incident_received_datetime
         - matched_crash_pks
@@ -27,6 +28,7 @@ select_permissions:
         - pcr_patient_race
         - person_id
         - travel_mode
+        - unparsed_apd_incident_numbers
         - updated_at
       filter: {}
       allow_aggregations: true
@@ -39,6 +41,7 @@ select_permissions:
         - crash_pk
         - id
         - incident_location_address
+        - incident_number
         - incident_problem
         - incident_received_datetime
         - matched_crash_pks
@@ -49,6 +52,7 @@ select_permissions:
         - pcr_patient_race
         - person_id
         - travel_mode
+        - unparsed_apd_incident_numbers
         - updated_at
       filter: {}
       allow_aggregations: true
@@ -61,6 +65,7 @@ select_permissions:
         - crash_pk
         - id
         - incident_location_address
+        - incident_number
         - incident_problem
         - incident_received_datetime
         - matched_crash_pks
@@ -71,6 +76,7 @@ select_permissions:
         - pcr_patient_race
         - person_id
         - travel_mode
+        - unparsed_apd_incident_numbers
         - updated_at
       filter: {}
       allow_aggregations: true

--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -7,7 +7,7 @@ object_relationships:
       foreign_key_constraint_on: crash_pk
   - name: injry_sev
     using:
-      foreign_key_constraint_on: patient_injry_sev
+      foreign_key_constraint_on: patient_injry_sev_id
 select_permissions:
   - role: editor
     permission:
@@ -21,7 +21,7 @@ select_permissions:
         - incident_received_datetime
         - matched_crash_pks
         - mvc_form_position_in_vehicle
-        - patient_injry_sev
+        - patient_injry_sev_id
         - pcr_patient_age
         - pcr_patient_gender
         - pcr_patient_race
@@ -43,7 +43,7 @@ select_permissions:
         - incident_received_datetime
         - matched_crash_pks
         - mvc_form_position_in_vehicle
-        - patient_injry_sev
+        - patient_injry_sev_id
         - pcr_patient_age
         - pcr_patient_gender
         - pcr_patient_race
@@ -65,7 +65,7 @@ select_permissions:
         - incident_received_datetime
         - matched_crash_pks
         - mvc_form_position_in_vehicle
-        - patient_injry_sev
+        - patient_injry_sev_id
         - pcr_patient_age
         - pcr_patient_gender
         - pcr_patient_race

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -20,6 +20,7 @@ import { chargeRelatedRecordCols } from "@/configs/chargeRelatedRecordTable";
 import { crashDataCards } from "@/configs/crashDataCard";
 import { crashNotesColumns } from "@/configs/notesColumns";
 import { peopleRelatedRecordCols } from "@/configs/peopleRelatedRecordTable";
+import { emsRelatedRecordCols } from "@/configs/emsRelatedRecordTable";
 import { unitRelatedRecordCols } from "@/configs/unitRelatedRecordTable";
 import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
 import { INSERT_CRASH_NOTE, UPDATE_CRASH_NOTE } from "@/queries/crashNotes";
@@ -187,6 +188,18 @@ export default function CrashDetailsPage({
             isValidating={isValidating}
             title="People"
             columns={peopleRelatedRecordCols}
+            mutation={UPDATE_PERSON}
+            onSaveCallback={onSaveCallback}
+          />
+        </Col>
+      </Row>
+      <Row id="ems">
+        <Col sm={12} className="mb-3">
+          <RelatedRecordTable
+            records={crash.people_list_view || []}
+            isValidating={isValidating}
+            title="EMS Patient care"
+            columns={emsRelatedRecordCols}
             mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
           />

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -196,11 +196,11 @@ export default function CrashDetailsPage({
       <Row id="ems">
         <Col sm={12} className="mb-3">
           <RelatedRecordTable
-            records={crash.people_list_view || []}
+            records={crash.ems__incidents || []}
             isValidating={isValidating}
             title="EMS Patient care"
             columns={emsRelatedRecordCols}
-            mutation={UPDATE_PERSON}
+            mutation=""
             onSaveCallback={onSaveCallback}
           />
         </Col>

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+import Card from "react-bootstrap/Card";
+import { emsListViewColumns } from "@/configs/emsColumns";
+import TableWrapper from "@/components/TableWrapper";
+import { emsListViewQueryConfig } from "@/configs/emsListViewTable";
+const localStorageKey = "emsListQueryConfig";
+
+export default function EMS() {
+  return (
+    <>
+      <Card className="mt-3">
+        <Card.Header className="fs-3 fw-bold">EMS Patient care</Card.Header>
+        <Card.Body>
+          <TableWrapper
+            columns={emsListViewColumns}
+            initialQueryConfig={emsListViewQueryConfig}
+            localStorageKey={localStorageKey}
+          />
+        </Card.Body>
+      </Card>
+    </>
+  );
+}

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -7,7 +7,6 @@ const localStorageKey = "emsListQueryConfig";
 
 export default function EMS() {
   return (
-    <>
       <Card className="mt-3">
         <Card.Header className="fs-3 fw-bold">EMS Patient care</Card.Header>
         <Card.Body>
@@ -18,6 +17,5 @@ export default function EMS() {
           />
         </Card.Body>
       </Card>
-    </>
   );
 }

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -27,6 +27,7 @@ export const ALL_EMS_COLUMNS = {
   apd_incident_numbers: {
     path: "apd_incident_numbers",
     label: "APD Case IDs",
+    sortable: true,
     valueFormatter: (value) => (Array.isArray(value) ? value.join(", ") : ""),
   },
   crash_match_status: {

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -106,7 +106,7 @@ export const ALL_EMS_COLUMNS = {
       labelColumnName: "label",
     },
     valueRenderer: (record) => {
-      const value = record.injry_sev.label;
+      const value = record?.injry_sev?.label || "";
       const className = `${getInjuryColorClass(value)} px-2 py-1 rounded`;
       return <span className={className}>{value}</span>;
     },

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -1,0 +1,107 @@
+import { getInjuryColorClass } from "@/utils/people";
+import { ColDataCardDef } from "@/types/types";
+import { EMSPatientCareRecord } from "@/types/ems";
+import { formatDate } from "@/utils/formatters";
+
+const formatCrashMatchStatus = (value: unknown) => {
+  if (!value || typeof value !== "string") {
+    return "";
+  }
+  switch (value) {
+    case "unmatched":
+      return "Unmatched";
+    case "multiple_matches_by_automation":
+      return "Multiple";
+    case "matched_by_automation":
+      return "Matched automatically";
+    case "matched_by_manual_qa":
+      return "Matched by review/QA";
+    default:
+      return "";
+  }
+};
+
+export const ALL_EMS_COLUMNS = {
+  apd_incident_numbers: {
+    path: "apd_incident_numbers",
+    label: "APD Case IDs",
+    valueFormatter: (value) => (Array.isArray(value) ? value.join(", ") : ""),
+  },
+  crash_match_status: {
+    path: "crash_match_status",
+    label: "Crash match status",
+    valueFormatter: formatCrashMatchStatus,
+    sortable: true,
+  },
+  crash_pk: {
+    path: "crash_pk",
+    label: "Crash ID",
+  },
+  id: {
+    path: "id",
+    label: "ID",
+    sortable: true,
+  },
+  incident_location_address: {
+    path: "incident_location_address",
+    label: "Incident address",
+    sortable: true,
+  },
+  incident_number: {
+    path: "incident_number",
+    label: "Incident #",
+    sortable: true,
+  },
+  incident_problem: {
+    path: "incident_problem",
+    label: "Incident problem",
+    sortable: true,
+  },
+  incident_received_datetime: {
+    path: "incident_received_datetime",
+    label: "Date",
+    style: { whiteSpace: "nowrap" },
+    valueFormatter: formatDate,
+    sortable: true,
+  },
+  mvc_form_position_in_vehicle: {
+    path: "mvc_form_position_in_vehicle",
+    label: "Position in vehicle",
+    sortable: true,
+  },
+  pcr_patient_age: { path: "pcr_patient_age", label: "Age" },
+  pcr_patient_gender: { path: "pcr_patient_gender", label: "Sex" },
+  pcr_patient_race: { path: "pcr_patient_race", label: "Race" },
+  patient_injry_sev_id: {
+    path: "injry_sev.label",
+    label: "Injury severity",
+    relationship: {
+      tableSchema: "lookups",
+      tableName: "injry_sev",
+      foreignKey: "patient_injry_sev_id",
+      idColumnName: "id",
+      labelColumnName: "label",
+    },
+    valueRenderer: (record) => {
+      const value = record.injry_sev.label;
+      const className = `${getInjuryColorClass(value)} px-2 py-1 rounded`;
+      return <span className={className}>{value}</span>;
+    },
+    style: { whiteSpace: "nowrap" },
+    sortable: true,
+  },
+  travel_mode: { path: "travel_mode", label: "Travel mode", sortable: true },
+} satisfies Record<string, ColDataCardDef<EMSPatientCareRecord>>;
+
+export const emsListViewColumns: ColDataCardDef<EMSPatientCareRecord>[] = [
+  ALL_EMS_COLUMNS.id,
+  ALL_EMS_COLUMNS.incident_number,
+  ALL_EMS_COLUMNS.incident_received_datetime,
+  ALL_EMS_COLUMNS.incident_location_address,
+  ALL_EMS_COLUMNS.travel_mode,
+  ALL_EMS_COLUMNS.incident_problem,
+  ALL_EMS_COLUMNS.patient_injry_sev_id,
+  ALL_EMS_COLUMNS.mvc_form_position_in_vehicle,
+  ALL_EMS_COLUMNS.apd_incident_numbers,
+  ALL_EMS_COLUMNS.crash_match_status,
+];

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -2,6 +2,8 @@ import { getInjuryColorClass } from "@/utils/people";
 import { ColDataCardDef } from "@/types/types";
 import { EMSPatientCareRecord } from "@/types/ems";
 import { formatDate } from "@/utils/formatters";
+import { Crash } from "@/types/crashes";
+import Link from "next/link";
 
 const formatCrashMatchStatus = (value: unknown) => {
   if (!value || typeof value !== "string") {
@@ -36,6 +38,27 @@ export const ALL_EMS_COLUMNS = {
   crash_pk: {
     path: "crash_pk",
     label: "Crash ID",
+  },
+  cris_crash_id: {
+    path: "crash.cris_crash_id",
+    label: "Crash ID",
+    relationship: {
+      tableSchema: "public",
+      tableName: "crashes",
+      foreignKey: "crash_pk",
+      idColumnName: "cris_crash_id",
+      labelColumnName: "Crash ID",
+    },
+    valueRenderer: (record: EMSPatientCareRecord) => {
+      if (!record.crash?.cris_crash_id) {
+        return "";
+      }
+      return (
+        <Link href={`/crashes/${record.crash.cris_crash_id}`} prefetch={false}>
+          {record.crash.cris_crash_id}
+        </Link>
+      );
+    },
   },
   id: {
     path: "id",
@@ -72,7 +95,7 @@ export const ALL_EMS_COLUMNS = {
   pcr_patient_age: { path: "pcr_patient_age", label: "Age" },
   pcr_patient_gender: { path: "pcr_patient_gender", label: "Sex" },
   pcr_patient_race: { path: "pcr_patient_race", label: "Race" },
-  patient_injry_sev_id: {
+  patient_injry_sev: {
     path: "injry_sev.label",
     label: "Injury severity",
     relationship: {
@@ -100,8 +123,9 @@ export const emsListViewColumns: ColDataCardDef<EMSPatientCareRecord>[] = [
   ALL_EMS_COLUMNS.incident_location_address,
   ALL_EMS_COLUMNS.travel_mode,
   ALL_EMS_COLUMNS.incident_problem,
-  ALL_EMS_COLUMNS.patient_injry_sev_id,
+  ALL_EMS_COLUMNS.patient_injry_sev,
   ALL_EMS_COLUMNS.mvc_form_position_in_vehicle,
   ALL_EMS_COLUMNS.apd_incident_numbers,
   ALL_EMS_COLUMNS.crash_match_status,
+  ALL_EMS_COLUMNS.cris_crash_id,
 ];

--- a/editor/configs/emsListViewTable.ts
+++ b/editor/configs/emsListViewTable.ts
@@ -1,0 +1,257 @@
+import { getYearsAgoDate, makeDateFilters } from "@/utils/dates";
+import { QueryConfig, FilterGroup } from "@/types/queryBuilder";
+import { DEFAULT_QUERY_LIMIT } from "@/utils/constants";
+
+const emsListViewFilterCards: FilterGroup[] = [
+  {
+    id: "travel_mode_filter_card",
+    label: "Travel mode",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "bicycle",
+        label: "Bicycle",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "travel_mode",
+            column: "travel_mode",
+            operator: "_eq",
+            value: "Bicycle",
+          },
+        ],
+      },
+      {
+        id: "e_scooter",
+        label: "E-Scooter",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "travel_mode",
+            column: "travel_mode",
+            operator: "_eq",
+            value: "E-Scooter",
+          },
+        ],
+      },
+
+      {
+        id: "motorcycle",
+        label: "Motorcycle",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "travel_mode",
+            column: "travel_mode",
+            operator: "_eq",
+            value: "Motorcycle",
+          },
+        ],
+      },
+      {
+        id: "motor_vehicle",
+        label: "Motor vehicle",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "travel_mode",
+            column: "travel_mode",
+            operator: "_eq",
+            value: "Motor Vehicle",
+          },
+        ],
+      },
+
+      {
+        id: "pedestrian",
+        label: "Pedestrian",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "travel_mode",
+            column: "travel_mode",
+            operator: "_eq",
+            value: "Pedestrian",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "injury_sev_filter_card",
+    label: "Injury severity",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "fatal",
+        label: "Fatal",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "fatal",
+            column: "patient_injry_sev_id",
+            operator: "_eq",
+            value: 4,
+          },
+        ],
+      },
+      {
+        id: "serious",
+        label: "Serious",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "serious",
+            column: "patient_injry_sev_id",
+            operator: "_eq",
+            value: 1,
+          },
+        ],
+      },
+      {
+        id: "minor",
+        label: "Minor",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "minor",
+            column: "patient_injry_sev_id",
+            operator: "_eq",
+            value: 2,
+          },
+        ],
+      },
+      {
+        id: "possible",
+        label: "Possible",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "possible",
+            column: "patient_injry_sev_id",
+            operator: "_eq",
+            value: 3,
+          },
+        ],
+      },
+      {
+        id: "non_injured",
+        label: "Not injured",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "non_injured",
+            column: "patient_injry_sev_id",
+            operator: "_eq",
+            value: 5,
+          },
+        ],
+      },
+    ],
+  },
+
+  {
+    id: "crash_match_status_filter_card",
+    label: "Crash match status",
+    groupOperator: "_or",
+    filterGroups: [
+      {
+        id: "unmatched",
+        label: "Unmatched",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unmatched",
+            column: "crash_match_status",
+            operator: "_eq",
+            value: "unmatched",
+          },
+        ],
+      },
+      {
+        id: "matched_by_automation",
+        label: "Matched automatically",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "matched_by_automation",
+            column: "crash_match_status",
+            operator: "_eq",
+            value: "matched_by_automation",
+          },
+        ],
+      },
+      {
+        id: "multiple_matches_by_automation",
+        label: "Multiple matches",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "multiple_matches_by_automation",
+            column: "crash_match_status",
+            operator: "_eq",
+            value: "multiple_matches_by_automation",
+          },
+        ],
+      },
+      {
+        id: "matched_by_manual_qa",
+        label: "Matched by review/QA",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "matched_by_manual_qa",
+            column: "crash_match_status",
+            operator: "_eq",
+            value: "matched_by_manual_qa",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const emsListViewQueryConfig: QueryConfig = {
+  exportable: true,
+  exportFilename: "ems_patient_care_records",
+  tableName: "ems__incidents",
+  limit: DEFAULT_QUERY_LIMIT,
+  offset: 0,
+  sortColName: "id",
+  sortAsc: false,
+  searchFilter: {
+    id: "search",
+    value: "",
+    column: "incident_location_address",
+    operator: "_ilike",
+    wildcard: true,
+  },
+  searchFields: [
+    { label: "Incident address", value: "incident_location_address" },
+    { label: "Incident number", value: "incident_number" },
+    { label: "APD Case IDs", value: "unparsed_apd_incident_numbers" },
+  ],
+  dateFilter: {
+    mode: "1y",
+    column: "incident_received_datetime",
+    filters: makeDateFilters("incident_received_datetime", {
+      start: getYearsAgoDate(1),
+      end: null,
+    }),
+  },
+  filterCards: emsListViewFilterCards,
+};

--- a/editor/configs/emsRelatedRecordTable.ts
+++ b/editor/configs/emsRelatedRecordTable.ts
@@ -1,0 +1,8 @@
+import { ALL_EMS_COLUMNS } from "./emsColumns";
+
+export const emsRelatedRecordCols = [
+  ALL_EMS_COLUMNS.unit_nbr,
+  ALL_EMS_COLUMNS.injry_sev,
+  ALL_EMS_COLUMNS.prsn_age,
+  ALL_EMS_COLUMNS.gndr,
+];

--- a/editor/configs/emsRelatedRecordTable.ts
+++ b/editor/configs/emsRelatedRecordTable.ts
@@ -1,8 +1,15 @@
 import { ALL_EMS_COLUMNS } from "./emsColumns";
 
 export const emsRelatedRecordCols = [
-  ALL_EMS_COLUMNS.unit_nbr,
-  ALL_EMS_COLUMNS.injry_sev,
-  ALL_EMS_COLUMNS.prsn_age,
-  ALL_EMS_COLUMNS.gndr,
+  ALL_EMS_COLUMNS.id,
+  ALL_EMS_COLUMNS.incident_location_address,
+  ALL_EMS_COLUMNS.travel_mode,
+  ALL_EMS_COLUMNS.incident_problem,
+  ALL_EMS_COLUMNS.patient_injry_sev,
+  ALL_EMS_COLUMNS.mvc_form_position_in_vehicle,
+  ALL_EMS_COLUMNS.pcr_patient_age,
+  ALL_EMS_COLUMNS.pcr_patient_gender,
+  ALL_EMS_COLUMNS.pcr_patient_race,
+  ALL_EMS_COLUMNS.apd_incident_numbers,
+  ALL_EMS_COLUMNS.crash_match_status,
 ];

--- a/editor/configs/emsRelatedRecordTable.ts
+++ b/editor/configs/emsRelatedRecordTable.ts
@@ -2,8 +2,8 @@ import { ALL_EMS_COLUMNS } from "./emsColumns";
 
 export const emsRelatedRecordCols = [
   ALL_EMS_COLUMNS.id,
-  ALL_EMS_COLUMNS.incident_location_address,
   ALL_EMS_COLUMNS.travel_mode,
+  ALL_EMS_COLUMNS.incident_location_address,
   ALL_EMS_COLUMNS.incident_problem,
   ALL_EMS_COLUMNS.patient_injry_sev,
   ALL_EMS_COLUMNS.mvc_form_position_in_vehicle,

--- a/editor/configs/peopleColumns.tsx
+++ b/editor/configs/peopleColumns.tsx
@@ -1,19 +1,7 @@
+import { getInjuryColorClass } from "@/utils/people";
 import { ColDataCardDef } from "@/types/types";
 import { Person } from "@/types/person";
 import PersonNameField from "@/components/PersonNameField";
-
-const getInjuryColorClass = (
-  injurySeverity: string
-): "bg-danger-subtle" | "bg-warning-subtle" | "" => {
-  switch (injurySeverity) {
-    case "SUSPECTED SERIOUS INJURY":
-      return "bg-warning-subtle";
-    case "FATAL INJURY":
-      return "bg-danger-subtle";
-    default:
-      return "";
-  }
-};
 
 export const ALL_PEOPLE_COLUMNS = {
   drvr_city_name: {

--- a/editor/configs/routes.ts
+++ b/editor/configs/routes.ts
@@ -7,6 +7,7 @@ import {
   FaHeart,
 } from "react-icons/fa6";
 import { IconType } from "react-icons";
+import { FaAmbulance } from "react-icons/fa";
 
 interface Route {
   path: string;
@@ -35,6 +36,11 @@ export const routes: Route[] = [
     path: "locations",
     label: "Locations",
     icon: FaLocationDot,
+  },
+  {
+    path: "ems",
+    label: "EMS",
+    icon: FaAmbulance,
   },
   {
     path: "upload-non-cr3",

--- a/editor/configs/routes.ts
+++ b/editor/configs/routes.ts
@@ -1,13 +1,13 @@
 import {
-  FaShieldHeart,
   FaGaugeHigh,
   FaLocationDot,
   FaUserGroup,
   FaCloudArrowUp,
   FaHeart,
+  FaCarBurst,
+  FaTruckMedical,
 } from "react-icons/fa6";
 import { IconType } from "react-icons";
-import { FaAmbulance } from "react-icons/fa";
 
 interface Route {
   path: string;
@@ -25,7 +25,7 @@ export const routes: Route[] = [
   {
     path: "crashes",
     label: "Crashes",
-    icon: FaShieldHeart,
+    icon: FaCarBurst,
   },
   {
     path: "fatalities",
@@ -40,7 +40,7 @@ export const routes: Route[] = [
   {
     path: "ems",
     label: "EMS",
-    icon: FaAmbulance,
+    icon: FaTruckMedical,
   },
   {
     path: "upload-non-cr3",

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -248,6 +248,27 @@ export const GET_CRASH = gql`
         text
         crash_pk
       }
+      ems__incidents(order_by: { id: asc }) {
+        id
+        apd_incident_numbers
+        crash_match_status
+        incident_location_address
+        incident_number
+        incident_problem
+        incident_received_datetime
+        injry_sev {
+          id
+          label
+        }
+        mvc_form_position_in_vehicle
+        patient_injry_sev_id
+        pcr_patient_age
+        pcr_patient_gender
+        pcr_patient_race
+        person_id
+        travel_mode
+        unparsed_apd_incident_numbers
+      }
     }
   }
 `;

--- a/editor/types/crashes.ts
+++ b/editor/types/crashes.ts
@@ -7,6 +7,7 @@ import { Person } from "@/types/person";
 import { Recommendation } from "@/types/recommendation";
 import { CrashesListRow } from "@/types/crashesList";
 import { CrashNote } from "./crashNote";
+import { EMSPatientCareRecord } from "@/types/ems";
 
 export type Crash = {
   active_school_zone_fl: boolean | null;
@@ -21,6 +22,7 @@ export type Crash = {
   crash_timestamp: string | null;
   cris_crash_id: number | null;
   collsn: LookupTableOption | null;
+  ems__incidents: EMSPatientCareRecord[] | null;
   fhe_collsn_id: number | null;
   id: number;
   in_austin_full_purpose: boolean;

--- a/editor/types/ems.ts
+++ b/editor/types/ems.ts
@@ -1,0 +1,21 @@
+import { LookupTableOption } from "./relationships";
+
+export type EMSPatientCareRecord = {
+  apd_incident_numbers: number[] | null;
+  crash_match_status: string;
+  crash_pk: number | null;
+  id: number;
+  incident_location_address: string | null;
+  incident_number: number | null;
+  incident_problem: string | null;
+  incident_received_datetime: string | null;
+  injry_sev: LookupTableOption;
+  mvc_form_position_in_vehicle: string | null;
+  patient_injry_sev_id: number | null;
+  pcr_patient_age: number | null;
+  pcr_patient_gender: string | null;
+  pcr_patient_race: string | null;
+  person_id: number | null;
+  travel_mode: string | null;
+  unparsed_apd_incident_numbers: string | null;
+};

--- a/editor/types/ems.ts
+++ b/editor/types/ems.ts
@@ -1,7 +1,9 @@
-import { LookupTableOption } from "./relationships";
+import { Crash } from "@/types/crashes";
+import { LookupTableOption } from "@/types/relationships";
 
 export type EMSPatientCareRecord = {
   apd_incident_numbers: number[] | null;
+  crash: Crash | null;
   crash_match_status: string;
   crash_pk: number | null;
   id: number;

--- a/editor/types/ems.ts
+++ b/editor/types/ems.ts
@@ -11,7 +11,7 @@ export type EMSPatientCareRecord = {
   incident_number: number | null;
   incident_problem: string | null;
   incident_received_datetime: string | null;
-  injry_sev: LookupTableOption;
+  injry_sev: LookupTableOption | null;
   mvc_form_position_in_vehicle: string | null;
   patient_injry_sev_id: number | null;
   pcr_patient_age: number | null;

--- a/editor/types/types.ts
+++ b/editor/types/types.ts
@@ -42,11 +42,19 @@ export interface ColDataCardDef<T extends Record<string, unknown>> {
    */
   relationship?: Relationship<T>;
   sortable?: boolean;
+  /**
+   * Function which formats a column value as a string. See formHelpers.getRecordValue()
+   * as an example of how the column value arg is supplied
+   */
   valueFormatter?: (
     value: unknown,
     record: T,
     column: ColDataCardDef<T>
   ) => string;
+  /**
+   * Function which returns a ReactNode given an input record and column definition.
+   * Enables custom value accessing and rendering.
+   */
   valueRenderer?: (record: T, column: ColDataCardDef<T>) => ReactNode;
   /**
    * Function that returns a custom component, used for display and/or editing

--- a/editor/types/types.ts
+++ b/editor/types/types.ts
@@ -38,7 +38,7 @@ export interface ColDataCardDef<T extends Record<string, unknown>> {
   inputType?: InputType;
   /**
    * Lookup table metadata, which is used to fetch lookup values
-   * and update the foreign key column with editing
+   * and update the foreign key column when editing
    */
   relationship?: Relationship<T>;
   sortable?: boolean;

--- a/editor/utils/people.ts
+++ b/editor/utils/people.ts
@@ -1,0 +1,15 @@
+/**
+ * Function returns a className based on inury severity
+ */
+export const getInjuryColorClass = (
+  injurySeverity: string
+): "bg-danger-subtle" | "bg-warning-subtle" | "" => {
+  switch (injurySeverity) {
+    case "SUSPECTED SERIOUS INJURY":
+      return "bg-warning-subtle";
+    case "FATAL INJURY":
+      return "bg-danger-subtle";
+    default:
+      return "";
+  }
+};


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/21852
* https://github.com/cityofaustin/atd-data-tech/issues/21924

<img width="1496" alt="Screenshot 2025-04-01 at 1 07 03 PM" src="https://github.com/user-attachments/assets/3db2e09b-22f5-4276-99fe-7265fe37825d" />

<img width="1435" alt="Screenshot 2025-04-01 at 1 07 28 PM" src="https://github.com/user-attachments/assets/c742ed6e-5c69-40a0-a181-fb6aae03a8e6" />

## Testing

**URL to test:** Local

1. Apply migrations and metadata
2. You can backfill some EMS-Crash links with this sql, which will take a minute or so to execute:

```sql
update crashes set latitude = latitude - .00000001 where crash_timestamp > '2024-01-01';
```
3. Start your editor and navigate to the new EMS tab. Try filtering using the search fields, date selectors, and filter cards. Test out the column sorting.

4. Filter the EMS table on records that have a match status of **Matched automatically**, then use the link in the **Crash ID** column (the rightmost column) to navigate to the crash details page for the crash.

5. Inspect the **EMS Patient Care** related record table. How does that look?

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
