### PR TITLE
v2.12.1 - Update crash-EMS trigger

### DIFF
--- a/database/migrations/default/1747404534187_patch_crash_ems_trigger/down.sql
+++ b/database/migrations/default/1747404534187_patch_crash_ems_trigger/down.sql
@@ -1,0 +1,111 @@
+-- Updating this trigger to always keep the matched_crash_pks up to date with automatic matching results
+-- regardless of crash match status
+CREATE OR REPLACE FUNCTION public.update_crash_ems_match()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_ems RECORD;
+    ems_record RECORD;
+    match_count INTEGER;
+    matched_crash_ids INTEGER[];
+    meters_threshold INTEGER := 1200;
+    -- 30 min threshold equates to a 60 minute window (+/- 30 minutes of crash timestamp)
+    time_threshold INTERVAL := '30 minutes';
+BEGIN
+    -- Find all EMS records near the crash location + time
+    FOR matching_ems IN (
+        SELECT 
+            e.id,
+            e.incident_received_datetime,
+            e.geometry,
+            e.crash_match_status
+        FROM 
+            ems__incidents e
+        WHERE
+            e.incident_received_datetime  >= (NEW.crash_timestamp - time_threshold)
+            AND e.incident_received_datetime  <= (NEW.crash_timestamp + time_threshold)
+            AND e.geometry IS NOT NULL
+            AND NEW.position IS NOT NULL
+            AND ST_DWithin(e.geometry::geography, NEW.position::geography, meters_threshold)
+    ) LOOP
+        -- Find all crashes which match this EMS record location + time
+        SELECT 
+            ARRAY(
+                SELECT c.id
+                FROM crashes c
+                WHERE 
+                    c.is_deleted = false
+                    and not c.is_temp_record
+                    AND matching_ems.incident_received_datetime  >= (c.crash_timestamp - time_threshold)
+                    AND matching_ems.incident_received_datetime  <= (c.crash_timestamp + time_threshold)
+                    AND c.position IS NOT NULL
+                    AND ST_DWithin(matching_ems.geometry::geography, c.position::geography, meters_threshold)
+            ) INTO matched_crash_ids;
+            
+        -- Get the count from the array length (handling when array_length is null as 0)
+        SELECT COALESCE(array_length(matched_crash_ids, 1), 0) INTO match_count;
+
+        -- For records that have been manually matched we want to only update the automated match column
+        IF matching_ems.crash_match_status === 'matched_by_manual_qa' THEN
+          IF match_count = 0 THEN
+            UPDATE ems__incidents 
+            SET matched_crash_pks = NULL
+            WHERE id = matching_ems.id;
+          ELSE 
+            -- if the match count is more than one we will update the matched_crash_pks
+            UPDATE ems__incidents 
+            SET matched_crash_pks = matched_crash_ids
+            WHERE id = matching_ems.id;
+          END IF;
+        -- If the record has not been manually matched
+        ELSE
+          IF match_count = 0 THEN
+              UPDATE ems__incidents 
+              SET crash_pk = NULL,
+                  crash_match_status = 'unmatched',
+                  matched_crash_pks = NULL
+              WHERE id = matching_ems.id;
+          ELSIF match_count = 1 THEN
+              -- this EMS record is only matched to one crash - we can assign the crash_pk and matched_crash_pks
+              UPDATE ems__incidents 
+              SET crash_pk = NEW.id,
+                  crash_match_status = 'matched_by_automation',
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          ELSE
+              -- multiple matching crashes found - can assign the matched_crash_pks but not crash_pk
+              UPDATE ems__incidents 
+              SET crash_match_status = 'multiple_matches_by_automation',
+                  crash_pk = NULL,
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          END IF;
+        END IF;
+    END LOOP;
+
+    --
+    -- nullify the crash_pk for EMS records that no longer match this crash
+    --
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE ems__incidents
+        SET crash_pk = NULL,
+            crash_match_status = 'unmatched',
+            matched_crash_pks = NULL
+        WHERE crash_pk = NEW.id
+          AND (
+              incident_received_datetime  < (NEW.crash_timestamp - time_threshold)
+              OR incident_received_datetime  > (NEW.crash_timestamp + time_threshold)
+              OR geometry IS NULL
+              OR NEW.position IS NULL
+              OR NEW.is_temp_record is TRUE
+              or NEW.is_deleted is TRUE
+              OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+          )
+          AND 
+            -- ignore manual qa matches: these should not be modified
+            crash_match_status != 'matched_by_manual_qa';
+    END IF;
+    RETURN NEW;
+END;
+$function$;

--- a/database/migrations/default/1747404534187_patch_crash_ems_trigger/up.sql
+++ b/database/migrations/default/1747404534187_patch_crash_ems_trigger/up.sql
@@ -1,0 +1,118 @@
+-- Updating this trigger to always keep the matched_crash_pks up to date with automatic matching results
+-- regardless of crash match status
+CREATE OR REPLACE FUNCTION public.update_crash_ems_match()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_ems RECORD;
+    ems_record RECORD;
+    match_count INTEGER;
+    matched_crash_ids INTEGER[];
+    meters_threshold INTEGER := 1200;
+    -- 30 min threshold equates to a 60 minute window (+/- 30 minutes of crash timestamp)
+    time_threshold INTERVAL := '30 minutes';
+BEGIN
+    -- Find all EMS records near the crash location + time
+    FOR matching_ems IN (
+        SELECT 
+            e.id,
+            e.incident_received_datetime,
+            e.geometry,
+            e.crash_match_status
+        FROM 
+            ems__incidents e
+        WHERE
+            e.incident_received_datetime  >= (NEW.crash_timestamp - time_threshold)
+            AND e.incident_received_datetime  <= (NEW.crash_timestamp + time_threshold)
+            AND e.geometry IS NOT NULL
+            AND NEW.position IS NOT NULL
+            AND ST_DWithin(e.geometry::geography, NEW.position::geography, meters_threshold)
+    ) LOOP
+        -- Find all crashes which match this EMS record location + time
+        SELECT 
+            ARRAY(
+                SELECT c.id
+                FROM crashes c
+                WHERE 
+                    c.is_deleted = false
+                    and not c.is_temp_record
+                    AND matching_ems.incident_received_datetime  >= (c.crash_timestamp - time_threshold)
+                    AND matching_ems.incident_received_datetime  <= (c.crash_timestamp + time_threshold)
+                    AND c.position IS NOT NULL
+                    AND ST_DWithin(matching_ems.geometry::geography, c.position::geography, meters_threshold)
+            ) INTO matched_crash_ids;
+            
+        -- Get the count from the array length (handling when array_length is null as 0)
+        SELECT COALESCE(array_length(matched_crash_ids, 1), 0) INTO match_count;
+
+        -- For records that have been manually matched we want to only update the matched_crash_pks column
+        IF matching_ems.crash_match_status = 'matched_by_manual_qa' THEN
+            UPDATE ems__incidents 
+            SET matched_crash_pks = matched_crash_ids
+            WHERE id = matching_ems.id;
+        -- If the record has not been manually matched
+        ELSE
+          IF match_count = 0 THEN
+              UPDATE ems__incidents 
+              SET crash_pk = NULL,
+                  crash_match_status = 'unmatched',
+                  matched_crash_pks = NULL
+              WHERE id = matching_ems.id;
+          ELSIF match_count = 1 THEN
+              -- this EMS record is only matched to one crash - we can assign the crash_pk and matched_crash_pks
+              UPDATE ems__incidents 
+              SET crash_pk = NEW.id,
+                  crash_match_status = 'matched_by_automation',
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          ELSE
+              -- multiple matching crashes found - can assign the matched_crash_pks but not crash_pk
+              UPDATE ems__incidents 
+              SET crash_match_status = 'multiple_matches_by_automation',
+                  crash_pk = NULL,
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          END IF;
+        END IF;
+    END LOOP;
+
+    IF TG_OP = 'UPDATE' THEN
+        -- update incidents which have not been manually matched
+        UPDATE ems__incidents
+        SET crash_pk = NULL,
+            crash_match_status = 'unmatched',
+            matched_crash_pks = NULL
+        WHERE crash_pk = NEW.id
+          AND (
+              incident_received_datetime  < (NEW.crash_timestamp - time_threshold)
+              OR incident_received_datetime  > (NEW.crash_timestamp + time_threshold)
+              OR geometry IS NULL
+              OR NEW.position IS NULL
+              OR NEW.is_temp_record is TRUE
+              or NEW.is_deleted is TRUE
+              OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+          )
+          AND 
+            -- ignore manual qa matches
+            crash_match_status != 'matched_by_manual_qa';
+       
+        -- update the matched_crash_pks column only for manually qa matches
+        UPDATE ems__incidents
+        SET matched_crash_pks = NULL
+        WHERE crash_pk = NEW.id
+          AND (
+              incident_received_datetime  < (NEW.crash_timestamp - time_threshold)
+              OR incident_received_datetime  > (NEW.crash_timestamp + time_threshold)
+              OR geometry IS NULL
+              OR NEW.position IS NULL
+              OR NEW.is_temp_record is TRUE
+              or NEW.is_deleted is TRUE
+              OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+          )
+          AND 
+            crash_match_status = 'matched_by_manual_qa';
+    END IF;
+    RETURN NEW;
+END;
+$function$;

--- a/editor/package-lock.json
+++ b/editor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vision-zero-editor",
-  "version": "2.12",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vision-zero-editor",
-      "version": "2.12",
+      "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
         "@auth0/auth0-react": "^2.3.0",

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vision-zero-editor",
-  "version": "2.12",
+  "version": "2.12.1",
   "description": "ATD Vision Zero Editor",
   "author": "TPW Data & Technology Services",
   "license": "MIT",

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viewer",
-  "version": "2.8.1",
+  "version": "2.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "viewer",
-      "version": "2.8.1",
+      "version": "2.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewer",
-  "version": "2.11",
+  "version": "2.12.1",
   "homepage": "/viewer",
   "description": "Vision Zero Viewer",
   "author": "Austin Transportation & Public Works - Data & Technology Services",


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/22612

I will PR this against prod as well once we have approvals.

## Testing

**URL to test:** Local

1. Apply migrations and metadata
2. Visit this crash's details: `http://localhost:3002/editor/crashes/17357278`
3. Scroll down to **EMS Patient care** and observe that there is a single EMS record with status of **Matched automatically**
4. Edit the crash's **Longitude** to be `-98.12642144`. Scroll down to the EMS table and notice that there are no EMS records listed.
5. Edit crash's **Longitude** back to the original value of `-97.676720393005`. Notice that the matched EMS record is listed in the EMS table. Use it's hyperlinked incident # to visit the incident details page.
6. Use the match UI to match the EMS record to any person record. Notice that it's status changes to **Matched by review/QA**
7. Navigate back to the crash details page, and again edit the longitude to  `-98.12642144`. Notice that the EMS record remains listed in the table.
8. Navigate back to the EMS incident details page, and use the falafel menu to "Reset" the record's status.
9. Notice that the EMS record now has a status of **Unmatched**
10. Finally, go back to the crash details and once again restore the crash to it's original **Longitude**: `-97.676720393005`. Notice that the EMS record is again listed in the table with a status of **Matched automatically**

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
