### PR TITLE
Throw an error if DB replication fails

### DIFF
--- a/database/snapshots/.gitignore
+++ b/database/snapshots/.gitignore
@@ -1,2 +1,3 @@
 *.sql
 *.error
+*.in_progress

--- a/database/snapshots/.gitignore
+++ b/database/snapshots/.gitignore
@@ -1,1 +1,2 @@
 *.sql
+*.error

--- a/vision-zero
+++ b/vision-zero
@@ -55,48 +55,48 @@ def checkDockerComposeAvailability():
 
 def doCommand(args):
     if args.command == "build":
-        buildTools(args)
+        buildTools()
     elif args.command == "local-stack-up":
-        dbUp(args)
-        graphqlEngineUp(args)
-        cr3UserApiUp(args)
+        dbUp()
+        graphqlEngineUp()
+        cr3UserApiUp()
     elif args.command == "local-stack-down":
-        cr3UserApiDown(args)
+        cr3UserApiDown()
         graphqlEngineDown(args)
         dbDown(args)
     elif args.command == "db-up":
-        dbUp(args)
+        dbUp()
     elif args.command == "db-down":
         dbDown(args)
     elif args.command == "graphql-engine-up":
-        dbUp(args)
-        graphqlEngineUp(args)
+        dbUp()
+        graphqlEngineUp()
     elif args.command == "graphql-engine-down":
         graphqlEngineDown(args)
     elif args.command == "api-up":
-        cr3UserApiUp(args)
+        cr3UserApiUp()
     elif args.command == "api-down":
-        cr3UserApiDown(args)
+        cr3UserApiDown()
     elif args.command == "hasura-console":
-        hasuraConsole(args)
+        hasuraConsole()
     elif args.command == "psql":
-        psql(args)
+        psql()
     elif args.command == "tools-shell":
-        dbUp(args)
-        toolsShell(args)
+        dbUp()
+        toolsShell()
     elif args.command == "stop":
-        stop(args)
+        stop()
     elif args.command == "replicate-db":
-        dbUp(args)
+        dbUp()
         replicateDb(args)
     elif args.command == "dump-local-db":
-        dumpLocalDb(args)
+        dumpLocalDb()
     elif args.command == "remove-snapshots":
-        removeSnapshots(args)
+        removeSnapshots()
 
 
 ## function to list the files in a directory and delete them
-def removeSnapshots(args):
+def removeSnapshots():
     print("🗑️  Removing snapshots")
     for f in os.listdir("database/snapshots/"):
         if not f.endswith(".sql"):
@@ -187,8 +187,18 @@ def replicateDb(args):
             print("This can take up to 15 minutes.")
         print(" ".join(replicate_runner_command) + " " + " ".join(replicate_command))
         snapshot = open(snapshotFQP, "w")
-        subprocess.run(replicate_runner_command + replicate_command, stdout=snapshot)
+        result = subprocess.run(
+            replicate_runner_command + replicate_command, stdout=snapshot
+        )
         snapshot.close()
+
+        if result.returncode != 0:
+            print(f"❌ pg_dump failed with return code {result.returncode}")
+            print(f"Error output: {result.stderr}")
+            os.remove(snapshotFQP)  # Remove the incomplete file
+            exit(1)
+        else:
+            print("✅ Database dump completed successfully")
 
     drop_database_command = [
         "psql",
@@ -213,12 +223,18 @@ def replicateDb(args):
 
     print("️🏗️ Loading the database with snapshot")
     print(" ".join(postgres_db_runner_command) + " " + " ".join(populate_command))
-    subprocess.run(populate_runner_command + populate_command)
+    result = subprocess.run(populate_runner_command + populate_command)
+    if result.returncode != 0:
+        print(
+            f"❌ Failed to load database from snapshot: return code {result.returncode}"
+        )
+        print(f"Error output: {result.stderr}")
+        exit(1)
 
-    graphqlEngineUp(args)
+    graphqlEngineUp()
 
 
-def dumpLocalDb(args):
+def dumpLocalDb():
     print("️Dumping local database")
     today = datetime.now().strftime("%Y-%m-%d-%H-%M:%S")
 
@@ -247,12 +263,12 @@ def dumpLocalDb(args):
         "--if-exists",
     ]
 
-    dump = open("database/dumps/visionzero_" + today + ".sql", "w")
+    dump = open("database/dumps/visionzero_local_" + today + ".sql", "w")
     subprocess.run(dump_runner_command + dump_command, stdout=dump)
     dump.close()
 
 
-def psql(args):
+def psql():
     # fmt: off
     db_tools_runner_command = docker_compose_invocation + [
         "-f", "docker-compose.yml", 
@@ -270,7 +286,7 @@ def psql(args):
     subprocess.run(db_tools_runner_command + ["psql"])
 
 
-def buildTools(args):
+def buildTools():
     print("🛠️  Rebuilding images with --no-cache -q")
     subprocess.run(
         docker_compose_invocation
@@ -283,7 +299,7 @@ def buildTools(args):
     )
 
 
-def dbUp(args):
+def dbUp():
     print("🛢️  Starting database")
     subprocess.run(
         docker_compose_invocation
@@ -315,7 +331,7 @@ def dbDown(args):
     time.sleep(5)
 
 
-def graphqlEngineUp(args):
+def graphqlEngineUp():
     print("🚀  Starting GraphQL Engine")
     subprocess.run(
         docker_compose_invocation
@@ -332,7 +348,7 @@ def graphqlEngineUp(args):
     print("You can run './vision-zero hasura-console' to open the console.")
 
 
-def cr3UserApiUp(args):
+def cr3UserApiUp():
     print("🚀  Starting Flask API")
     subprocess.run(
         docker_compose_invocation
@@ -348,7 +364,7 @@ def cr3UserApiUp(args):
     print("🚀  CR3 / User flask API started.")
 
 
-def cr3UserApiDown(args):
+def cr3UserApiDown():
     print("🛑 Stopping Flask API")
     subprocess.run(
         docker_compose_invocation
@@ -363,7 +379,7 @@ def cr3UserApiDown(args):
     print("🚀  CR3 / User flask API stopped.")
 
 
-def hasuraConsole(args):
+def hasuraConsole():
     print("🚀  Opening Hasura console")
     try:
         subprocess.call(
@@ -387,7 +403,7 @@ def graphqlEngineDown(args):
     subprocess.run(["docker", "ps"])
 
 
-def toolsShell(args):
+def toolsShell():
     print("🐚  Starting tools shell")
 
     # fmt: off
@@ -407,7 +423,7 @@ def toolsShell(args):
     subprocess.run(tool_runner_command + shell_command)
 
 
-def stop(args):
+def stop():
     print("🛑  Stopping containers")
     subprocess.run(
         docker_compose_invocation

--- a/vision-zero
+++ b/vision-zero
@@ -167,18 +167,6 @@ def replicateDb(args):
         "postgis",
     ]
     
-    populate_runner_command = docker_compose_invocation + [
-        "-f", "docker-compose.yml", 
-        "run",
-        "--rm",
-        "-e", "PGHOST=" + 'postgis',
-        "-e", "PGUSER=" + os.environ["POSTGRES_USER"],
-        "-e", "PGPASSWORD=" + os.environ["POSTGRES_PASSWORD"],
-        "-e", "PGDATABASE=postgres",
-        "postgis",
-    ]
-    # fmt: on
-
     if not (os.path.exists(snapshotFQP)):
         print("️🗄  Downloading remote database")
         if args.include_change_log_data:
@@ -187,9 +175,16 @@ def replicateDb(args):
             print("This can take up to 15 minutes.")
         print(" ".join(replicate_runner_command) + " " + " ".join(replicate_command))
         snapshot = open(snapshotFQP, "w")
-        result = subprocess.run(
-            replicate_runner_command + replicate_command, stdout=snapshot
-        )
+
+        try:
+            result = subprocess.run(
+                replicate_runner_command + replicate_command,
+                stdout=snapshot,
+            )
+        except Exception as e:
+            os.remove(snapshotFQP)  # Remove the incomplete file
+            raise e
+
         snapshot.close()
 
         if result.returncode != 0:
@@ -223,7 +218,7 @@ def replicateDb(args):
 
     print("️🏗️ Loading the database with snapshot")
     print(" ".join(postgres_db_runner_command) + " " + " ".join(populate_command))
-    result = subprocess.run(populate_runner_command + populate_command)
+    result = subprocess.run(postgres_db_runner_command + populate_command)
     if result.returncode != 0:
         print(
             f"❌ Failed to load database from snapshot: return code {result.returncode}"
@@ -301,7 +296,7 @@ def buildTools():
 
 def dbUp():
     print("🛢️  Starting database")
-    subprocess.run(
+    result = subprocess.run(
         docker_compose_invocation
         + [
             "-f",
@@ -311,6 +306,10 @@ def dbUp():
             "postgis",
         ]
     )
+    if result.returncode != 0:
+        print(f"❌ database startup failed with return code {result.returncode}")
+        print(f"Error output: {result.stderr}")
+        exit(1)
     subprocess.run(["docker", "ps"])
     time.sleep(5)
 

--- a/vision-zero
+++ b/vision-zero
@@ -258,7 +258,7 @@ def dumpLocalDb():
         "--if-exists",
     ]
 
-    dump = open("database/dumps/visionzero_local_" + today + ".sql", "w")
+    dump = open("database/dumps/visionzero_" + today + ".sql", "w")
     subprocess.run(dump_runner_command + dump_command, stdout=dump)
     dump.close()
 

--- a/vision-zero
+++ b/vision-zero
@@ -62,17 +62,17 @@ def doCommand(args):
         cr3UserApiUp()
     elif args.command == "local-stack-down":
         cr3UserApiDown()
-        graphqlEngineDown(args)
-        dbDown(args)
+        graphqlEngineDown()
+        dbDown()
     elif args.command == "db-up":
         dbUp()
     elif args.command == "db-down":
-        dbDown(args)
+        dbDown()
     elif args.command == "graphql-engine-up":
         dbUp()
         graphqlEngineUp()
     elif args.command == "graphql-engine-down":
-        graphqlEngineDown(args)
+        graphqlEngineDown()
     elif args.command == "api-up":
         cr3UserApiUp()
     elif args.command == "api-down":
@@ -107,7 +107,7 @@ def removeSnapshots():
 
 # def replicateDb(includeChangeLogData=False):
 def replicateDb(args):
-    graphqlEngineDown(args)
+    graphqlEngineDown()
 
     snapshotFilename = ""
     if args.filename:
@@ -126,8 +126,9 @@ def replicateDb(args):
             + ".sql"
         )
 
-    snapshotFQP = "database/snapshots/" + snapshotFilename
-    snapshotFQP_error = snapshotFQP.replace(".sql", ".error")
+    snapshotFQP_complete = "database/snapshots/" + snapshotFilename
+    snapshotFQP_in_progress = snapshotFQP_complete.replace(".sql", ".in_progress")
+    snapshotFQP_error = snapshotFQP_complete.replace(".sql", ".error")
 
     # fmt: off
     replicate_runner_command = docker_compose_invocation + [
@@ -168,14 +169,14 @@ def replicateDb(args):
         "postgis",
     ]
     
-    if not (os.path.exists(snapshotFQP)):
+    if not (os.path.exists(snapshotFQP_in_progress)):
         print("️🗄  Downloading remote database")
         if args.include_change_log_data:
             print("This will take a while, on the order of half an hour.")
         else:
             print("This can take up to 15 minutes.")
         print(" ".join(replicate_runner_command) + " " + " ".join(replicate_command))
-        snapshot = open(snapshotFQP, "w")
+        snapshot = open(snapshotFQP_in_progress, "w")
 
         try:
             result = subprocess.run(
@@ -184,18 +185,19 @@ def replicateDb(args):
             )
         except Exception as e:
             # rename the corrupted snapshot
-            os.rename(snapshotFQP, snapshotFQP_error)
+            os.rename(snapshotFQP_in_progress, snapshotFQP_error)
             raise e
-
-        snapshot.close()
 
         if result.returncode != 0:
             print(f"❌ pg_dump failed with return code {result.returncode}")
             print(f"Error output: {result.stderr}")
             # rename the corrupted snapshot
-            os.rename(snapshotFQP, snapshotFQP_error)
+            os.rename(snapshotFQP_in_progress, snapshotFQP_error)
+            snapshot.close()
             exit(1)
         else:
+            os.rename(snapshotFQP_in_progress, snapshotFQP_complete)
+            snapshot.close()
             print("✅ Database dump completed successfully")
 
     drop_database_command = [
@@ -317,8 +319,8 @@ def dbUp():
     time.sleep(5)
 
 
-def dbDown(args):
-    graphqlEngineDown(args)
+def dbDown():
+    graphqlEngineDown()
     print("🛢️  Stopping database")
     subprocess.run(
         docker_compose_invocation
@@ -391,7 +393,7 @@ def hasuraConsole():
         print("Exited Hasura console")
 
 
-def graphqlEngineDown(args):
+def graphqlEngineDown():
     print("🚀  Stopping GraphQL Engine")
     subprocess.run(
         docker_compose_invocation

--- a/vision-zero
+++ b/vision-zero
@@ -127,6 +127,7 @@ def replicateDb(args):
         )
 
     snapshotFQP = "database/snapshots/" + snapshotFilename
+    snapshotFQP_error = snapshotFQP.replace(".sql", ".error")
 
     # fmt: off
     replicate_runner_command = docker_compose_invocation + [
@@ -182,7 +183,8 @@ def replicateDb(args):
                 stdout=snapshot,
             )
         except Exception as e:
-            os.remove(snapshotFQP)  # Remove the incomplete file
+            # rename the corrupted snapshot
+            os.rename(snapshotFQP, snapshotFQP_error)
             raise e
 
         snapshot.close()
@@ -190,7 +192,8 @@ def replicateDb(args):
         if result.returncode != 0:
             print(f"❌ pg_dump failed with return code {result.returncode}")
             print(f"Error output: {result.stderr}")
-            os.remove(snapshotFQP)  # Remove the incomplete file
+            # rename the corrupted snapshot
+            os.rename(snapshotFQP, snapshotFQP_error)
             exit(1)
         else:
             print("✅ Database dump completed successfully")


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/22791

This update the `vision-zero` helper script to make it more obvious when a replication error occurs.



## Testing

**URL to test:** Local

In the root of this repo, modify your `.env` file by changing the RR database from `vision_zero` to `vision_zero_x`.

```shell
# .env
RR_DATABASE="vision_zero_x"
```

Now try to replicate

```shell
 ./vision-zero replicate-db
```

And confirm that the scrip throws an error. Something like:

```shell
❌ pg_dump failed with return code 1
Error output: None
```

Locate and open the failed snapshot in the `/database/snapshots` directory. It will have the `.error` file extension.

Fix your `.env` so that it's using the correct DB name, and replicate again.

While the snapshot is downloading, browser your `/database/snapshots` directory and observe that the snapshot filename has the extension `.in_progress`.

Once the replication completes, observe the file extension is `.sql` and that the database is working normally.

Finally, test out a few of the other command line options. Definitely test this one:

```shell
./vision-zero local-stack-up
```

### Bonus points

Remove or rename today's working snapshot from your `/database/snapshots` directory. Start a fresh snapshot download with ` ./vision-zero replicate-db`. Then interrupt the process with your keyboard by pressing `ctrl` + `c`. Verify that the incomplete snapshot has the extension `.error`.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
