### PR TITLE
Add keyboard shortcut to EMS related records table

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -42,6 +42,7 @@ const shortcutKeyLookup: ShortcutKeyLookup[] = [
   { key: "A", elementId: "address" },
   { key: "U", elementId: "units" },
   { key: "P", elementId: "people" },
+  { key: "E", elementId: "ems" },
   { key: "C", elementId: "charges" },
   { key: "N", elementId: "notes" },
   { key: "F", elementId: "fatality" },


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/21861

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-1765--atd-vze-staging.netlify.app/editor/crashes/

**Steps to test:**

go to any crash page. 
use the keyboard and "Shift + e"
the ems card is at the top of the window now

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
