### PR TITLE
Adds column visibility settings to tables

### DIFF
--- a/editor/components/CrashRecommendationCard.tsx
+++ b/editor/components/CrashRecommendationCard.tsx
@@ -204,7 +204,7 @@ export default function CrashRecommendationCard({
             )}
             {isEditing && isLoadingPartners && <Spinner size="sm" />}
             {isEditing && partners && (
-              <div style={{ height: "200px", overflowY: "scroll" }}>
+              <div style={{ height: "200px", overflowY: "auto" }}>
                 <CrashRecommendationPartners
                   setValue={setValue}
                   watch={watch}

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -3,12 +3,18 @@ import { produce } from "immer";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import ButtonToolbar from "react-bootstrap/ButtonToolbar";
-import AlignedLabel from "./AlignedLabel";
-import { QueryConfig } from "@/types/queryBuilder";
-import "react-datepicker/dist/react-datepicker.css";
 import { FaAngleLeft, FaAngleRight, FaDownload } from "react-icons/fa6";
+import AlignedLabel from "./AlignedLabel";
+import TableSettingsMenu from "@/components/TableSettingsMenu";
+import { QueryConfig } from "@/types/queryBuilder";
+import { ColumnVisibilitySetting } from "@/types/types";
+import "react-datepicker/dist/react-datepicker.css";
 
 interface PaginationControlProps {
+  columnVisbilitySettings: ColumnVisibilitySetting[];
+  setColumnVisbilitySettings: Dispatch<
+    SetStateAction<ColumnVisibilitySetting[]>
+  >;
   queryConfig: QueryConfig;
   setQueryConfig: Dispatch<SetStateAction<QueryConfig>>;
   recordCount: number;
@@ -19,10 +25,11 @@ interface PaginationControlProps {
 }
 
 /**
- * UI component that controls pagination by setting the
- * QueryConfig offset
+ * UI component that controls pagination, export, and column settings
  */
 export default function TablePaginationControls({
+  columnVisbilitySettings,
+  setColumnVisbilitySettings,
   queryConfig,
   setQueryConfig,
   recordCount,
@@ -86,7 +93,7 @@ export default function TablePaginationControls({
         </Button>
         <span
           aria-label="Current page number"
-          className="btn text-secondary mx-2 text-nowrap border-0"
+          className="my-auto text-center text-secondary mx-2 text-nowrap border-0"
         >
           {`Page ${currentPageNum}`}
         </span>
@@ -108,6 +115,10 @@ export default function TablePaginationControls({
           <FaAngleRight />
         </Button>
       </ButtonGroup>
+      <TableSettingsMenu
+        columnVisbilitySettings={columnVisbilitySettings}
+        setColumnVisbilitySettings={setColumnVisbilitySettings}
+      />
     </ButtonToolbar>
   );
 }

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -11,8 +11,8 @@ import { ColumnVisibilitySetting } from "@/types/types";
 import "react-datepicker/dist/react-datepicker.css";
 
 interface PaginationControlProps {
-  columnVisbilitySettings: ColumnVisibilitySetting[];
-  setColumnVisbilitySettings: Dispatch<
+  columnVisibilitySettings: ColumnVisibilitySetting[];
+  setColumnVisibilitySettings: Dispatch<
     SetStateAction<ColumnVisibilitySetting[]>
   >;
   queryConfig: QueryConfig;
@@ -28,8 +28,8 @@ interface PaginationControlProps {
  * UI component that controls pagination, export, and column settings
  */
 export default function TablePaginationControls({
-  columnVisbilitySettings,
-  setColumnVisbilitySettings,
+  columnVisibilitySettings,
+  setColumnVisibilitySettings,
   queryConfig,
   setQueryConfig,
   recordCount,
@@ -116,8 +116,8 @@ export default function TablePaginationControls({
         </Button>
       </ButtonGroup>
       <TableSettingsMenu
-        columnVisbilitySettings={columnVisbilitySettings}
-        setColumnVisbilitySettings={setColumnVisbilitySettings}
+        columnVisibilitySettings={columnVisibilitySettings}
+        setColumnVisibilitySettings={setColumnVisibilitySettings}
       />
     </ButtonToolbar>
   );

--- a/editor/components/TableSettingsMenu.tsx
+++ b/editor/components/TableSettingsMenu.tsx
@@ -1,0 +1,76 @@
+import { Dispatch, SetStateAction, useCallback } from "react";
+import Dropdown from "react-bootstrap/Dropdown";
+import Form from "react-bootstrap/Form";
+import { ColumnVisibilitySetting } from "@/types/types";
+import { FaGear } from "react-icons/fa6";
+
+interface TableSettingsMenuProps {
+  columnVisbilitySettings: ColumnVisibilitySetting[];
+  setColumnVisbilitySettings: Dispatch<
+    SetStateAction<ColumnVisibilitySetting[]>
+  >;
+}
+
+/**
+ * Table component that controls column visibility
+ */
+export default function TableSettingsMenu({
+  columnVisbilitySettings,
+  setColumnVisbilitySettings,
+}: TableSettingsMenuProps) {
+  const handleUpdateColVisibility = useCallback(
+    (columns: ColumnVisibilitySetting[], path: string) => {
+      const updatedColVisibilitySettings = columns.map((col) => {
+        if (col.path !== path) {
+          return col;
+        }
+        return { ...col, isVisible: !col.isVisible };
+      });
+      // do nothing if this will result in all columns being invisible
+      const willAllColumnsBeInivisible = updatedColVisibilitySettings.every(
+        (col) => col.isVisible === false
+      );
+      if (!willAllColumnsBeInivisible) {
+        setColumnVisbilitySettings(updatedColVisibilitySettings);
+      }
+    },
+    [setColumnVisbilitySettings]
+  );
+
+  return (
+    <Dropdown>
+      <Dropdown.Toggle
+        variant="outline-primary"
+        className="border-0 hide-toggle"
+        id="column-visibility-picker"
+      >
+        <FaGear />
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu style={{ maxHeight: "50vh", overflowY: "auto" }}>
+        {columnVisbilitySettings.map((col) => {
+          return (
+            <Dropdown.Item
+              className="d-flex align-items-center"
+              key={col.path}
+              onClick={(e) => {
+                handleUpdateColVisibility(columnVisbilitySettings, col.path);
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
+              <Form.Check
+                style={{ pointerEvents: "none" }}
+                type="switch"
+                label={col.label}
+                checked={col.isVisible}
+                className="my-auto"
+                readOnly
+              />
+            </Dropdown.Item>
+          );
+        })}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}

--- a/editor/components/TableSettingsMenu.tsx
+++ b/editor/components/TableSettingsMenu.tsx
@@ -27,10 +27,10 @@ export default function TableSettingsMenu({
         return { ...col, isVisible: !col.isVisible };
       });
       // do nothing if this will result in all columns being invisible
-      const willAllColumnsBeInivisible = updatedColVisibilitySettings.every(
+      const willAllColumnsBeInvisible = updatedColVisibilitySettings.every(
         (col) => col.isVisible === false
       );
-      if (!willAllColumnsBeInivisible) {
+      if (!willAllColumnsBeInvisible) {
         setColumnVisibilitySettings(updatedColVisibilitySettings);
       }
     },

--- a/editor/components/TableSettingsMenu.tsx
+++ b/editor/components/TableSettingsMenu.tsx
@@ -5,8 +5,8 @@ import { ColumnVisibilitySetting } from "@/types/types";
 import { FaGear } from "react-icons/fa6";
 
 interface TableSettingsMenuProps {
-  columnVisbilitySettings: ColumnVisibilitySetting[];
-  setColumnVisbilitySettings: Dispatch<
+  columnVisibilitySettings: ColumnVisibilitySetting[];
+  setColumnVisibilitySettings: Dispatch<
     SetStateAction<ColumnVisibilitySetting[]>
   >;
 }
@@ -15,8 +15,8 @@ interface TableSettingsMenuProps {
  * Table component that controls column visibility
  */
 export default function TableSettingsMenu({
-  columnVisbilitySettings,
-  setColumnVisbilitySettings,
+  columnVisibilitySettings,
+  setColumnVisibilitySettings,
 }: TableSettingsMenuProps) {
   const handleUpdateColVisibility = useCallback(
     (columns: ColumnVisibilitySetting[], path: string) => {
@@ -31,10 +31,10 @@ export default function TableSettingsMenu({
         (col) => col.isVisible === false
       );
       if (!willAllColumnsBeInivisible) {
-        setColumnVisbilitySettings(updatedColVisibilitySettings);
+        setColumnVisibilitySettings(updatedColVisibilitySettings);
       }
     },
-    [setColumnVisbilitySettings]
+    [setColumnVisibilitySettings]
   );
 
   return (
@@ -48,13 +48,13 @@ export default function TableSettingsMenu({
       </Dropdown.Toggle>
 
       <Dropdown.Menu style={{ maxHeight: "50vh", overflowY: "auto" }}>
-        {columnVisbilitySettings.map((col) => {
+        {columnVisibilitySettings.map((col) => {
           return (
             <Dropdown.Item
               className="d-flex align-items-center"
               key={col.path}
               onClick={(e) => {
-                handleUpdateColVisibility(columnVisbilitySettings, col.path);
+                handleUpdateColVisibility(columnVisibilitySettings, col.path);
                 e.preventDefault();
                 e.stopPropagation();
               }}

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -69,7 +69,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   /**
    * Initialize column visibility from provided columns
    */
-  const [columnVisbilitySettings, setColumnVisbilitySettings] = useState<
+  const [columnVisibilitySettings, setColumnVisibilitySettings] = useState<
     ColumnVisibilitySetting[]
   >(
     columns
@@ -94,7 +94,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   const visibleColumns = useMemo(
     () =>
       columns.filter((col) => {
-        const colFromVisibilitySettings = columnVisbilitySettings.find(
+        const colFromVisibilitySettings = columnVisibilitySettings.find(
           (visibleColumn) => visibleColumn.path === col.path
         );
         /**
@@ -105,7 +105,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
           ? colFromVisibilitySettings.isVisible
           : !col.exportOnly && !col.defaultHidden;
       }),
-    [columns, columnVisbilitySettings]
+    [columns, columnVisibilitySettings]
   );
 
   const query = useQueryBuilder(
@@ -222,7 +222,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
        * ensures that stale col visibility data from storage is brought into sync
        * with the current version of the table config
        */
-      const updatedColVisibilitySettings = columnVisbilitySettings.map(
+      const updatedColVisibilitySettings = columnVisibilitySettings.map(
         (col) => {
           const savedCol = columnVisibilityFromStorage.find(
             (savedCol) => savedCol.path === col.path
@@ -235,13 +235,13 @@ export default function TableWrapper<T extends Record<string, unknown>>({
           }
         }
       );
-      setColumnVisbilitySettings(updatedColVisibilitySettings);
+      setColumnVisibilitySettings(updatedColVisibilitySettings);
       setIsColVisibilityLocalStorageLoaded(true);
     }
   }, [
     localStorageKey,
     columns,
-    columnVisbilitySettings,
+    columnVisibilitySettings,
     isColVisibilityLocalStorageLoaded,
   ]);
 
@@ -262,13 +262,13 @@ export default function TableWrapper<T extends Record<string, unknown>>({
       const columnVisLocalStorageKey = localStorageKey + "_columnVisibility";
       localStorage.setItem(
         columnVisLocalStorageKey,
-        JSON.stringify(columnVisbilitySettings)
+        JSON.stringify(columnVisibilitySettings)
       );
     }
   }, [
     isColVisibilityLocalStorageLoaded,
     localStorageKey,
-    columnVisbilitySettings,
+    columnVisibilitySettings,
   ]);
 
   /**
@@ -373,8 +373,8 @@ export default function TableWrapper<T extends Record<string, unknown>>({
           </Col>
           <Col className="d-flex justify-content-end mt-2" xs="auto">
             <TablePaginationControls
-              columnVisbilitySettings={columnVisbilitySettings}
-              setColumnVisbilitySettings={setColumnVisbilitySettings}
+              columnVisibilitySettings={columnVisibilitySettings}
+              setColumnVisibilitySettings={setColumnVisibilitySettings}
               queryConfig={queryConfig}
               setQueryConfig={setQueryConfig}
               recordCount={rows.length}

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -193,8 +193,8 @@ export default function TableWrapper<T extends Record<string, unknown>>({
    * Load column visibility settings from localstorage
    */
   useEffect(() => {
-    if (!isColVisibilityLocalStorageLoaded) {
-      console.log("SKIP LOADING VIS");
+    if (isColVisibilityLocalStorageLoaded) {
+      return;
     }
     /**
      * Try to load column visibility

--- a/editor/configs/crashesListViewColumns.tsx
+++ b/editor/configs/crashesListViewColumns.tsx
@@ -26,6 +26,12 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
     valueFormatter: formatDate,
   },
   {
+    path: "crash_day_of_week",
+    label: "Day of week",
+    defaultHidden: true,
+    sortable: true,
+  },
+  {
     path: "crash_date_ct",
     label: "crash_date_ct",
     exportOnly: true,
@@ -38,6 +44,12 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
   {
     path: "address_primary",
     label: "Address",
+    sortable: true,
+  },
+  {
+    path: "council_district",
+    label: "Council district",
+    defaultHidden: true,
     sortable: true,
   },
   {
@@ -56,25 +68,21 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
     sortable: true,
   },
   {
+    path: "nonincap_injry_count",
+    label: "Minor injuries",
+    defaultHidden: true,
+    sortable: true,
+  },
+  {
+    path: "unkn_injry_count",
+    label: "unkn_injry_count",
+    exportOnly: true,
+  },
+  {
     path: "est_comp_cost_crash_based",
     label: "Est Comp Cost",
     sortable: true,
     valueFormatter: formatDollars,
-  },
-  {
-    path: "nonincap_injry_count",
-    label: "nonincap_injry_count",
-    exportOnly: true,
-  },
-  {
-    path: "crash_day_of_week",
-    label: "crash_day_of_week",
-    exportOnly: true,
-  },
-  {
-    path: "council_district",
-    label: "council_district",
-    exportOnly: true,
   },
   {
     path: "crash_injry_sev_desc",
@@ -194,11 +202,6 @@ export const crashesListViewColumns: ColDataCardDef<CrashesListRow>[] = [
   {
     path: "traffic_cntl_id",
     label: "traffic_cntl_id",
-    exportOnly: true,
-  },
-  {
-    path: "unkn_injry_count",
-    label: "unkn_injry_count",
     exportOnly: true,
   },
   {

--- a/editor/styles/global.scss
+++ b/editor/styles/global.scss
@@ -181,4 +181,9 @@ to make sure it renders on top is a common fix */
   background-color: $light !important;
 }
 
+/* Hide down arrow from dropdown toggle button */
+.dropdown-toggle.hide-toggle::after {
+  content: none !important;
+}
+
 @import "bootstrap/scss/bootstrap.scss";

--- a/editor/types/types.ts
+++ b/editor/types/types.ts
@@ -28,6 +28,12 @@ export interface ColDataCardDef<T extends Record<string, unknown>> {
    */
   editable?: boolean;
   /**
+   * If the field should be hidden from the UI by default - only affects
+   * when the column is used in a component which supports toggling
+   * column visibility
+   */
+  defaultHidden?: boolean;
+  /**
    * If the field should only be available in the exported table data -
    * only affects when column is used in a table config
    */
@@ -92,4 +98,13 @@ export interface FormValues {
   // form libraries like react-hook-form to ensure type safety and
   // consistency when handling form submissions.
   value: string;
+}
+
+/**
+ * Interface for column visibility picker state
+ */
+export interface ColumnVisibilitySetting {
+  path: string;
+  label: string;
+  isVisible: boolean;
 }


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/22007

<img width="1451" alt="Image" src="https://github.com/user-attachments/assets/6c98ede6-28bb-4e36-9755-011fa1d8f581" />

I was noodling on the VZE over the weekend and became annoyed by some column layouts. This PR adds a column visibility picker and I took a first pass at adding some new columns to the crashes list.

## Testing

**URL to test:** [Netlify](https://deploy-preview-1759--atd-vze-staging.netlify.app/)

1. Visit the crashes list and use the gear icon button to toggle some columns on and off.
2. Try switching all columns off, and verify that the last remaining visible column cannot be switched off
3. Refresh your page and verify that the visibility settings persist 
4. In your dev console, find the localstorage entry for `crashesListViewQueryConfig_columnVisibility` and replace the value with `[{ "path": "pizza", "isVisible": true, "label": "Pizza" }]`. Refresh your page and observe that the localstorage entry is refreshed with the table's default values.
5. Export the crashes list view and observe that all columns, including the `exportOnly` columns, are included
6. Test out the column visibility feature on the locations and fatalities lists as well.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
