### PR TITLE
EMS details page: add summary and patient cards to EMS details page

### DIFF
--- a/editor/components/AppBreadCrumb.tsx
+++ b/editor/components/AppBreadCrumb.tsx
@@ -5,6 +5,7 @@ import Col from "react-bootstrap/Col";
 import { routes } from "@/configs/routes";
 
 interface Crumb {
+  path: string;
   label: string;
   type: "page" | "id";
 }
@@ -21,21 +22,21 @@ const useCrumbs = (path: string): Crumb[] =>
       return crumbs;
     }
     // find the formatted route label
-    const crumb = parts[0].split("?")[0].toLowerCase();
-    const crumbLabel = routes.find(
-      (route) => route.label.toLowerCase() === crumb
-    );
+    const pathPart = parts[0].split("?")[0];
+    const route = routes.find((route) => route.path === pathPart.toLowerCase());
     crumbs.push({
       // if we don't remove the query string, nextjs can hit a server/client mismatch on login
       // todo: this can't be the right way to fix this
       // todo: test if still an issue with app router
-      label: crumbLabel ? crumbLabel.label : crumb,
+      label: route ? route.label : pathPart,
       type: "page",
+      path: pathPart,
     });
     if (parts.length > 1) {
       crumbs.push({
         label: decodeURI(parts[1].split("?")[0]),
         type: "id",
+        path: pathPart,
       });
     }
     // only two levels deep supported
@@ -66,7 +67,7 @@ export default function AppBreadCrumb() {
                   <span>
                     <Link
                       className="text-decoration-none"
-                      href={`/${crumb.label}`}
+                      href={`/${crumb.path}`}
                     >
                       {crumb.label}
                     </Link>

--- a/editor/components/AppBreadCrumb.tsx
+++ b/editor/components/AppBreadCrumb.tsx
@@ -22,19 +22,16 @@ const useCrumbs = (path: string): Crumb[] =>
       return crumbs;
     }
     // find the formatted route label
-    const pathPart = parts[0].split("?")[0];
+    const pathPart = parts[0];
     const route = routes.find((route) => route.path === pathPart.toLowerCase());
     crumbs.push({
-      // if we don't remove the query string, nextjs can hit a server/client mismatch on login
-      // todo: this can't be the right way to fix this
-      // todo: test if still an issue with app router
       label: route ? route.label : pathPart,
       type: "page",
       path: pathPart,
     });
     if (parts.length > 1) {
       crumbs.push({
-        label: decodeURI(parts[1].split("?")[0]),
+        label: decodeURI(parts[1]),
         type: "id",
         path: pathPart,
       });

--- a/editor/components/AppBreadCrumb.tsx
+++ b/editor/components/AppBreadCrumb.tsx
@@ -2,6 +2,7 @@ import { useMemo, Fragment } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import Col from "react-bootstrap/Col";
+import { routes } from "@/configs/routes";
 
 interface Crumb {
   label: string;
@@ -19,11 +20,16 @@ const useCrumbs = (path: string): Crumb[] =>
       // we are at root
       return crumbs;
     }
+    // find the formatted route label
+    const crumb = parts[0].split("?")[0].toLowerCase();
+    const crumbLabel = routes.find(
+      (route) => route.label.toLowerCase() === crumb
+    );
     crumbs.push({
       // if we don't remove the query string, nextjs can hit a server/client mismatch on login
       // todo: this can't be the right way to fix this
       // todo: test if still an issue with app router
-      label: parts[0].split("?")[0],
+      label: crumbLabel ? crumbLabel.label : crumb,
       type: "page",
     });
     if (parts.length > 1) {
@@ -48,6 +54,7 @@ export default function AppBreadCrumb() {
   if (!isDetailsPage) {
     return null;
   }
+
   return (
     <div className="px-3 py-2">
       <Col>
@@ -58,7 +65,7 @@ export default function AppBreadCrumb() {
                 <Fragment key={crumb.label}>
                   <span>
                     <Link
-                      className="text-decoration-none text-capitalize"
+                      className="text-decoration-none"
                       href={`/${crumb.label}`}
                     >
                       {crumb.label}

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -1,7 +1,7 @@
 import { getInjuryColorClass } from "@/utils/people";
 import { ColDataCardDef } from "@/types/types";
 import { EMSPatientCareRecord } from "@/types/ems";
-import { formatDate } from "@/utils/formatters";
+import { formatDate, formatDateTime } from "@/utils/formatters";
 import Link from "next/link";
 
 const formatCrashMatchStatus = (value: unknown) => {
@@ -64,6 +64,11 @@ export const ALL_EMS_COLUMNS = {
     path: "id",
     label: "ID",
     sortable: true,
+  },
+  id_hyperlinked: {
+    path: "id",
+    label: "ID",
+    sortable: true,
     valueRenderer: (record: EMSPatientCareRecord) => (
       <Link href={`/ems/${record.id}`} prefetch={false}>
         {record.id}
@@ -83,6 +88,13 @@ export const ALL_EMS_COLUMNS = {
   incident_problem: {
     path: "incident_problem",
     label: "Incident problem",
+    sortable: true,
+  },
+  incident_received_datetime_with_timestamp: {
+    path: "incident_received_datetime",
+    label: "Date",
+    style: { whiteSpace: "nowrap" },
+    valueFormatter: formatDateTime,
     sortable: true,
   },
   incident_received_datetime: {
@@ -122,7 +134,7 @@ export const ALL_EMS_COLUMNS = {
 } satisfies Record<string, ColDataCardDef<EMSPatientCareRecord>>;
 
 export const emsListViewColumns: ColDataCardDef<EMSPatientCareRecord>[] = [
-  ALL_EMS_COLUMNS.id,
+  ALL_EMS_COLUMNS.id_hyperlinked,
   ALL_EMS_COLUMNS.incident_number,
   ALL_EMS_COLUMNS.incident_received_datetime,
   ALL_EMS_COLUMNS.incident_location_address,

--- a/editor/configs/emsDataCards.ts
+++ b/editor/configs/emsDataCards.ts
@@ -1,0 +1,21 @@
+import { ALL_EMS_COLUMNS as columns } from "@/configs/emsColumns";
+
+export const emsDataCards = {
+  summary: [
+    columns.id,
+    columns.incident_number,
+    columns.incident_received_datetime_with_timestamp,
+    columns.incident_problem,
+    columns.crash_match_status,
+    columns.apd_incident_numbers,
+    columns.cris_crash_id,
+  ],
+  patient: [
+    columns.patient_injry_sev,
+    columns.travel_mode,
+    columns.mvc_form_position_in_vehicle,
+    columns.pcr_patient_age,
+    columns.pcr_patient_gender,
+    columns.pcr_patient_race,
+  ],
+};


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/22025
* https://github.com/cityofaustin/atd-data-tech/issues/22029

<img width="1079" alt="Screenshot 2025-04-09 at 2 21 47 PM" src="https://github.com/user-attachments/assets/1286485b-0967-4bb2-a010-e0060e7d31b0" />

## Testing

**URL to test:** Local, because we've branched from a branch

1. Apply migrations and metadata and start your app. 
2. Run this in your SQL client so that you have some matched EMS records to work with

```sql
update crashes set latitude = latitude - .00000001 where crash_timestamp > '2025-01-01';
```

3. Use the EMS list page to navigate to an EMS record with a matched crash. Check that the data cards look good, including the hyperlinked **Crash ID** field on the summary card
4. Inspect some more EMS records, including an unmated one.
5. Test out the bread crumb navigation from the EMS details page and the crash details page and the location details page

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
