### PR TITLE
EMS details: hide select button for people records that are already linked

### DIFF
--- a/database/metadata/databases/default/tables/public_people_list_view.yaml
+++ b/database/metadata/databases/default/tables/public_people_list_view.yaml
@@ -20,6 +20,15 @@ object_relationships:
         remote_table:
           name: drvr_ethncty
           schema: lookups
+  - name: ems_pcr
+    using:
+      manual_configuration:
+        column_mapping:
+          id: person_id
+        insertion_order: null
+        remote_table:
+          name: ems__incidents
+          schema: public
   - name: gndr
     using:
       manual_configuration:

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -136,13 +136,6 @@ export default function EMSDetailsPage({
     typename: "people_list_view",
   });
 
-  /**
-   * Array of all the person ids that have already been matched to ems records in this incident
-   */
-  const matchedPersonIds: number[] | undefined = ems_pcrs
-    ?.map((ems) => ems.person_id)
-    .filter((id) => id !== null);
-
   const onSaveCallback = useCallback(async () => {
     await refetch();
   }, [refetch]);
@@ -176,9 +169,8 @@ export default function EMSDetailsPage({
           });
       },
       selectedEmsPcr: selectedEmsPcr,
-      matchedPersonIds: matchedPersonIds,
     }),
-    [updateEMSIncident, selectedEmsPcr, refetch, matchedPersonIds]
+    [updateEMSIncident, selectedEmsPcr, refetch]
   );
 
   if (error) {

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -136,6 +136,13 @@ export default function EMSDetailsPage({
     typename: "people_list_view",
   });
 
+  /**
+   * Array of all the person ids that have already been matched to ems records in this incident
+   */
+  const matchedPersonIds: number[] | undefined = ems_pcrs
+    ?.map((ems) => ems.person_id)
+    .filter((id) => id !== null);
+
   const onSaveCallback = useCallback(async () => {
     await refetch();
   }, [refetch]);
@@ -169,8 +176,9 @@ export default function EMSDetailsPage({
           });
       },
       selectedEmsPcr: selectedEmsPcr,
+      matchedPersonIds: matchedPersonIds,
     }),
-    [updateEMSIncident, selectedEmsPcr, refetch]
+    [updateEMSIncident, selectedEmsPcr, refetch, matchedPersonIds]
   );
 
   if (error) {

--- a/editor/components/EMSLinkToPersonButton.tsx
+++ b/editor/components/EMSLinkToPersonButton.tsx
@@ -18,11 +18,8 @@ const EMSLinkToPersonButton: React.FC<
   RowActionComponentProps<PeopleListRow, EMSLinkToPersonButtonProps>
 > = ({ record, additionalProps }) => {
   const isLinkingInProgress = !!additionalProps?.selectedEmsPcr;
-  const isPersonAlreadyLinked = additionalProps?.matchedPersonIds
-    ? additionalProps?.matchedPersonIds.some(
-        (personId) => personId === record.id
-      )
-    : null;
+  // Does the person already have a non-null ems_pcr relationship
+  const isPersonAlreadyLinked = !!record.ems_pcr;
 
   if (!isLinkingInProgress || isPersonAlreadyLinked) {
     return null;

--- a/editor/components/EMSLinkToPersonButton.tsx
+++ b/editor/components/EMSLinkToPersonButton.tsx
@@ -11,7 +11,6 @@ const allowedLinkRecordRoles = ["vz-admin", "editor"];
 export interface EMSLinkToPersonButtonProps extends Record<string, unknown> {
   onClick: (emsId: number, personId: number, crashPk: number) => void;
   selectedEmsPcr: EMSPatientCareRecord | null;
-  matchedPersonIds: number[] | undefined;
 }
 
 const EMSLinkToPersonButton: React.FC<

--- a/editor/components/EMSLinkToPersonButton.tsx
+++ b/editor/components/EMSLinkToPersonButton.tsx
@@ -11,14 +11,20 @@ const allowedLinkRecordRoles = ["vz-admin", "editor"];
 export interface EMSLinkToPersonButtonProps extends Record<string, unknown> {
   onClick: (emsId: number, personId: number, crashPk: number) => void;
   selectedEmsPcr: EMSPatientCareRecord | null;
+  matchedPersonIds: number[] | undefined;
 }
 
 const EMSLinkToPersonButton: React.FC<
   RowActionComponentProps<PeopleListRow, EMSLinkToPersonButtonProps>
 > = ({ record, additionalProps }) => {
   const isLinkingInProgress = !!additionalProps?.selectedEmsPcr;
+  const isPersonAlreadyLinked = additionalProps?.matchedPersonIds
+    ? additionalProps?.matchedPersonIds.some(
+        (personId) => personId === record.id
+      )
+    : null;
 
-  if (!isLinkingInProgress) {
+  if (!isLinkingInProgress || isPersonAlreadyLinked) {
     return null;
   }
 

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -121,6 +121,9 @@ export const GET_MATCHING_PEOPLE = gql`
           label
         }
       }
+      ems_pcr {
+        id
+      }
     }
   }
 `;

--- a/editor/types/peopleList.ts
+++ b/editor/types/peopleList.ts
@@ -1,6 +1,7 @@
 import { Crash } from "@/types/crashes";
 import { LookupTableOption } from "./relationships";
 import { Unit } from "@/types/unit";
+import { EMSPatientCareRecord } from "@/types/ems";
 
 export type PeopleListRow = {
   crash_pk: number;
@@ -26,5 +27,5 @@ export type PeopleListRow = {
   unit_id: number;
   unit?: Unit;
   crash?: Crash;
-  ems_pcr: LookupTableOption;
+  ems_pcr?: EMSPatientCareRecord;
 };

--- a/editor/types/peopleList.ts
+++ b/editor/types/peopleList.ts
@@ -26,4 +26,5 @@ export type PeopleListRow = {
   unit_id: number;
   unit?: Unit;
   crash?: Crash;
+  ems_pcr: LookupTableOption;
 };


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/22207

Best to test this after https://github.com/cityofaustin/vision-zero/pull/1779 for your own context

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Make sure you apply metadata locally
2. Go to an incident with unmatched PCRs, start linking them to people and see that after a person gets linked the select button no longer shows up on that row when you try to link other pcrs
3. Go to a different incident with unmatched PCRs with a timestamp that is very close to the previous incident, you should see that when you go to select people some of them are already unavailable to be selected if you linked them with the previous incident in step 1

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
