### PR TITLE
Indicate that EMS features are in beta

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -3,7 +3,6 @@ import { notFound } from "next/navigation";
 import { useCallback, useEffect } from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
-
 import ChangeLog from "@/components/ChangeLog";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
 import CrashHeader from "@/components/CrashHeader";
@@ -34,6 +33,7 @@ import {
   useKeyboardShortcut,
 } from "@/utils/shortcuts";
 import { formatAddresses } from "@/utils/formatters";
+import EMSCardHeader from "@/components/EMSCardHeader";
 
 const typename = "crashes";
 
@@ -182,7 +182,8 @@ export default function CrashDetailsPage({
           <RelatedRecordTable
             records={crash.units || []}
             isValidating={isValidating}
-            title="Units"
+            noRowsMessage="No unit records found"
+            header="Units"
             columns={unitRelatedRecordCols}
             mutation={UPDATE_UNIT}
             onSaveCallback={onSaveCallback}
@@ -194,7 +195,8 @@ export default function CrashDetailsPage({
           <RelatedRecordTable
             records={crash.people_list_view || []}
             isValidating={isValidating}
-            title="People"
+            noRowsMessage="No people records found"
+            header="People"
             columns={peopleRelatedRecordCols}
             mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
@@ -206,7 +208,8 @@ export default function CrashDetailsPage({
           <RelatedRecordTable
             records={crash.ems__incidents || []}
             isValidating={isValidating}
-            title="EMS Patient care"
+            header={<EMSCardHeader />}
+            noRowsMessage="No EMS records found"
             columns={emsRelatedRecordCols}
             mutation=""
             onSaveCallback={onSaveCallback}
@@ -218,7 +221,8 @@ export default function CrashDetailsPage({
           <RelatedRecordTable
             records={crash.charges_cris || []}
             isValidating={isValidating}
-            title="Charges"
+            noRowsMessage="No charge records found"
+            header="Charges"
             columns={chargeRelatedRecordCols}
             mutation={""}
             onSaveCallback={onSaveCallback}

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -1,21 +1,40 @@
 "use client";
+import Badge from "react-bootstrap/Badge";
 import Card from "react-bootstrap/Card";
+import AlignedLabel from "@/components/AlignedLabel";
 import { emsListViewColumns } from "@/configs/emsColumns";
 import TableWrapper from "@/components/TableWrapper";
 import { emsListViewQueryConfig } from "@/configs/emsListViewTable";
+import { FaCircleInfo } from "react-icons/fa6";
+
 const localStorageKey = "emsListQueryConfig";
 
 export default function EMS() {
   return (
-      <Card className="mt-3">
-        <Card.Header className="fs-3 fw-bold">EMS Patient care</Card.Header>
-        <Card.Body>
-          <TableWrapper
-            columns={emsListViewColumns}
-            initialQueryConfig={emsListViewQueryConfig}
-            localStorageKey={localStorageKey}
-          />
-        </Card.Body>
-      </Card>
+    <Card className="mt-3">
+      <Card.Header>
+        <div className="d-flex mb-2">
+          <span className="fs-3 fw-bold me-2">EMS Patient care</span>
+          <div className="align-self-center">
+            <Badge bg="info">Beta</Badge>
+          </div>
+        </div>
+        <Card.Subtitle className="fw-light text-secondary">
+          <AlignedLabel>
+            <FaCircleInfo className="me-2" />
+            <span>
+              EMS is currently in beta. Data may be inaccurate or change significantly as we continue to refine the system.
+            </span>
+          </AlignedLabel>
+        </Card.Subtitle>
+      </Card.Header>
+      <Card.Body>
+        <TableWrapper
+          columns={emsListViewColumns}
+          initialQueryConfig={emsListViewQueryConfig}
+          localStorageKey={localStorageKey}
+        />
+      </Card.Body>
+    </Card>
   );
 }

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -23,7 +23,8 @@ export default function EMS() {
           <AlignedLabel>
             <FaCircleInfo className="me-2" />
             <span>
-              EMS is currently in beta. Data may be inaccurate or change significantly as we continue to refine the system.
+              EMS analysis is currently in beta. Data may be inaccurate or
+              change significantly as we continue to refine the system.
             </span>
           </AlignedLabel>
         </Card.Subtitle>

--- a/editor/components/EMSCardHeader.tsx
+++ b/editor/components/EMSCardHeader.tsx
@@ -1,0 +1,24 @@
+import Badge from "react-bootstrap/Badge";
+import { FaCircleInfo } from "react-icons/fa6";
+
+export default function EMSCardHeader() {
+  return (
+    <>
+      <div className="d-flex mb-2">
+        <span className="fs-5 fw-bold me-2">EMS Patient care</span>
+        <div className="align-self-center align-items-center">
+          <Badge bg="info">Beta</Badge>
+        </div>
+      </div>
+      <div className="fw-light text-secondary">
+        <span className="d-flex align-items-center">
+          <FaCircleInfo className="me-2" style={{minWidth: "1rem"}} />
+          <span>
+            EMS is currently in beta. Data may be inaccurate or change
+            significantly as we continue to refine the system.
+          </span>
+        </span>
+      </div>
+    </>
+  );
+}

--- a/editor/components/EMSCardHeader.tsx
+++ b/editor/components/EMSCardHeader.tsx
@@ -12,9 +12,9 @@ export default function EMSCardHeader() {
       </div>
       <div className="fw-light text-secondary">
         <span className="d-flex align-items-center">
-          <FaCircleInfo className="me-2" style={{minWidth: "1rem"}} />
+          <FaCircleInfo className="me-2" style={{ minWidth: "1rem" }} />
           <span>
-            EMS is currently in beta. Data may be inaccurate or change
+            EMS analysis is currently in beta. Data may be inaccurate or change
             significantly as we continue to refine the system.
           </span>
         </span>

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -7,6 +7,7 @@ import { ColDataCardDef } from "@/types/types";
 import AlignedLabel from "@/components/AlignedLabel";
 import DeleteNoteButton from "@/components/DeleteNoteButton";
 import PermissionsRequired from "@/components/PermissionsRequired";
+import { Card } from "react-bootstrap";
 
 const allowedNoteRoles = ["vz-admin", "editor"];
 
@@ -55,10 +56,15 @@ export default function NotesCard<T extends Record<string, unknown>>({
         columns={notesColumns}
         mutation={updateMutation}
         rowActionMutation={updateMutation}
+        noRowsMessage="No notes found"
         isValidating={false}
-        title="Notes"
+        header={
+          <div className="d-flex justify-content-between">
+            <Card.Title>Notes</Card.Title>
+            <AddNoteButton onClick={handleOpenModal} />
+          </div>
+        }
         onSaveCallback={onSaveCallback}
-        headerActionComponent={<AddNoteButton onClick={handleOpenModal} />}
         rowActionComponent={DeleteNoteButton}
       />
 

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -26,13 +26,14 @@ interface RelatedRecordTableProps<T extends Record<string, unknown>> {
    */
   isValidating: boolean;
   /**
-   * The title to be rendered in the table's card header
+   * Optional message to be rendered when the table has no rows
    */
-  title: string;
+  noRowsMessage?: string;
   /**
-   * Optional React component to be rendered in the card's header
+   * The card header string or component to be rendered in the table's card header. If a string is
+   * provided, it will be rendered as a <Card.Title>
    */
-  headerActionComponent?: React.ReactNode;
+  header: React.ReactNode;
   /**
    * Optional react component to be rendered in the rightmost
    * column of every row
@@ -68,18 +69,19 @@ export default function RelatedRecordTable<T extends Record<string, unknown>>({
   mutation,
   rowActionMutation,
   isValidating,
-  title,
-  headerActionComponent,
+  noRowsMessage,
+  header,
   onSaveCallback,
   rowActionComponent,
 }: RelatedRecordTableProps<T>) {
   return (
     <Card>
       <Card.Header>
-        <div className="d-flex justify-content-between">
-          <Card.Title>{title}</Card.Title>
-          {!!headerActionComponent && headerActionComponent}
-        </div>
+        {typeof header === "string" ? (
+          <Card.Title>{header}</Card.Title>
+        ) : (
+          header
+        )}
       </Card.Header>
       <Card.Body>
         <Table hover responsive>
@@ -101,7 +103,7 @@ export default function RelatedRecordTable<T extends Record<string, unknown>>({
                   colSpan={columns.length + (rowActionComponent ? 1 : 0)}
                   className="text-center text-secondary"
                 >
-                  No {title.toLowerCase()} found
+                  {noRowsMessage ? noRowsMessage : "No records found"}
                 </td>
               </tr>
             ) : (

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vision-zero-editor",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "ATD Vision Zero Editor",
   "author": "TPW Data & Technology Services",
   "license": "MIT",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewer",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "homepage": "/viewer",
   "description": "Vision Zero Viewer",
   "author": "Austin Transportation & Public Works - Data & Technology Services",


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/21982

## Testing

**URL to test:** Netlify

1. Visit the `/ems` page and look at the updated card header
2. Find an ems record with a matched crash, then visit the crash details page and look at the EMS related record table card header

Does this look ok?
---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
