### PR TITLE
Ability to set EMS record status as "Match not found (Review/QA)"

### DIFF
--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -96,6 +96,7 @@ update_permissions:
       columns:
         - crash_match_status
         - crash_pk
+        - matched_crash_pks
         - person_id
         - updated_by
       filter: {}
@@ -106,6 +107,7 @@ update_permissions:
       columns:
         - crash_match_status
         - crash_pk
+        - matched_crash_pks
         - person_id
         - updated_by
       filter: {}

--- a/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/down.sql
+++ b/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/down.sql
@@ -1,11 +1,3 @@
-alter table ems__incidents
-drop constraint ems__incidents_crash_match_status_check;
-
-alter table ems__incidents
-add constraint ems__incidents_crash_match_status_check check (crash_match_status in (
-        'unmatched',
-        'matched_by_automation',
-        'multiple_matches_by_automation',
-        'matched_by_manual_qa',
-    )
-    );
+-- cant revert bc constraint will be violated if records have already
+-- been set to 'unmatched_by_manual_qa'
+select 0;

--- a/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/down.sql
+++ b/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/down.sql
@@ -1,0 +1,11 @@
+alter table ems__incidents
+drop constraint ems__incidents_crash_match_status_check;
+
+alter table ems__incidents
+add constraint ems__incidents_crash_match_status_check check (crash_match_status in (
+        'unmatched',
+        'matched_by_automation',
+        'multiple_matches_by_automation',
+        'matched_by_manual_qa',
+    )
+    );

--- a/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/up.sql
+++ b/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/up.sql
@@ -1,0 +1,12 @@
+alter table ems__incidents
+drop constraint ems__incidents_crash_match_status_check;
+
+alter table ems__incidents
+add constraint ems__incidents_crash_match_status_check check (crash_match_status in (
+        'unmatched',
+        'matched_by_automation',
+        'multiple_matches_by_automation',
+        'matched_by_manual_qa',
+        'unmatched_by_manual_qa'
+    )
+    );

--- a/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/up.sql
+++ b/database/migrations/default/1746472713390_ems_update_crash_match_status_constraint/up.sql
@@ -1,3 +1,5 @@
+-- Add unmatched by manual QA as a crash match status 
+
 alter table ems__incidents
 drop constraint ems__incidents_crash_match_status_check;
 

--- a/database/migrations/default/1746472913390_ems_update_triggers_matched_crash_pks/down.sql
+++ b/database/migrations/default/1746472913390_ems_update_triggers_matched_crash_pks/down.sql
@@ -1,0 +1,101 @@
+CREATE OR REPLACE FUNCTION public.update_crash_ems_match()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_ems RECORD;
+    ems_record RECORD;
+    match_count INTEGER;
+    matched_crash_ids INTEGER[];
+    meters_threshold INTEGER := 1200;
+    -- 30 min threshold equates to a 60 minute window (+/- 30 minutes of crash timestamp)
+    time_threshold INTERVAL := '30 minutes';
+BEGIN
+    -- Find all EMS records near the crash location + time
+    FOR matching_ems IN (
+        SELECT 
+            e.id,
+            e.incident_received_datetime,
+            e.geometry
+        FROM 
+            ems__incidents e
+        WHERE
+            -- ignore manual qa matches: these should not be modified
+            e.crash_match_status != 'matched_by_manual_qa'
+            AND e.incident_received_datetime  >= (NEW.crash_timestamp - time_threshold)
+            AND e.incident_received_datetime  <= (NEW.crash_timestamp + time_threshold)
+            AND e.geometry IS NOT NULL
+            AND NEW.position IS NOT NULL
+            AND ST_DWithin(e.geometry::geography, NEW.position::geography, meters_threshold)
+    ) LOOP
+        -- Find all crashes which match this EMS record location + time
+        SELECT 
+            ARRAY(
+                SELECT c.id
+                FROM crashes c
+                WHERE 
+                    c.is_deleted = false
+                    and not c.is_temp_record
+                    AND matching_ems.incident_received_datetime  >= (c.crash_timestamp - time_threshold)
+                    AND matching_ems.incident_received_datetime  <= (c.crash_timestamp + time_threshold)
+                    AND c.position IS NOT NULL
+                    AND ST_DWithin(matching_ems.geometry::geography, c.position::geography, meters_threshold)
+            ) INTO matched_crash_ids;
+            
+        -- Get the count from the array length (handling when array_length is null as 0)
+        SELECT COALESCE(array_length(matched_crash_ids, 1), 0) INTO match_count;
+        
+        IF match_count = 0 THEN
+            UPDATE ems__incidents 
+            SET crash_pk = NULL,
+                crash_match_status = 'unmatched',
+                matched_crash_pks = NULL
+            WHERE id = matching_ems.id;
+        ELSIF match_count = 1 THEN
+            -- this EMS record is only matched to one crash - we can assign the crash_pk
+            UPDATE ems__incidents 
+            SET crash_pk = NEW.id,
+                crash_match_status = 'matched_by_automation',
+                matched_crash_pks = NULL
+            WHERE id = matching_ems.id;
+        ELSE
+            -- multiple matching crashes found - cannot assign crash_pk
+            UPDATE ems__incidents 
+            SET crash_match_status = 'multiple_matches_by_automation',
+                crash_pk = NULL,
+                matched_crash_pks = matched_crash_ids
+            WHERE id = matching_ems.id;
+        END IF;
+    END LOOP;
+
+    --
+    -- nullify the crash_pk for EMS records that no longer match this crash
+    --
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE ems__incidents
+        SET crash_pk = NULL,
+            crash_match_status = 'unmatched',
+            matched_crash_pks = NULL
+        WHERE crash_pk = NEW.id
+          AND (
+              incident_received_datetime  < (NEW.crash_timestamp - time_threshold)
+              OR incident_received_datetime  > (NEW.crash_timestamp + time_threshold)
+              OR geometry IS NULL
+              OR NEW.position IS NULL
+              OR NEW.is_temp_record is TRUE
+              or NEW.is_deleted is TRUE
+              OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+          )
+          AND 
+            -- ignore manual qa matches: these should not be modified
+            crash_match_status != 'matched_by_manual_qa';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+UPDATE ems__incidents set matched_crash_pks = null where crash_match_status = 'matched_by_automation';
+
+COMMENT ON COLUMN ems__incidents.matched_crash_pks IS 'The IDs of multiple crashes that were found to match this record. Set via trigger.';
+
+COMMENT ON COLUMN ems__incidents.crash_pk IS 'Crash ID matched to this record';

--- a/database/migrations/default/1746472913390_ems_update_triggers_matched_crash_pks/up.sql
+++ b/database/migrations/default/1746472913390_ems_update_triggers_matched_crash_pks/up.sql
@@ -1,0 +1,117 @@
+-- Updating this trigger to always keep the matched_crash_pks up to date with automatic matching results
+-- regardless of crash match status
+CREATE OR REPLACE FUNCTION public.update_crash_ems_match()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_ems RECORD;
+    ems_record RECORD;
+    match_count INTEGER;
+    matched_crash_ids INTEGER[];
+    meters_threshold INTEGER := 1200;
+    -- 30 min threshold equates to a 60 minute window (+/- 30 minutes of crash timestamp)
+    time_threshold INTERVAL := '30 minutes';
+BEGIN
+    -- Find all EMS records near the crash location + time
+    FOR matching_ems IN (
+        SELECT 
+            e.id,
+            e.incident_received_datetime,
+            e.geometry,
+            e.crash_match_status
+        FROM 
+            ems__incidents e
+        WHERE
+            e.incident_received_datetime  >= (NEW.crash_timestamp - time_threshold)
+            AND e.incident_received_datetime  <= (NEW.crash_timestamp + time_threshold)
+            AND e.geometry IS NOT NULL
+            AND NEW.position IS NOT NULL
+            AND ST_DWithin(e.geometry::geography, NEW.position::geography, meters_threshold)
+    ) LOOP
+        -- Find all crashes which match this EMS record location + time
+        SELECT 
+            ARRAY(
+                SELECT c.id
+                FROM crashes c
+                WHERE 
+                    c.is_deleted = false
+                    and not c.is_temp_record
+                    AND matching_ems.incident_received_datetime  >= (c.crash_timestamp - time_threshold)
+                    AND matching_ems.incident_received_datetime  <= (c.crash_timestamp + time_threshold)
+                    AND c.position IS NOT NULL
+                    AND ST_DWithin(matching_ems.geometry::geography, c.position::geography, meters_threshold)
+            ) INTO matched_crash_ids;
+            
+        -- Get the count from the array length (handling when array_length is null as 0)
+        SELECT COALESCE(array_length(matched_crash_ids, 1), 0) INTO match_count;
+
+        -- For records that have been manually matched we want to only update the automated match column
+        IF matching_ems.crash_match_status === 'matched_by_manual_qa' THEN
+          IF match_count = 0 THEN
+            UPDATE ems__incidents 
+            SET matched_crash_pks = NULL
+            WHERE id = matching_ems.id;
+          ELSE 
+            -- if the match count is more than one we will update the matched_crash_pks
+            UPDATE ems__incidents 
+            SET matched_crash_pks = matched_crash_ids
+            WHERE id = matching_ems.id;
+          END IF;
+        -- If the record has not been manually matched
+        ELSE
+          IF match_count = 0 THEN
+              UPDATE ems__incidents 
+              SET crash_pk = NULL,
+                  crash_match_status = 'unmatched',
+                  matched_crash_pks = NULL
+              WHERE id = matching_ems.id;
+          ELSIF match_count = 1 THEN
+              -- this EMS record is only matched to one crash - we can assign the crash_pk and matched_crash_pks
+              UPDATE ems__incidents 
+              SET crash_pk = NEW.id,
+                  crash_match_status = 'matched_by_automation',
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          ELSE
+              -- multiple matching crashes found - can assign the matched_crash_pks but not crash_pk
+              UPDATE ems__incidents 
+              SET crash_match_status = 'multiple_matches_by_automation',
+                  crash_pk = NULL,
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          END IF;
+        END IF;
+    END LOOP;
+
+    --
+    -- nullify the crash_pk for EMS records that no longer match this crash
+    --
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE ems__incidents
+        SET crash_pk = NULL,
+            crash_match_status = 'unmatched',
+            matched_crash_pks = NULL
+        WHERE crash_pk = NEW.id
+          AND (
+              incident_received_datetime  < (NEW.crash_timestamp - time_threshold)
+              OR incident_received_datetime  > (NEW.crash_timestamp + time_threshold)
+              OR geometry IS NULL
+              OR NEW.position IS NULL
+              OR NEW.is_temp_record is TRUE
+              or NEW.is_deleted is TRUE
+              OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+          )
+          AND 
+            -- ignore manual qa matches: these should not be modified
+            crash_match_status != 'matched_by_manual_qa';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+UPDATE ems__incidents set matched_crash_pks = ARRAY[crash_pk] where crash_match_status = 'matched_by_automation';
+
+COMMENT ON COLUMN ems__incidents.matched_crash_pks IS 'The IDs of crashes that were found to match this record. Set via trigger, always kept up to date regardless of EMS crash match status.';
+
+COMMENT ON COLUMN ems__incidents.crash_pk IS 'Crash ID matched to this record, could be assigned automatically via trigger or manually by user.';

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -128,17 +128,16 @@ export default function EMSDetailsPage({
    * matched with the ems record or that occurred within 12 hours of the incident
    * if it has a crash status of unmatched
    */
-  const { data: matchingPeople, isValidating: personIsValidating } =
-    useQuery<PeopleListRow>({
-      query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
-      variables: {
-        crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
-      },
-      typename: "people_list_view",
-      options: {
-        keepPreviousData: false,
-      },
-    });
+  const { data: matchingPeople } = useQuery<PeopleListRow>({
+    query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
+    variables: {
+      crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
+    },
+    typename: "people_list_view",
+    options: {
+      keepPreviousData: false,
+    },
+  });
 
   const onSaveCallback = useCallback(async () => {
     await refetch();

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -128,13 +128,17 @@ export default function EMSDetailsPage({
    * matched with the ems record or that occurred within 12 hours of the incident
    * if it has a crash status of unmatched
    */
-  const { data: matchingPeople } = useQuery<PeopleListRow>({
-    query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
-    variables: {
-      crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
-    },
-    typename: "people_list_view",
-  });
+  const { data: matchingPeople, isValidating: personIsValidating } =
+    useQuery<PeopleListRow>({
+      query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
+      variables: {
+        crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
+      },
+      typename: "people_list_view",
+      options: {
+        keepPreviousData: false,
+      },
+    });
 
   const onSaveCallback = useCallback(async () => {
     await refetch();

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -223,6 +223,7 @@ export default function EMSDetailsPage({
             onSaveCallback={onSaveCallback}
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}
+            rowActionMutation={UPDATE_EMS_INCIDENT}
           />
         </Col>
       </Row>

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -44,7 +44,7 @@ export default function EMSDetailsPage({
     data: ems_pcrs,
     error,
     isValidating,
-    refetch,
+    refetch: refetchEMS,
   } = useQuery<EMSPatientCareRecord>({
     query: incident_number ? GET_EMS_RECORDS : null,
     variables: {
@@ -66,7 +66,7 @@ export default function EMSDetailsPage({
    * Hook which manages which related crash PKs we should
    * use to query people records
    */
-  const relatedCrashPks: number[] = useMemo(() => {
+  const matchedCrashPks: number[] = useMemo(() => {
     if (!ems_pcrs) {
       return [];
     }
@@ -90,8 +90,15 @@ export default function EMSDetailsPage({
    */
   const unmatchedTimeInterval: string[] = useMemo(() => {
     if (incident?.incident_received_datetime) {
-      // Return time interval only if we have any unmatched ems pcrs
-      if (ems_pcrs?.some((ems) => ems.crash_match_status === "unmatched")) {
+      // Return time interval only if the record doesnt have a crash_pk or any matched_crash_pks
+      if (
+        ems_pcrs?.some(
+          (ems) =>
+            ems.crash_pk === null &&
+            (ems.matched_crash_pks === null ||
+              ems.matched_crash_pks.length === 0)
+        )
+      ) {
         const incidentTimestamp = parseISO(incident.incident_received_datetime);
         const time12HoursBefore = subHours(incidentTimestamp, 12).toISOString();
         const time12HoursAfter = addHours(incidentTimestamp, 12).toISOString();
@@ -103,7 +110,7 @@ export default function EMSDetailsPage({
 
   /**
    * Get all crash records that occurred within 12 hours of the incidents
-   * if any of the ems pcrs have a crash match status of unmatched
+   * if any of the ems pcrs are unmatched
    */
   const { data: unmatchedCrashes } = useQuery<Crash>({
     query: unmatchedTimeInterval[0] ? GET_UNMATCHED_EMS_CRASHES : null,
@@ -120,7 +127,7 @@ export default function EMSDetailsPage({
 
   // Combine and dedupe related crash and unmatched crash pks
   const allCrashPks = Array.from(
-    new Set([...relatedCrashPks, ...unmatchedCrashPks])
+    new Set([...matchedCrashPks, ...unmatchedCrashPks])
   );
 
   /**
@@ -128,20 +135,22 @@ export default function EMSDetailsPage({
    * matched with the ems record or that occurred within 12 hours of the incident
    * if it has a crash status of unmatched
    */
-  const { data: matchingPeople } = useQuery<PeopleListRow>({
-    query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
-    variables: {
-      crash_pks: unmatchedTimeInterval[0] ? allCrashPks : relatedCrashPks,
-    },
-    typename: "people_list_view",
-    options: {
-      keepPreviousData: false,
-    },
-  });
+  const { data: matchingPeople, refetch: refetchPeople } =
+    useQuery<PeopleListRow>({
+      query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
+      variables: {
+        crash_pks: unmatchedTimeInterval[0] ? allCrashPks : matchedCrashPks,
+      },
+      typename: "people_list_view",
+      options: {
+        keepPreviousData: false,
+      },
+    });
 
   const onSaveCallback = useCallback(async () => {
-    await refetch();
-  }, [refetch]);
+    await refetchEMS();
+    await refetchPeople();
+  }, [refetchEMS, refetchPeople]);
 
   /**
    * Memoize the additional components props for related record tables
@@ -165,14 +174,15 @@ export default function EMSDetailsPage({
           id: emsId,
           person_id: personId,
         })
-          .then(() => refetch())
+          .then(() => refetchEMS())
+          .then(() => refetchPeople())
           .then(() => {
             setSelectedEmsPcr(null);
           });
       },
       selectedEmsPcr: selectedEmsPcr,
     }),
-    [updateEMSIncident, selectedEmsPcr, refetch]
+    [updateEMSIncident, selectedEmsPcr, refetchEMS, refetchPeople]
   );
 
   if (error) {

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -1,4 +1,5 @@
-import Button from "react-bootstrap/Button";
+import { Dropdown, Button } from "react-bootstrap";
+import { FaEllipsisVertical } from "react-icons/fa6";
 import { EMSPatientCareRecord } from "@/types/ems";
 import { RowActionComponentProps } from "@/components/RelatedRecordTable";
 import { FaLink } from "react-icons/fa6";
@@ -15,7 +16,6 @@ export interface EMSLinkRecordButtonProps extends Record<string, unknown> {
 const EMSLinkRecordButton: React.FC<
   RowActionComponentProps<EMSPatientCareRecord, EMSLinkRecordButtonProps>
 > = ({ record, additionalProps }) => {
-
   const isLinkingInProgress = !!additionalProps?.selectedEmsPcr;
   const isLinkingThisRecord =
     additionalProps?.selectedEmsPcr &&
@@ -29,22 +29,33 @@ const EMSLinkRecordButton: React.FC<
 
   return (
     <PermissionsRequired allowedRoles={allowedLinkRecordRoles}>
-      <Button
-        size="sm"
-        variant={isLinkingThisRecord ? "secondary" : "primary"}
-        disabled={isLinkingInProgress && !isLinkingThisRecord}
-        onClick={() => {
-          additionalProps?.onClick(record);
-        }}
-      >
-        {!isLinkingThisRecord && (
-          <AlignedLabel>
-            <FaLink className="me-2" />
-            <span>Select person</span>
-          </AlignedLabel>
-        )}
-        {isLinkingThisRecord && <span>Cancel</span>}
-      </Button>
+      <div className="d-flex">
+        <Button
+          size="sm"
+          variant={isLinkingThisRecord ? "secondary" : "primary"}
+          disabled={isLinkingInProgress && !isLinkingThisRecord}
+          onClick={() => {
+            additionalProps?.onClick(record);
+          }}
+        >
+          {!isLinkingThisRecord && (
+            <AlignedLabel>
+              <FaLink className="me-2" />
+              <span>Select person</span>
+            </AlignedLabel>
+          )}
+          {isLinkingThisRecord && <span>Cancel</span>}
+        </Button>
+        <Dropdown className="ms-1">
+          <Dropdown.Toggle variant="outline-primary" size="sm">
+            <FaEllipsisVertical />
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            <Dropdown.Item>Set as unmatched</Dropdown.Item>
+            <Dropdown.Item>Reset</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
     </PermissionsRequired>
   );
 };

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -50,7 +50,7 @@ const EMSLinkRecordButton: React.FC<
           <Dropdown.Toggle variant="outline-primary" size="sm">
             <FaEllipsisVertical />
           </Dropdown.Toggle>
-          <Dropdown.Menu>
+          <Dropdown.Menu popperConfig={{ strategy: "fixed" }}>
             <Dropdown.Item>Set as unmatched</Dropdown.Item>
             <Dropdown.Item>Reset</Dropdown.Item>
           </Dropdown.Menu>

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -6,6 +6,7 @@ import { FaLink } from "react-icons/fa6";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import AlignedLabel from "@/components/AlignedLabel";
 import { useMutation } from "@/utils/graphql";
+import { useMemo } from "react";
 
 const allowedLinkRecordRoles = ["vz-admin", "editor"];
 
@@ -22,7 +23,34 @@ const EMSLinkRecordButton: React.FC<
     additionalProps?.selectedEmsPcr &&
     record.id === additionalProps?.selectedEmsPcr.id;
 
-  const { mutate: setRecordManualUnmatched } = useMutation(mutation);
+  /**
+   * Hook that gets the variables to be used in the reset button mutation
+   */
+  const resetButtonUpdates = useMemo(() => {
+    let updates = {};
+    if (record.matched_crash_pks === null) {
+      updates = {
+        crash_pk: null,
+        person_id: null,
+        crash_match_status: "unmatched",
+      };
+    } else if (record.matched_crash_pks.length === 1) {
+      updates = {
+        crash_pk: record.matched_crash_pks[0],
+        person_id: null,
+        crash_match_status: "matched_by_automation",
+      };
+    } else if (record.matched_crash_pks.length > 1) {
+      updates = {
+        crash_pk: null,
+        person_id: null,
+        crash_match_status: "multiple_matches_by_automation",
+      };
+    }
+    return updates;
+  }, [record]);
+
+  const { mutate: updateEMSRecord } = useMutation(mutation);
 
   return (
     <PermissionsRequired allowedRoles={allowedLinkRecordRoles}>
@@ -43,33 +71,45 @@ const EMSLinkRecordButton: React.FC<
           )}
           {isLinkingThisRecord && <span>Cancel</span>}
         </Button>
-        <Dropdown className="ms-1">
-          <Dropdown.Toggle
-            className="hide-toggle"
-            variant="outline-primary"
-            size="sm"
-          >
-            <FaEllipsisVertical />
-          </Dropdown.Toggle>
-          <Dropdown.Menu renderOnMount popperConfig={{ strategy: "fixed" }}>
-            <Dropdown.Item
-              onClick={async () => {
-                await setRecordManualUnmatched({
-                  id: record.id,
-                  updates: {
-                    crash_match_status: "unmatched_by_manual_qa",
-                    crash_pk: null,
-                    person_id: null,
-                  },
-                });
-                await onSaveCallback();
-              }}
+        {!isLinkingThisRecord && (
+          <Dropdown className="ms-1">
+            <Dropdown.Toggle
+              className="hide-toggle"
+              variant="outline-primary"
+              size="sm"
             >
-              Match not found
-            </Dropdown.Item>
-            <Dropdown.Item>Reset</Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
+              <FaEllipsisVertical />
+            </Dropdown.Toggle>
+            <Dropdown.Menu renderOnMount popperConfig={{ strategy: "fixed" }}>
+              <Dropdown.Item
+                onClick={async () => {
+                  await updateEMSRecord({
+                    id: record.id,
+                    updates: {
+                      crash_match_status: "unmatched_by_manual_qa",
+                      crash_pk: null,
+                      person_id: null,
+                    },
+                  });
+                  await onSaveCallback();
+                }}
+              >
+                Match not found
+              </Dropdown.Item>
+              <Dropdown.Item
+                onClick={async () => {
+                  await updateEMSRecord({
+                    id: record.id,
+                    updates: resetButtonUpdates,
+                  });
+                  await onSaveCallback();
+                }}
+              >
+                Reset
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
+        )}
       </div>
     </PermissionsRequired>
   );

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -47,7 +47,7 @@ const EMSLinkRecordButton: React.FC<
           <Dropdown.Toggle variant="outline-primary" size="sm">
             <FaEllipsisVertical />
           </Dropdown.Toggle>
-          <Dropdown.Menu popperConfig={{ strategy: "fixed" }}>
+          <Dropdown.Menu renderOnMount popperConfig={{ strategy: "fixed" }}>
             <Dropdown.Item
               onClick={async () => {
                 await setRecordManualUnmatched({

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -22,13 +22,7 @@ const EMSLinkRecordButton: React.FC<
     additionalProps?.selectedEmsPcr &&
     record.id === additionalProps?.selectedEmsPcr.id;
 
-  const isRecordAlreadyLinked = !!record.person_id;
-
   const { mutate: setRecordManualUnmatched } = useMutation(mutation);
-
-  if (isRecordAlreadyLinked) {
-    return null;
-  }
 
   return (
     <PermissionsRequired allowedRoles={allowedLinkRecordRoles}>
@@ -60,12 +54,15 @@ const EMSLinkRecordButton: React.FC<
                   id: record.id,
                   updates: {
                     crash_match_status: "unmatched_by_manual_qa",
+                    crash_pk: null,
+                    person_id: null,
+                    matched_crash_pks: null,
                   },
                 });
                 await onSaveCallback();
               }}
             >
-              Set as unmatched
+              Match not found
             </Dropdown.Item>
             <Dropdown.Item>Reset</Dropdown.Item>
           </Dropdown.Menu>

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -5,6 +5,7 @@ import { RowActionComponentProps } from "@/components/RelatedRecordTable";
 import { FaLink } from "react-icons/fa6";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import AlignedLabel from "@/components/AlignedLabel";
+import { useMutation } from "@/utils/graphql";
 
 const allowedLinkRecordRoles = ["vz-admin", "editor"];
 
@@ -15,13 +16,15 @@ export interface EMSLinkRecordButtonProps extends Record<string, unknown> {
 
 const EMSLinkRecordButton: React.FC<
   RowActionComponentProps<EMSPatientCareRecord, EMSLinkRecordButtonProps>
-> = ({ record, additionalProps }) => {
+> = ({ record, additionalProps, mutation, onSaveCallback }) => {
   const isLinkingInProgress = !!additionalProps?.selectedEmsPcr;
   const isLinkingThisRecord =
     additionalProps?.selectedEmsPcr &&
     record.id === additionalProps?.selectedEmsPcr.id;
 
   const isRecordAlreadyLinked = !!record.person_id;
+
+  const { mutate: setRecordManualUnmatched } = useMutation(mutation);
 
   if (isRecordAlreadyLinked) {
     return null;
@@ -51,7 +54,19 @@ const EMSLinkRecordButton: React.FC<
             <FaEllipsisVertical />
           </Dropdown.Toggle>
           <Dropdown.Menu popperConfig={{ strategy: "fixed" }}>
-            <Dropdown.Item>Set as unmatched</Dropdown.Item>
+            <Dropdown.Item
+              onClick={async () => {
+                await setRecordManualUnmatched({
+                  id: record.id,
+                  updates: {
+                    crash_match_status: "unmatched_by_manual_qa",
+                  },
+                });
+                await onSaveCallback();
+              }}
+            >
+              Set as unmatched
+            </Dropdown.Item>
             <Dropdown.Item>Reset</Dropdown.Item>
           </Dropdown.Menu>
         </Dropdown>

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -44,7 +44,11 @@ const EMSLinkRecordButton: React.FC<
           {isLinkingThisRecord && <span>Cancel</span>}
         </Button>
         <Dropdown className="ms-1">
-          <Dropdown.Toggle variant="outline-primary" size="sm">
+          <Dropdown.Toggle
+            className="hide-toggle"
+            variant="outline-primary"
+            size="sm"
+          >
             <FaEllipsisVertical />
           </Dropdown.Toggle>
           <Dropdown.Menu renderOnMount popperConfig={{ strategy: "fixed" }}>
@@ -56,7 +60,6 @@ const EMSLinkRecordButton: React.FC<
                     crash_match_status: "unmatched_by_manual_qa",
                     crash_pk: null,
                     person_id: null,
-                    matched_crash_pks: null,
                   },
                 });
                 await onSaveCallback();

--- a/editor/configs/emsColumns.tsx
+++ b/editor/configs/emsColumns.tsx
@@ -17,6 +17,8 @@ const formatCrashMatchStatus = (value: unknown) => {
       return "Matched automatically";
     case "matched_by_manual_qa":
       return "Matched by review/QA";
+    case "unmatched_by_manual_qa":
+      return "Unmatched by review/QA";
     default:
       return "";
   }

--- a/editor/configs/emsListViewTable.ts
+++ b/editor/configs/emsListViewTable.ts
@@ -221,6 +221,20 @@ const emsListViewFilterCards: FilterGroup[] = [
           },
         ],
       },
+      {
+        id: "unmatched_by_manual_qa",
+        label: "Unmatched by review/QA",
+        groupOperator: "_and",
+        enabled: false,
+        filters: [
+          {
+            id: "unmatched_by_manual_qa",
+            column: "crash_match_status",
+            operator: "_eq",
+            value: "unmatched_by_manual_qa",
+          },
+        ],
+      },
     ],
   },
 ];

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -143,7 +143,10 @@ export const UPDATE_EMS_INCIDENT_CRASH_AND_PERSON = gql`
 `;
 
 export const UPDATE_EMS_INCIDENT = gql`
-  mutation update_crashes($id: Int!, $updates: ems__incidents_set_input) {
+  mutation UpdateEMSIncidentGeneral(
+    $id: Int!
+    $updates: ems__incidents_set_input
+  ) {
     update_ems__incidents(where: { id: { _eq: $id } }, _set: $updates) {
       affected_rows
       returning {

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -129,7 +129,7 @@ export const GET_MATCHING_PEOPLE = gql`
 `;
 
 export const UPDATE_EMS_INCIDENT_CRASH_AND_PERSON = gql`
-  mutation UpdateEMSIncident($id: Int!, $person_id: Int!) {
+  mutation UpdateEMSPersonCrashStatus($id: Int!, $person_id: Int!) {
     update_ems__incidents(
       where: { id: { _eq: $id } }
       _set: {
@@ -143,10 +143,7 @@ export const UPDATE_EMS_INCIDENT_CRASH_AND_PERSON = gql`
 `;
 
 export const UPDATE_EMS_INCIDENT = gql`
-  mutation UpdateEMSIncidentGeneral(
-    $id: Int!
-    $updates: ems__incidents_set_input
-  ) {
+  mutation UpdateEMSIncident($id: Int!, $updates: ems__incidents_set_input) {
     update_ems__incidents(where: { id: { _eq: $id } }, _set: $updates) {
       affected_rows
       returning {

--- a/editor/styles/global.scss
+++ b/editor/styles/global.scss
@@ -59,6 +59,7 @@ $dark: $night;
   border-color: #495057 !important;
   // bs tertiary background
   background-color: rgb(42.5, 47.5, 52.5);
+
   &:hover,
   &:active,
   &:focus,
@@ -72,6 +73,7 @@ $dark: $night;
   background-color: $light !important;
   border-color: $light !important;
   color: #000;
+
   &:hover,
   &:active,
   &:focus,
@@ -182,8 +184,9 @@ to make sure it renders on top is a common fix */
 }
 
 /* Hide down arrow from dropdown toggle button */
-.dropdown-toggle.hide-toggle::after {
-  content: none !important;
+.dropdown-toggle::after {
+  display: none !important;
 }
+
 
 @import "bootstrap/scss/bootstrap.scss";

--- a/editor/styles/global.scss
+++ b/editor/styles/global.scss
@@ -184,8 +184,8 @@ to make sure it renders on top is a common fix */
 }
 
 /* Hide down arrow from dropdown toggle button */
-.dropdown-toggle::after {
-  display: none !important;
+.dropdown-toggle.hide-toggle::after {
+  content: none !important;
 }
 
 


### PR DESCRIPTION
## Associated issues
Closes https://github.com/issues/assigned?issue=cityofaustin%7Catd-data-tech%7C22299

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local

**Steps to test:**
1. Apply migrations and metadata
2. Test going to various EMS incidents and using the falafel menu to update the record to Unmatched by review/QA by clicking "Match not found"
3. If all records in the incident are set to this, the associated people list should not return anything
4. The reset button doesnt do anything for now
5. Test filtering the crash match status to Unmatched by review/QA in the EMS list page

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
