### PR TITLE
EMS details: show people from crashes that occurred on the same date as the incident

### DIFF
--- a/database/metadata/databases/default/tables/public_people_list_view.yaml
+++ b/database/metadata/databases/default/tables/public_people_list_view.yaml
@@ -20,6 +20,15 @@ object_relationships:
         remote_table:
           name: drvr_ethncty
           schema: lookups
+  - name: ems_pcr
+    using:
+      manual_configuration:
+        column_mapping:
+          id: person_id
+        insertion_order: null
+        remote_table:
+          name: ems__incidents
+          schema: public
   - name: gndr
     using:
       manual_configuration:

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -80,30 +80,36 @@ export default function EMSDetailsPage({
   }, [ems_pcrs]);
 
   /**
-   * Hook which manages getting the 12 hour timestamp interval
+   * Function that gets the 12 hour timestamp interval
    * to be used for fetching people list for unmatched EMS records
    */
-  const unmatchedTimeInterval: Date[] = useMemo(() => {
-    // if any of the ems records have a crash match status of unmatched
-    if (ems_pcrs?.some((ems) => ems.crash_match_status === "unmatched")) {
-      if (ems_pcrs[0].incident_received_datetime) {
-        const incidentTimestamp = parseISO(
-          ems_pcrs[0].incident_received_datetime
-        );
-        const time12HoursBefore = subHours(incidentTimestamp, 12);
-        const time12HoursAfter = addHours(incidentTimestamp, 12);
-        return [time12HoursBefore, time12HoursAfter];
-      }
+  const getUnmatchedTimeInterval = () => {
+    if (ems_pcrs?.[0].incident_received_datetime) {
+      const incidentTimestamp = parseISO(
+        ems_pcrs[0].incident_received_datetime
+      );
+      const time12HoursBefore = subHours(incidentTimestamp, 12);
+      const time12HoursAfter = addHours(incidentTimestamp, 12);
+      return [time12HoursBefore, time12HoursAfter];
     }
-    return [];
-  }, [ems_pcrs]);
+    return null;
+  };
+
+  // Check if any of the ems incidents have an unmatched status
+  const areAnyUnmatchedEMSRecords = ems_pcrs?.some(
+    (ems) => ems.crash_match_status === "unmatched"
+  );
+
+  const unmatchedTimeInterval = areAnyUnmatchedEMSRecords
+    ? getUnmatchedTimeInterval()
+    : null;
 
   /**
    * Get all crash records that occurred within 12 hours of the incidents
    * if the incidents have a crash match status of unmatched
    */
   const { data: unmatchedCrashes } = useQuery<Crash>({
-    query: unmatchedTimeInterval[0] ? GET_UNMATCHED_EMS_CRASHES : null,
+    query: unmatchedTimeInterval ? GET_UNMATCHED_EMS_CRASHES : null,
     variables: {
       time12HoursBefore: unmatchedTimeInterval?.[0],
       time12HoursAfter: unmatchedTimeInterval?.[1],

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -89,6 +89,7 @@ export default function EMSDetailsPage({
    * to be used for fetching people list for unmatched EMS records
    */
   const unmatchedTimeInterval: Date[] = useMemo(() => {
+    // if any of the ems records have a crash match status of unmatched
     if (ems_pcrs?.some((ems) => ems.crash_match_status === "unmatched")) {
       if (incident?.incident_received_datetime) {
         const incidentTimestamp = parseISO(incident.incident_received_datetime);
@@ -117,7 +118,7 @@ export default function EMSDetailsPage({
     ? unmatchedCrashes?.map((crash) => crash.id)
     : [];
 
-  const totalCrashPks = [...relatedCrashPks, ...unmatchedCrashPks];
+  const allCrashPks = [...relatedCrashPks, ...unmatchedCrashPks];
 
   /**
    * Get all people records linked to crashes that were either automatically
@@ -125,9 +126,9 @@ export default function EMSDetailsPage({
    * if it has a crash status of unmatched
    */
   const { data: matchingPeople } = useQuery<PeopleListRow>({
-    query: totalCrashPks[0] ? GET_MATCHING_PEOPLE : null,
+    query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
     variables: {
-      crash_pks: totalCrashPks,
+      crash_pks: allCrashPks,
     },
     typename: "people_list_view",
   });

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -103,7 +103,7 @@ export default function EMSDetailsPage({
 
   /**
    * Get all crash records that occurred within 12 hours of the incidents
-   * if the incidents have a crash match status of unmatched
+   * if any of the ems pcrs have a crash match status of unmatched
    */
   const { data: unmatchedCrashes } = useQuery<Crash>({
     query: unmatchedTimeInterval[0] ? GET_UNMATCHED_EMS_CRASHES : null,
@@ -125,7 +125,7 @@ export default function EMSDetailsPage({
 
   /**
    * Get all people records linked to crashes that were either automatically
-   * matched with the ems incident or that occurred within 12 hours of the incident
+   * matched with the ems record or that occurred within 12 hours of the incident
    * if it has a crash status of unmatched
    */
   const { data: matchingPeople } = useQuery<PeopleListRow>({

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -58,11 +58,6 @@ export default function EMSDetailsPage({
   );
 
   /**
-   * Use the first EMS record as the "incident"
-   */
-  const incident = ems_pcrs?.[0];
-
-  /**
    * Hook which manages which related crash PKs we should
    * use to query people records
    */
@@ -175,6 +170,11 @@ export default function EMSDetailsPage({
   if (error) {
     console.error(error);
   }
+
+  /**
+   * Use the first EMS record as the "incident"
+   */
+  const incident = ems_pcrs?.[0];
 
   /**
    * Set the title of the page inside the HTML head element

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -88,13 +88,13 @@ export default function EMSDetailsPage({
    * Hook that gets the 12 hour timestamp interval
    * to be used for fetching people list for unmatched EMS records
    */
-  const unmatchedTimeInterval: Date[] = useMemo(() => {
+  const unmatchedTimeInterval: string[] = useMemo(() => {
     if (incident?.incident_received_datetime) {
       // Return time interval only if we have any unmatched ems pcrs
       if (ems_pcrs?.some((ems) => ems.crash_match_status === "unmatched")) {
         const incidentTimestamp = parseISO(incident.incident_received_datetime);
-        const time12HoursBefore = subHours(incidentTimestamp, 12);
-        const time12HoursAfter = addHours(incidentTimestamp, 12);
+        const time12HoursBefore = subHours(incidentTimestamp, 12).toISOString();
+        const time12HoursAfter = addHours(incidentTimestamp, 12).toISOString();
         return [time12HoursBefore, time12HoursAfter];
       }
     }

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -58,6 +58,11 @@ export default function EMSDetailsPage({
   );
 
   /**
+   * Use the first EMS record as the "incident"
+   */
+  const incident = ems_pcrs?.[0];
+
+  /**
    * Hook which manages which related crash PKs we should
    * use to query people records
    */
@@ -80,39 +85,31 @@ export default function EMSDetailsPage({
   }, [ems_pcrs]);
 
   /**
-   * Function that gets the 12 hour timestamp interval
+   * Hook that gets the 12 hour timestamp interval
    * to be used for fetching people list for unmatched EMS records
    */
-  const getUnmatchedTimeInterval = () => {
-    if (ems_pcrs?.[0].incident_received_datetime) {
-      const incidentTimestamp = parseISO(
-        ems_pcrs[0].incident_received_datetime
-      );
-      const time12HoursBefore = subHours(incidentTimestamp, 12);
-      const time12HoursAfter = addHours(incidentTimestamp, 12);
-      return [time12HoursBefore, time12HoursAfter];
+  const unmatchedTimeInterval: Date[] = useMemo(() => {
+    if (incident?.incident_received_datetime) {
+      // Return time interval only if we have any unmatched ems pcrs
+      if (ems_pcrs?.some((ems) => ems.crash_match_status === "unmatched")) {
+        const incidentTimestamp = parseISO(incident.incident_received_datetime);
+        const time12HoursBefore = subHours(incidentTimestamp, 12);
+        const time12HoursAfter = addHours(incidentTimestamp, 12);
+        return [time12HoursBefore, time12HoursAfter];
+      }
     }
-    return null;
-  };
-
-  // Check if any of the ems incidents have an unmatched status
-  const areAnyUnmatchedEMSRecords = ems_pcrs?.some(
-    (ems) => ems.crash_match_status === "unmatched"
-  );
-
-  const unmatchedTimeInterval = areAnyUnmatchedEMSRecords
-    ? getUnmatchedTimeInterval()
-    : null;
+    return [];
+  }, [incident, ems_pcrs]);
 
   /**
    * Get all crash records that occurred within 12 hours of the incidents
    * if the incidents have a crash match status of unmatched
    */
   const { data: unmatchedCrashes } = useQuery<Crash>({
-    query: unmatchedTimeInterval ? GET_UNMATCHED_EMS_CRASHES : null,
+    query: unmatchedTimeInterval[0] ? GET_UNMATCHED_EMS_CRASHES : null,
     variables: {
-      time12HoursBefore: unmatchedTimeInterval?.[0],
-      time12HoursAfter: unmatchedTimeInterval?.[1],
+      time12HoursBefore: unmatchedTimeInterval[0],
+      time12HoursAfter: unmatchedTimeInterval[1],
     },
     typename: "crashes",
   });
@@ -121,7 +118,10 @@ export default function EMSDetailsPage({
     ? unmatchedCrashes?.map((crash) => crash.id)
     : [];
 
-  const allCrashPks = [...relatedCrashPks, ...unmatchedCrashPks];
+  // Combine and dedupe related crash and unmatched crash pks
+  const allCrashPks = Array.from(
+    new Set([...relatedCrashPks, ...unmatchedCrashPks])
+  );
 
   /**
    * Get all people records linked to crashes that were either automatically
@@ -129,9 +129,9 @@ export default function EMSDetailsPage({
    * if it has a crash status of unmatched
    */
   const { data: matchingPeople } = useQuery<PeopleListRow>({
-    query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
+    query: GET_MATCHING_PEOPLE,
     variables: {
-      crash_pks: unmatchedTimeInterval ? allCrashPks : relatedCrashPks,
+      crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
     },
     typename: "people_list_view",
   });
@@ -176,11 +176,6 @@ export default function EMSDetailsPage({
   if (error) {
     console.error(error);
   }
-
-  /**
-   * Use the first EMS record as the "incident"
-   */
-  const incident = ems_pcrs?.[0];
 
   /**
    * Set the title of the page inside the HTML head element
@@ -238,7 +233,7 @@ export default function EMSDetailsPage({
             <RelatedRecordTable<PeopleListRow, EMSLinkToPersonButtonProps>
               records={matchingPeople}
               isValidating={isValidating}
-              noRowsMessage="No crashes found"
+              noRowsMessage="No people found"
               header="Associated people records"
               columns={emsMatchingPeopleColumns}
               mutation=""

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -129,7 +129,7 @@ export default function EMSDetailsPage({
    * if it has a crash status of unmatched
    */
   const { data: matchingPeople } = useQuery<PeopleListRow>({
-    query: GET_MATCHING_PEOPLE,
+    query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
     variables: {
       crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
     },
@@ -227,23 +227,21 @@ export default function EMSDetailsPage({
           />
         </Col>
       </Row>
-      {matchingPeople && (
-        <Row>
-          <Col sm={12} className="mb-3">
-            <RelatedRecordTable<PeopleListRow, EMSLinkToPersonButtonProps>
-              records={matchingPeople}
-              isValidating={isValidating}
-              noRowsMessage="No people found"
-              header="Associated people records"
-              columns={emsMatchingPeopleColumns}
-              mutation=""
-              onSaveCallback={onSaveCallback}
-              rowActionComponent={EMSLinkToPersonButton}
-              rowActionComponentAdditionalProps={linkToPersonButtonProps}
-            />
-          </Col>
-        </Row>
-      )}
+      <Row>
+        <Col sm={12} className="mb-3">
+          <RelatedRecordTable<PeopleListRow, EMSLinkToPersonButtonProps>
+            records={matchingPeople ? matchingPeople : []}
+            isValidating={isValidating}
+            noRowsMessage="No people found"
+            header="Associated people records"
+            columns={emsMatchingPeopleColumns}
+            mutation=""
+            onSaveCallback={onSaveCallback}
+            rowActionComponent={EMSLinkToPersonButton}
+            rowActionComponentAdditionalProps={linkToPersonButtonProps}
+          />
+        </Col>
+      </Row>
     </>
   );
 }

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -91,15 +91,17 @@ export default function EMSDetailsPage({
   const unmatchedTimeInterval: Date[] = useMemo(() => {
     // if any of the ems records have a crash match status of unmatched
     if (ems_pcrs?.some((ems) => ems.crash_match_status === "unmatched")) {
-      if (incident?.incident_received_datetime) {
-        const incidentTimestamp = parseISO(incident.incident_received_datetime);
+      if (ems_pcrs[0].incident_received_datetime) {
+        const incidentTimestamp = parseISO(
+          ems_pcrs[0].incident_received_datetime
+        );
         const time12HoursBefore = subHours(incidentTimestamp, 12);
         const time12HoursAfter = addHours(incidentTimestamp, 12);
         return [time12HoursBefore, time12HoursAfter];
       }
     }
     return [];
-  }, [incident, ems_pcrs]);
+  }, [ems_pcrs]);
 
   /**
    * Get all crash records that occurred within 12 hours of the incidents

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -131,7 +131,7 @@ export default function EMSDetailsPage({
   const { data: matchingPeople } = useQuery<PeopleListRow>({
     query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
     variables: {
-      crash_pks: allCrashPks,
+      crash_pks: unmatchedTimeInterval ? allCrashPks : relatedCrashPks,
     },
     typename: "people_list_view",
   });

--- a/editor/components/EMSLinkToPersonButton.tsx
+++ b/editor/components/EMSLinkToPersonButton.tsx
@@ -17,8 +17,10 @@ const EMSLinkToPersonButton: React.FC<
   RowActionComponentProps<PeopleListRow, EMSLinkToPersonButtonProps>
 > = ({ record, additionalProps }) => {
   const isLinkingInProgress = !!additionalProps?.selectedEmsPcr;
+  // Does the person already have a non-null ems_pcr relationship
+  const isPersonAlreadyLinked = !!record.ems_pcr;
 
-  if (!isLinkingInProgress) {
+  if (!isLinkingInProgress || isPersonAlreadyLinked) {
     return null;
   }
 

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -121,6 +121,9 @@ export const GET_MATCHING_PEOPLE = gql`
           label
         }
       }
+      ems_pcr {
+        id
+      }
     }
   }
 `;

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -55,7 +55,7 @@ export const GET_MATCHING_PEOPLE = gql`
   query EMSMatchingCrashes($crash_pks: [Int!]) {
     people_list_view(
       where: { crash_pk: { _in: $crash_pks } }
-      order_by: { cris_crash_id: asc, unit_nbr: asc, prsn_nbr: asc }
+      order_by: { crash_timestamp: asc, unit_nbr: asc, prsn_nbr: asc }
     ) {
       crash_pk
       crash_timestamp

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -34,6 +34,26 @@ export const GET_EMS_RECORDS = gql`
   }
 `;
 
+export const GET_UNMATCHED_EMS_CRASHES = gql`
+  query EMSUnmatchedCrashes(
+    $timestamp12HoursBefore: timestamptz!
+    $timestamp12HoursAfter: timestamptz!
+  ) {
+    crashes(
+      where: {
+        crash_timestamp: {
+          _gte: $timestamp12HoursBefore
+          _lte: $timestamp12HoursAfter
+        }
+      }
+    ) {
+      id
+      cris_crash_id
+      crash_timestamp
+    }
+  }
+`;
+
 export const GET_MATCHING_PEOPLE = gql`
   query EMSMatchingCrashes($crash_pks: [Int!]) {
     people_list_view(
@@ -133,4 +153,3 @@ export const UPDATE_EMS_INCIDENT = gql`
     }
   }
 `;
-

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -36,15 +36,12 @@ export const GET_EMS_RECORDS = gql`
 
 export const GET_UNMATCHED_EMS_CRASHES = gql`
   query EMSUnmatchedCrashes(
-    $timestamp12HoursBefore: timestamptz!
-    $timestamp12HoursAfter: timestamptz!
+    $time12HoursBefore: timestamptz!
+    $time12HoursAfter: timestamptz!
   ) {
     crashes(
       where: {
-        crash_timestamp: {
-          _gte: $timestamp12HoursBefore
-          _lte: $timestamp12HoursAfter
-        }
+        crash_timestamp: { _gte: $time12HoursBefore, _lte: $time12HoursAfter }
       }
     ) {
       id

--- a/editor/types/peopleList.ts
+++ b/editor/types/peopleList.ts
@@ -1,6 +1,7 @@
 import { Crash } from "@/types/crashes";
 import { LookupTableOption } from "./relationships";
 import { Unit } from "@/types/unit";
+import { EMSPatientCareRecord } from "@/types/ems";
 
 export type PeopleListRow = {
   crash_pk: number;
@@ -26,4 +27,5 @@ export type PeopleListRow = {
   unit_id: number;
   unit?: Unit;
   crash?: Crash;
+  ems_pcr?: EMSPatientCareRecord;
 };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/issues/assigned?issue=cityofaustin%7Catd-data-tech%7C22200

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
local

**Steps to test:**
1. Go to the EMS page, click on some EMS records that have a crash status of unmatched.
2. See that the people list is populated with  people from crashes that occurred within 12 hours of the ems incident
3. Test linking an ems incident to a person record and see the status turn from unmatched to matched by manual Q/A and the person list should update with only people from that crash id
4. Go to a EMS page that has at least two unmatched records
5. Link one, see that both records will turn to matched with Q/A and the people list will shorten to only people from that crash id. 
6. Then in your hasura console or db manager test deleting the crash pk and update crash_status to "unmatched" again on one of the records in the `ems__incidents` tables, so that one record is unmatched and the other record is matched. See that the people list populates with records both from the crash id you manually Q/Aed and from crashes that occurred within 12 hours of the record that is now unmatched. This is to test the behavior that in the future users will be able to null out a crash pk they manually added and revert to the non-fiddled with crash match status for one of the ems records while keeping the other ems record manual QA

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
