### PR TITLE
Viewer: Update the "By Population" chart 

### DIFF
--- a/viewer/src/Components/Popover/popoverConfig.js
+++ b/viewer/src/Components/Popover/popoverConfig.js
@@ -1,4 +1,3 @@
-import React from "react";
 import raceEthnicityTable2018 from "./raceEthnicityTable2018.png";
 import { popEsts } from "../../constants/popEsts";
 

--- a/viewer/src/Components/Popover/popoverConfig.js
+++ b/viewer/src/Components/Popover/popoverConfig.js
@@ -1,3 +1,4 @@
+import React from "react";
 import raceEthnicityTable2018 from "./raceEthnicityTable2018.png";
 import { popEsts } from "../../constants/popEsts";
 

--- a/viewer/src/constants/popEsts.js
+++ b/viewer/src/constants/popEsts.js
@@ -1,19 +1,19 @@
 export const popEsts = {
   years: {
-    2026: 1040252,
-    2025: 1023982,
-    2024: 1007643, 
-    2023: 987508,
-    2022: 960915,
-    2021: 951989,
-    2020: 943549,
-    2019: 924887,
-    2018: 912041,
-    2017: 898677,
-    2016: 881422,
+    2026: 1074501,
+    2025: 1061233,
+    2024: 1046493,
+    2023: 1030277,
+    2022: 1015470,
+    2021: 1003160,
+    2020: 987722,
+    2019: 971512,
+    2018: 954138,
+    2017: 936238,
+    2016: 913245,
   },
   sourceURL:
-    "https://demographics-austin.hub.arcgis.com/documents/27bd25c8afff4017a66cd4c467893c3f/explore",
+    "https://demographics-austin.hub.arcgis.com/documents/d00bff21b4ec4165941664709ce6a348/about",
   sourceString:
-    "City of Austin Full Purpose Population figures. Lila Valencia, City Demographer, Planning Department, City of Austin.  Based on data accessed in November, 2023."
+    "Demographics & Data Division, Planning Department, City of Austin. Based on data accessed in May 2025.",
 };


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/22544

While checking my updates, it stood out to me that we only show the last 4 years on this chart when every other chart has 5 years, but I am assuming it was to show the final ratio and not have it tick up throughout the year. 

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-1796--atd-vzv-staging.netlify.app/

**Steps to test:**

Scroll down to the bottom to find the "By Population" card and click the info icon. Compare to the information in prod. 



---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
