### PR TITLE
Create EMS -> person match trigger

### DIFF
--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -124,6 +124,7 @@ update_permissions:
   - role: editor
     permission:
       columns:
+        - _match_event_name
         - crash_match_status
         - crash_pk
         - matched_crash_pks
@@ -136,6 +137,7 @@ update_permissions:
   - role: vz-admin
     permission:
       columns:
+        - _match_event_name
         - crash_match_status
         - crash_pk
         - matched_crash_pks

--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -125,11 +125,8 @@ update_permissions:
     permission:
       columns:
         - _match_event_name
-        - crash_match_status
         - crash_pk
-        - matched_crash_pks
         - person_id
-        - person_match_status
         - updated_by
       filter: {}
       check: null
@@ -138,11 +135,8 @@ update_permissions:
     permission:
       columns:
         - _match_event_name
-        - crash_match_status
         - crash_pk
-        - matched_crash_pks
         - person_id
-        - person_match_status
         - updated_by
       filter: {}
       check: null

--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -37,6 +37,7 @@ select_permissions:
         - incident_received_datetime
         - matched_crash_pks
         - matched_non_cr3_case_ids
+        - matched_person_ids
         - mvc_form_position_in_vehicle
         - non_cr3_match_status
         - patient_injry_sev_id
@@ -45,6 +46,7 @@ select_permissions:
         - pcr_patient_race
         - pcr_transport_destination
         - person_id
+        - person_match_status
         - travel_mode
         - unparsed_apd_incident_numbers
         - updated_at
@@ -68,6 +70,7 @@ select_permissions:
         - incident_received_datetime
         - matched_crash_pks
         - matched_non_cr3_case_ids
+        - matched_person_ids
         - mvc_form_position_in_vehicle
         - non_cr3_match_status
         - patient_injry_sev_id
@@ -76,6 +79,7 @@ select_permissions:
         - pcr_patient_race
         - pcr_transport_destination
         - person_id
+        - person_match_status
         - travel_mode
         - unparsed_apd_incident_numbers
         - updated_at
@@ -99,6 +103,7 @@ select_permissions:
         - incident_received_datetime
         - matched_crash_pks
         - matched_non_cr3_case_ids
+        - matched_person_ids
         - mvc_form_position_in_vehicle
         - non_cr3_match_status
         - patient_injry_sev_id
@@ -107,6 +112,7 @@ select_permissions:
         - pcr_patient_race
         - pcr_transport_destination
         - person_id
+        - person_match_status
         - travel_mode
         - unparsed_apd_incident_numbers
         - updated_at
@@ -122,6 +128,7 @@ update_permissions:
         - crash_pk
         - matched_crash_pks
         - person_id
+        - person_match_status
         - updated_by
       filter: {}
       check: null
@@ -133,6 +140,7 @@ update_permissions:
         - crash_pk
         - matched_crash_pks
         - person_id
+        - person_match_status
         - updated_by
       filter: {}
       check: null

--- a/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
@@ -19,6 +19,36 @@ BEGIN
 END;
 $function$;
 
+CREATE OR REPLACE FUNCTION public.ems_update_incident_crash_pk()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_person_record RECORD;
+BEGIN
+    IF NEW.person_id is null
+        THEN return null;
+    END IF;
+    -- Find matching person record
+    SELECT id, crash_pk INTO matching_person_record 
+    FROM people_list_view 
+    WHERE id = NEW.person_id;
+    
+    -- Update crash_pk of related EMS if not already matched to a person
+    UPDATE ems__incidents 
+    SET 
+        crash_pk = matching_person_record.crash_pk,
+        updated_by = NEW.updated_by,
+        crash_match_status = 'matched_by_manual_qa'
+    WHERE
+        id != NEW.id
+        AND incident_number = NEW.incident_number
+        AND crash_pk is distinct from matching_person_record.crash_pk
+        AND person_id IS NULL;
+    RETURN null;
+END;
+$function$;
+
 --
 -- add person_match_status column
 --

--- a/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE FUNCTION public.ems_update_person_crash_id()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_person_record RECORD;
+BEGIN
+    IF NEW.person_id is null
+        THEN return NEW;
+    END IF;
+    -- Find matching person record
+    SELECT id, crash_pk INTO matching_person_record 
+    FROM people_list_view 
+    WHERE id = NEW.person_id;
+
+    NEW.crash_pk = matching_person_record.crash_pk;
+    NEW.crash_match_status = 'matched_by_manual_qa';
+    return NEW;
+END;
+$function$;
+
+--
+-- add person_match_status column
+--
+alter table ems__incidents drop column person_match_status, drop matched_person_ids;
+
+drop function if exists ems_update_person_crash_id;
+

--- a/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION public.ems_update_person_crash_id()
- RETURNS trigger
- LANGUAGE plpgsql
+RETURNS trigger
+LANGUAGE plpgsql
 AS $function$
 DECLARE
     matching_person_record RECORD;
@@ -20,8 +20,8 @@ END;
 $function$;
 
 CREATE OR REPLACE FUNCTION public.ems_update_incident_crash_pk()
- RETURNS trigger
- LANGUAGE plpgsql
+RETURNS trigger
+LANGUAGE plpgsql
 AS $function$
 DECLARE
     matching_person_record RECORD;
@@ -49,10 +49,180 @@ BEGIN
 END;
 $function$;
 
---
--- add person_match_status column
---
-alter table ems__incidents drop column person_match_status, drop matched_person_ids;
+CREATE OR REPLACE FUNCTION public.update_crash_ems_match()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_ems RECORD;
+    ems_record RECORD;
+    ems_cleanup_count INTEGER;
+    match_count INTEGER;
+    matched_crash_ids INTEGER[];
+    updated_matched_crash_ids INTEGER[];
+    remaining_crash_ids_count INTEGER;
+    meters_threshold INTEGER := 1200;
+    -- 30 min threshold equates to a 60 minute window (+/- 30 minutes of crash timestamp)
+    time_threshold INTERVAL := '30 minutes';
+BEGIN
+    -- Find all EMS records near the crash location + time
+    FOR matching_ems IN (
+        SELECT 
+            e.id,
+            e.incident_received_datetime,
+            e.geometry,
+            e.crash_match_status
+        FROM 
+            ems__incidents e
+        WHERE
+            e.incident_received_datetime  >= (NEW.crash_timestamp - time_threshold)
+            AND e.incident_received_datetime  <= (NEW.crash_timestamp + time_threshold)
+            AND e.geometry IS NOT NULL
+            AND NEW.position IS NOT NULL
+            AND ST_DWithin(e.geometry::geography, NEW.position::geography, meters_threshold)
+    ) LOOP
+        -- Find all crashes which match this EMS record location + time
+        SELECT 
+        COALESCE(array_agg(c.id), ARRAY[]::integer[])
+        FROM crashes c
+        WHERE 
+            c.is_deleted = false
+            and not c.is_temp_record
+            AND matching_ems.incident_received_datetime  >= (c.crash_timestamp - time_threshold)
+            AND matching_ems.incident_received_datetime  <= (c.crash_timestamp + time_threshold)
+            AND c.position IS NOT NULL
+            AND ST_DWithin(matching_ems.geometry::geography, c.position::geography, meters_threshold)
+        INTO matched_crash_ids;
+            
+        -- Get the count from the array length (handling when array_length is null as 0)
+        SELECT COALESCE(array_length(matched_crash_ids, 1), 0) INTO match_count;
 
-drop function if exists ems_update_person_crash_id;
+        -- For records that have been manually matched we want to only update the matched_crash_pks column
+        IF matching_ems.crash_match_status = 'matched_by_manual_qa' THEN
+            UPDATE ems__incidents 
+            SET matched_crash_pks = matched_crash_ids
+            WHERE id = matching_ems.id;
+        -- If the record has not been manually matched
+        ELSE
+          IF match_count = 0 THEN
+              UPDATE ems__incidents 
+              SET crash_pk = NULL,
+                  crash_match_status = 'unmatched',
+                  matched_crash_pks = NULL
+              WHERE id = matching_ems.id;
+          ELSIF match_count = 1 THEN
+              -- this EMS record is only matched to one crash - we can assign the crash_pk and matched_crash_pks
+              UPDATE ems__incidents 
+              SET crash_pk = NEW.id,
+                  crash_match_status = 'matched_by_automation',
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          ELSE
+              -- multiple matching crashes found - can assign the matched_crash_pks but not crash_pk
+              UPDATE ems__incidents 
+              SET crash_match_status = 'multiple_matches_by_automation',
+                  crash_pk = NULL,
+                  matched_crash_pks = matched_crash_ids
+              WHERE id = matching_ems.id;
+          END IF;
+        END IF;
+    END LOOP;
+
+    IF TG_OP = 'UPDATE' THEN
+        --
+        -- Check if there are any EMS records that reference this crash
+        --
+        SELECT COUNT(*) INTO ems_cleanup_count
+        FROM ems__incidents 
+        WHERE NEW.id = ANY(matched_crash_pks);
+
+        raise debug '% EMS records need to be checked for possible update', ems_cleanup_count;
+        
+        IF ems_cleanup_count > 0 THEN
+            --
+            -- Check for EMS records that were previously matched to this crash but should no longer be
+            --
+            FOR ems_record IN (
+                SELECT 
+                    id, 
+                    incident_number,
+                    matched_crash_pks, 
+                    crash_match_status,
+                    crash_pk,
+                    incident_received_datetime,
+                    geometry
+                FROM ems__incidents
+                WHERE NEW.id = ANY(matched_crash_pks)
+                    --
+                    -- If the incident matches any of these conditions, it should NOT be matched
+                    -- to this crash
+                    --
+                    AND (
+                        incident_received_datetime < (NEW.crash_timestamp - time_threshold)
+                        OR incident_received_datetime > (NEW.crash_timestamp + time_threshold)
+                        OR geometry IS NULL
+                        OR NEW.position IS NULL
+                        OR NEW.is_deleted IS TRUE
+                        OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+                    )
+            )
+            LOOP
+                raise debug 'Handling cleanup for EMS incident # %, ID %', ems_record.incident_number, ems_record.id;
+
+                -- Remove the this crash ID from the EMS record's matched_crash_pks
+                SELECT array_remove(ems_record.matched_crash_pks, NEW.id) INTO updated_matched_crash_ids;
+                SELECT COALESCE(array_length(updated_matched_crash_ids, 1), 0) INTO remaining_crash_ids_count;
+
+                raise debug 'remaining_crash_ids_count: %', remaining_crash_ids_count;
+                raise debug 'updated_matched_crash_ids: %', updated_matched_crash_ids;
+                --
+                -- Update the EMS records based on remaining match count
+                --
+                IF ems_record.crash_match_status = 'matched_by_manual_qa' THEN
+                    -- For manually matched records, only update the crash ID array
+                    raise debug 'Updating matched_crash_pks for manually matched EMS incident # %, ID % to %', ems_record.incident_number, ems_record.id, NULLIF(updated_matched_crash_ids, '{}');
+                    UPDATE ems__incidents
+                    SET matched_crash_pks = NULLIF(updated_matched_crash_ids, '{}')
+                    WHERE id = ems_record.id;
+                ELSIF remaining_crash_ids_count = 0 THEN
+                    -- No other crashes matched to this EMS record
+                    raise debug 'Updating EMS incident # %, ID % as `unmatched`', ems_record.incident_number, ems_record.id;
+                    UPDATE ems__incidents 
+                    SET crash_pk = NULL,
+                        crash_match_status = 'unmatched',
+                        matched_crash_pks = NULL
+                    WHERE id = ems_record.id;
+                ELSIF remaining_crash_ids_count = 1 THEN
+                    -- One crash remaining: match it to the EMS record
+                    raise debug 'Matching EMS incident # %, ID % to crash ID %', ems_record.incident_number, ems_record.id, updated_matched_crash_ids[1];
+                    UPDATE ems__incidents 
+                    SET crash_pk = updated_matched_crash_ids[1],
+                        crash_match_status = 'matched_by_automation',
+                        matched_crash_pks = updated_matched_crash_ids
+                    WHERE id = ems_record.id;
+                ELSE
+                    -- Multiple crashes matches remaining
+                    raise debug 'Updating matched_crash_pks for EMS incident # %, ID % which still has multiple matches', ems_record.incident_number, ems_record.id;
+                    UPDATE ems__incidents 
+                    SET crash_pk = NULL,
+                        crash_match_status = 'multiple_matches_by_automation',
+                        matched_crash_pks = updated_matched_crash_ids
+                    WHERE id = ems_record.id;
+                END IF;
+            END LOOP;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+
+DROP FUNCTION if exists public.find_matching_person_ids;
+DROP TRIGGER if exists ems_update_handle_record_match_event_trigger on ems__incidents;
+DROP FUNCTION if exists public.ems_update_handle_record_match_event;
+
+ALTER TABLE ems__incidents DROP COLUMN person_match_status,
+DROP COLUMN matched_person_ids,
+DROP COLUMN _match_event_name
+drop constraint check_person_id_crash_pk_dependency;
 

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -115,7 +115,8 @@ BEGIN
             ERRCODE = '23514';
     END IF;
     --
-    --  `unmatch_crash_by_manual_qa` event is via VZE UI action
+    -- `unmatch_crash_by_manual_qa` event is set from the VZE using the
+    -- "Match not found" dropdown menu option
     --
     IF NEW._match_event_name = 'unmatch_crash_by_manual_qa' then
         NEW.crash_match_status = 'unmatched_by_manual_qa'; 
@@ -127,7 +128,7 @@ BEGIN
         return NEW;
     END IF;
     --
-    -- `unmatch_person_by_manual_qa` event is via VZE UI when
+    -- `unmatch_person_by_manual_qa` event is set from the VZE when
     -- the EMS record's person ID input is cleared
     --
     IF NEW._match_event_name = 'unmatch_person_by_manual_qa' then
@@ -309,7 +310,7 @@ END;
 $function$;
 
 --
--- add match events the ems-crash matching trigger
+-- Update the ems-crash matching trigger to use _match_event_name
 --
 CREATE
 OR REPLACE FUNCTION public.update_crash_ems_match() RETURNS trigger LANGUAGE plpgsql AS $function$

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -1,0 +1,131 @@
+--
+-- add person_match_status column
+--
+alter table ems__incidents
+    add column person_match_status text default 'unmatched'
+    check (
+        person_match_status in (
+            'unmatched',
+            'matched_by_automation',
+            'matched_by_manual_qa',
+            'multiple_matches_by_automation'
+        )
+    ),
+    add column matched_person_ids integer [];
+
+comment on column ems__incidents.person_match_status is 'The status of the CR3 person record match';
+comment on column ems__incidents.matched_person_ids is 'The IDs of the CR3 person records that were found to match this record';
+
+--
+-- Add person_match_status to this trigger
+--
+CREATE OR REPLACE FUNCTION public.ems_update_person_crash_id()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_person_record RECORD;
+BEGIN
+    IF NEW.person_id is null THEN
+        NEW.person_match_status = 'unmatched';  -- <- new line
+        return NEW;
+    END IF;
+    -- Find matching person record
+    SELECT id, crash_pk INTO matching_person_record 
+    FROM people_list_view 
+    WHERE id = NEW.person_id;
+
+    NEW.crash_pk = matching_person_record.crash_pk;
+    NEW.crash_match_status = 'matched_by_manual_qa';
+    NEW.person_match_status = 'matched_by_manual_qa';  -- <- new line
+    return NEW;
+END;
+$function$;
+
+--
+-- Create trigger function to match person record 
+--
+CREATE OR REPLACE FUNCTION public.ems_person_ems_match()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    other_matching_ems_id INTEGER;
+    matching_person_ids INTEGER[];
+BEGIN
+    IF NEW.person_match_status = 'matched_by_manual_qa' 
+    or NEW.pcr_patient_age is NULL
+    or NEW.pcr_patient_gender is NULL
+    or NEW.pcr_patient_race is NULL
+    THEN
+        -- do nothing
+        return NEW;
+    END IF;
+
+    IF NEW.crash_pk is NULL THEN
+        new.person_match_status = 'unmatched';
+        new.matched_person_ids = NULL;
+        return NEW;
+    END IF;
+
+    --
+    -- Check to see if there are other EMS patients with the same demographics as NEW
+    --
+    select id from ems__incidents e where
+    e.incident_number = NEW.incident_number
+    and e.id !=  NEW.id
+    and e.pcr_patient_age = NEW.pcr_patient_age
+    and e.pcr_patient_race = NEW.pcr_patient_race
+    and e.pcr_patient_gender = NEW.pcr_patient_gender
+    limit 1
+    into other_matching_ems_id;
+
+    --
+    -- Stop if multiple identical PCRs 
+    -- todo: we could potentially try to match multiple records to multiple people?
+    --
+    IF other_matching_ems_id IS NOT NULL THEN
+        raise debug 'Multiple EMS patients with same demographic characteristcs found - aborting person match.';
+        return NEW;
+    END IF;
+
+    --
+    -- Query for matching person records
+    --
+    SELECT
+        COALESCE(array_agg(p.id), ARRAY[]::integer[])
+    FROM
+        people_list_view p
+        left join lookups.drvr_ethncty ethncty_lkp on ethncty_lkp.id = p.prsn_ethnicity_id
+        left join lookups.gndr gndr_lkp on gndr_lkp.id = p.prsn_gndr_id
+    WHERE
+        p.crash_pk = NEW.crash_pk
+        and p.prsn_age = NEW.pcr_patient_age
+        AND gndr_lkp.label ilike NEW.pcr_patient_gender
+        AND NEW.pcr_patient_race ilike CONCAT('%', ethncty_lkp.label, '%')
+        into matching_person_ids;
+
+    raise debug 'Found % matching people records', array_length(matching_person_ids, 1);
+
+    IF array_length(matching_person_ids, 1) IS NULL THEN
+        -- no match
+        NEW.person_match_status = 'unmatched';
+        NEW.matched_person_ids = NULL;
+        NEW.person_id = NULL;
+    ELSIF array_length(matching_person_ids, 1) = 1 THEN
+        NEW.matched_person_ids = matching_person_ids;
+        NEW.person_id = matching_person_ids[1];
+        NEW.person_match_status = 'matched_by_automation';
+    ELSE
+        NEW.matched_person_ids = matching_person_ids;
+        NEW.person_match_status = 'multiple_matches_by_automation';
+        NEW.person_id = NULL;
+    END IF;
+    return NEW;
+END;
+$function$;
+
+drop trigger if exists ems_person_match_trigger on ems__incidents;
+
+create trigger ems_person_match_trigger BEFORE UPDATE ON ems__incidents FOR EACH ROW WHEN 
+    (old.crash_pk IS DISTINCT FROM new.crash_pk) EXECUTE FUNCTION ems_person_ems_match();

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -86,7 +86,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 --
--- Add person_match_status to this trigger
+-- New trigger that handles matching using an event-driven approach
 --
 CREATE
 OR REPLACE FUNCTION public.ems_update_handle_record_match_event() RETURNS trigger LANGUAGE plpgsql AS $function$
@@ -257,7 +257,6 @@ BEGIN
 END;
 $function$;
 
-DROP TRIGGER IF EXISTS ems_update_handle_match_trigger ON ems__incidents;
 DROP TRIGGER IF EXISTS ems_update_handle_record_match_event_trigger ON ems__incidents;
 
 CREATE TRIGGER ems_update_handle_record_match_event_trigger BEFORE

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -105,7 +105,8 @@ BEGIN
         'match_person_by_manual_qa',
         'reset_crash_match',
         'sync_crash_pk_on_person_match',
-        'unmatch_by_manual_qa',
+        'unmatch_crash_by_manual_qa',
+        'unmatch_person_by_manual_qa',
         'update_matched_crash_ids'
     ) then
         RAISE EXCEPTION 'Invalid _match_event_name: `%`', NEW._match_event_name
@@ -114,13 +115,23 @@ BEGIN
             ERRCODE = '23514';
     END IF;
     --
-    --  `unmatch_by_manual_qa` event is via VZE UI action
+    --  `unmatch_crash_by_manual_qa` event is via VZE UI action
     --
-    IF NEW._match_event_name = 'unmatch_by_manual_qa' then
+    IF NEW._match_event_name = 'unmatch_crash_by_manual_qa' then
         NEW.crash_match_status = 'unmatched_by_manual_qa'; 
         NEW.crash_pk = NULL;
         NEW.person_match_status = 'unmatched_by_manual_qa';
         NEW.matched_person_ids = NULL;
+        NEW.person_id = NULL;
+        NEW._match_event_name = null;
+        return NEW;
+    END IF;
+    --
+    -- `unmatch_person_by_manual_qa` event is via VZE UI when
+    -- the EMS record's person ID input is cleared
+    --
+    IF NEW._match_event_name = 'unmatch_person_by_manual_qa' then
+        NEW.person_match_status = 'unmatched_by_manual_qa';
         NEW.person_id = NULL;
         NEW._match_event_name = null;
         return NEW;

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -114,7 +114,7 @@ BEGIN
             ERRCODE = '23514';
     END IF;
     --
-    --  Expecting `unmatch_by_manual_qa` when this status is selected through the VZE UI
+    --  `unmatch_by_manual_qa` event is via VZE UI action
     --
     IF NEW._match_event_name = 'unmatch_by_manual_qa' then
         NEW.crash_match_status = 'unmatched_by_manual_qa'; 
@@ -126,7 +126,7 @@ BEGIN
         return NEW;
     END IF;
     --
-    -- Expecting `match_person_by_manual_qa` when a person match is selected through the VZE UI
+    -- `match_person_by_manual_qa` is sent when a person match is selected through the VZE UI
     --
     IF NEW._match_event_name = 'match_person_by_manual_qa' and NEW.person_id is not null then
         -- 
@@ -146,7 +146,9 @@ BEGIN
         NEW._match_event_name = null;
         return new;
     END IF;
-
+    --
+    -- The update_matched_crash_ids event is set via the EMS-crash matching trigger
+    --
     IF NEW._match_event_name = 'update_matched_crash_ids' then
         IF NEW.crash_match_status = 'matched_by_manual_qa'
         OR NEW.person_match_status = 'matched_by_manual_qa'then
@@ -164,7 +166,7 @@ BEGIN
         END IF;
     END IF;
     --
-    -- Match status can be reset via the VZE UI or via previous step in this function
+    -- reset_crash_match can be sent from the VZE UI or via previous step in this function
     --
     IF NEW._match_event_name = 'reset_crash_match' then
         --

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -26,6 +26,7 @@ AS $function$
 DECLARE
     matching_person_record RECORD;
 BEGIN
+    raise debug '**function: ems_update_person_crash_id **';
     IF NEW.person_id is null THEN
         NEW.person_match_status = 'unmatched';  -- <- new line
         return NEW;
@@ -53,6 +54,7 @@ DECLARE
     other_matching_ems_id INTEGER;
     matching_person_ids INTEGER[];
 BEGIN
+    raise debug '**function: ems_person_ems_match **';
     IF NEW.person_match_status = 'matched_by_manual_qa' 
     or NEW.pcr_patient_age is NULL
     or NEW.pcr_patient_gender is NULL
@@ -131,7 +133,7 @@ create trigger ems_person_match_trigger BEFORE UPDATE ON ems__incidents FOR EACH
     (old.crash_pk IS DISTINCT FROM new.crash_pk) EXECUTE FUNCTION ems_person_ems_match();
 
 --
--- Update this function to ignore updats 
+-- Update this function to ignore updates 
 --
 CREATE OR REPLACE FUNCTION public.ems_update_incident_crash_pk()
  RETURNS trigger
@@ -140,6 +142,7 @@ AS $function$
 DECLARE
     matching_person_record RECORD;
 BEGIN
+    raise debug '**function: ems_update_incident_crash_pk **';
     IF NEW.person_id is null
         THEN return null;
     END IF;
@@ -150,6 +153,7 @@ BEGIN
     
     -- Update crash_pk of related EMS if not already matched to a person and match was not automatic
     IF NEW.person_match_status = 'matched_by_manual_qa' THEN
+        raise debug 'updating related EMS records to matched by manual/qa';
         UPDATE ems__incidents 
         SET 
             crash_pk = matching_person_record.crash_pk,

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -432,3 +432,6 @@ $function$;
 -- delete this trigger which is now redundant
 DROP TRIGGER IF EXISTS ems_update_person_crash_id_trigger ON ems__incidents;
 DROP FUNCTION IF EXISTS ems_update_person_crash_id;
+
+-- finally, update the `person_match_status` of existing EMS records that are already matched to a person 
+update ems__incidents set person_match_status = 'matched_by_manual_qa' where person_id is not null;

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -275,10 +275,6 @@ CREATE TRIGGER ems_update_handle_record_match_event_trigger BEFORE
 UPDATE ON ems__incidents FOR EACH ROW
 EXECUTE FUNCTION ems_update_handle_record_match_event();
 
--- delete trigger which is now redundant
-DROP TRIGGER IF EXISTS ems_update_person_crash_id_trigger ON ems__incidents;
-DROP FUNCTION IF EXISTS ems_update_person_crash_id;
-
 --
 -- This function runs **after** updates to the EMS record and should be triggered when
 -- NEW.crash_pk is distinct from OLD.crash_pk and person_id is not null
@@ -432,3 +428,7 @@ BEGIN
     RETURN NEW;
 END;
 $function$;
+
+-- delete this trigger which is now redundant
+DROP TRIGGER IF EXISTS ems_update_person_crash_id_trigger ON ems__incidents;
+DROP FUNCTION IF EXISTS ems_update_person_crash_id;

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -1,22 +1,24 @@
+-- todo: update matching trigger
+
 --
 -- add person_match_status column
 --
 alter table ems__incidents
-    add column person_match_status text default 'unmatched'
-    check (
-        person_match_status in (
-            'unmatched',
-            'unmatched_by_manual_qa',
-            'matched_by_automation',
-            'matched_by_manual_qa',
-            'multiple_matches_by_automation'
-        )
-    ),
-    add column matched_person_ids integer [],
-    add column _match_event_name text,
-     check (
-        _match_event_name is null
-    );
+add column person_match_status text default 'unmatched'
+check (
+    person_match_status in (
+        'unmatched',
+        'unmatched_by_manual_qa',
+        'matched_by_automation',
+        'matched_by_manual_qa',
+        'multiple_matches_by_automation'
+    )
+),
+add column matched_person_ids integer [],
+add column _match_event_name text
+check (
+    _match_event_name is null
+);
 
 comment on column ems__incidents.person_match_status is 'The status of the CR3 person record match';
 comment on column ems__incidents.matched_person_ids is 'The IDs of the CR3 person records that were found to match this record';
@@ -25,144 +27,228 @@ comment on column ems__incidents._match_event_name is 'The name of the matching 
 --
 -- Add person_match_status to this trigger
 --
-CREATE OR REPLACE FUNCTION public.ems_update_person_crash_id()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
+create or replace function public.ems_update_handle_record_match()
+returns trigger
+language plpgsql
+as $function$
 DECLARE
-    matching_person_record RECORD;
-BEGIN
-    --
-    -- This function should only be executed when an EMS record's person_id changes
-    -- it is confusing that this business logic lives in the trigger declaration
-    -- move it here for clarity?
-    --
-    --
-    -- YES combine these triggers
-    --
-    raise debug '**function: ems_update_person_crash_id **';
-    IF NEW.person_id is null THEN
-        raise debug 'setting EMS record ID % person_match_status to unmatched because person_id is null', NEW.id;
-        NEW.person_match_status = 'unmatched';  -- <- new line
-        return NEW;
-    END IF;
-    -- Find matching person record
-    SELECT id, crash_pk INTO matching_person_record 
-    FROM people_list_view 
-    WHERE id = NEW.person_id;
-
-    raise debug 'setting EMS record ID % crash_match_status and person_match_status to matched_by_manual_qa', NEW.id;
-    NEW.crash_pk = matching_person_record.crash_pk;
-    NEW.crash_match_status = 'matched_by_manual_qa';
-    NEW.person_match_status = 'matched_by_manual_qa';  -- <- new line
-    return NEW;
-END;
-$function$;
-
---
--- Create trigger function to match person record 
---
-CREATE OR REPLACE FUNCTION public.ems_person_ems_match()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-DECLARE
-    other_matching_ems_id INTEGER;
     matching_person_ids INTEGER[];
+    matching_person_record RECORD;
+    other_matching_ems_id INTEGER;
 BEGIN
-    raise debug '**function: ems_person_ems_match **';
-    IF NEW.person_match_status = 'matched_by_manual_qa' 
-    or NEW.pcr_patient_age is NULL
-    or NEW.pcr_patient_gender is NULL
-    or NEW.pcr_patient_race is NULL
-    THEN
-        raise debug 'Doing nothing for EMS ID %', NEW.id;
-        -- do nothing
-        return NEW;
+    raise debug '**function: ems_update_handle_person_match for EMS ID: % **, event: %', NEW.id, NEW._match_event_name;
+    
+    --
+    -- Only continue if crash_pk or person_id has changed
+    --
+     IF NEW._match_event_name is null then
+        return new;
+    end if;
+
+    --
+    -- Expecting `match_person_by_manual_qa` to come from VZE when a person match
+    -- is selected through the UI
+    --
+    IF NEW._match_event_name = 'match_person_by_manual_qa' and NEW.person_id is not null then
+        -- 
+        -- Make sure crash_pk aligns with provided person_id
+        --
+        SELECT id, crash_pk INTO matching_person_record 
+        FROM people_list_view 
+        WHERE id = NEW.person_id;
+
+        IF matching_person_record.crash_pk IS DISTINCT FROM NEW.crash_pk then
+            raise debug 'updating EMS record ID % crash_pk to % to match updated person_id', NEW.id, matching_person_record.crash_pk;
+            NEW.crash_pk = matching_person_record.crash_pk;
+            NEW.crash_match_status = 'matched_by_manual_qa';
+            NEW.person_match_status = 'matched_by_manual_qa';
+        end if;
+        NEW._match_event_name = null;
+        return new;
+    end if;
+
+    IF NEW._match_event_name = 'reset_crash_match' then
+        --
+        --  No matched crash IDs
+        --
+        IF array_length(NEW.matched_crash_pks, 1) IS NULL THEN
+            -- reset to unmatched
+            raise debug 'Reset EMS ID % crash_match_status to unmatched', NEW.id;
+            NEW.crash_match_status = 'unmatched';
+            NEW.crash_pk = NULL;
+            NEW.person_match_status = 'unmatched';
+            NEW.matched_person_ids = NULL;
+            NEW.person_id = NULL;
+            NEW._match_event_name = null;
+            return NEW;
+        --
+        --  One matching crash ID
+        --
+        ELSIF array_length(NEW.matched_crash_pks, 1) = 1 THEN
+            raise debug 'Reset EMS ID % crash_match_status to matched_by_automation', NEW.id;
+            NEW.crash_pk = NEW.matched_crash_pks[1];
+            NEW.crash_match_status = 'matched_by_automation';
+            --
+            -- todo reset person match status as well?
+            -- Let person matching block handle person fields. todo: test
+            --
+
+            
+
+
+
+            -- IF array_length(NEW.matched_person_ids, 1) IS NULL THEN
+            --     -- no match
+            --     raise debug 'Reset person match status to unmatched for EMS ID %', NEW.id;
+            --     NEW.person_match_status = 'unmatched';
+            --     NEW.person_id = NULL;
+            -- ELSIF array_length(NEW.matched_person_ids, 1) = 1 THEN
+            --     raise debug 'Reset person match for EMS ID % to %', NEW.id, NEW.matched_person_ids[1];
+            --     NEW.person_id = NEW.matched_person_ids[1];
+            --     NEW.person_match_status = 'matched_by_automation';
+            -- ELSE
+            --     raise debug 'Multiple person matches found for EMS ID %', NEW.id;
+            --     NEW.person_match_status = 'multiple_matches_by_automation';
+            --     NEW.person_id = NULL;
+            -- END IF;
+
+            -- notice how we don't return NEW here—proceed to person match
+        ELSE
+            raise debug 'Reset EMS ID % to multiple_matches_by_automation', NEW.id;
+            NEW.crash_pk = null;
+            NEW.crash_match_status = 'multiple_matches_by_automation';
+            NEW.person_id = NULL;
+            NEW.person_match_status = 'unmatched';
+            NEW.matched_person_ids = NULL;
+            NEW._match_event_name = null;
+            return new;
+        END IF;
     END IF;
+    
 
-    IF NEW.crash_pk is NULL THEN
-        new.matched_person_ids = NULL;
-        raise debug 'Setting EMS ID % person_match_status to unmatched and to null', NEW.id;
-        new.person_match_status = 'unmatched';
-        new.matched_person_ids = NULL;
-        return NEW;
+    -- IF NEW._match_event_name = 'reset_person_match' then
+    --     -- todo
+    --     NEW._match_event_name = null;
+    --     return new;
+    -- END IF;
+
+
+    IF NEW._match_event_name in (
+        'match_crash_by_automation',
+        'match_crash_by_manual_qa',
+        'sync_crash_pk_on_person_match',
+        'reset_crash_match'
+    )
+        AND new.crash_pk IS NOT NULL THEN
+        
+        -- reset _match_event_name in outermost block to avoid repetition
+        NEW._match_event_name = null;
+
+        raise debug 'EMS record ID % matched to crash %', NEW.id, NEW.crash_pk;
+
+        -- todo: check if person_match status is matched_by_manual_qa before we continue?
+        if NEW.person_match_status = 'matched_by_manual_qa' 
+            or NEW.pcr_patient_age is NULL
+            or NEW.pcr_patient_gender is NULL
+            or NEW.pcr_patient_race is NULL
+            THEN
+                -- ignore this update / nothing to do
+                raise debug 'Doing nothing for EMS ID %', NEW.id;
+                return new;
+        ELSE
+            --
+            --  Begin automated person matching
+            --
+            --
+            -- Check to see if there are other EMS patients with the same demographics
+            --
+            -- todo: index these columns?
+            --
+            select id from ems__incidents e where
+            e.incident_number = NEW.incident_number
+            and e.id !=  NEW.id
+            and e.pcr_patient_age = NEW.pcr_patient_age
+            and e.pcr_patient_race = NEW.pcr_patient_race
+            and e.pcr_patient_gender = NEW.pcr_patient_gender
+            limit 1
+            into other_matching_ems_id;
+
+            --
+            -- Do not proceed if multiple identical PCRs 
+            -- todo: we could potentially try to match multiple records to multiple people?
+            --
+            IF other_matching_ems_id IS NOT NULL THEN
+                raise debug 'Multiple EMS patients with same demographic characteristcs found - aborting person match.';
+            ELSE
+                --
+                --  At this point, we have an EMS record:
+                -- whose crash_pk has changed and is not nul
+                -- person_match_status is not matched_by_manual_qa
+                -- is a unique incident # + demographics 
+                --
+                -- Query for matching person records
+                --
+                SELECT
+                    COALESCE(array_agg(p.id), ARRAY[]::integer[])
+                FROM
+                    people_list_view p
+                    left join lookups.drvr_ethncty ethncty_lkp on ethncty_lkp.id = p.prsn_ethnicity_id
+                    left join lookups.gndr gndr_lkp on gndr_lkp.id = p.prsn_gndr_id
+                WHERE
+                    p.crash_pk = NEW.crash_pk
+                    and p.prsn_age = NEW.pcr_patient_age
+                    AND gndr_lkp.label ilike NEW.pcr_patient_gender
+                    AND NEW.pcr_patient_race ilike CONCAT('%', ethncty_lkp.label, '%')
+                    into matching_person_ids;
+
+                raise debug 'Found % matching people records', array_length(matching_person_ids, 1);
+
+                IF array_length(matching_person_ids, 1) IS NULL THEN
+                    -- no match
+                    raise debug 'No person match found for EMS ID %', NEW.id;
+                    NEW.person_match_status = 'unmatched';
+                    NEW.matched_person_ids = NULL;
+                    NEW.person_id = NULL;
+                    return NEW;
+                ELSIF array_length(matching_person_ids, 1) = 1 THEN
+                    raise debug 'One person match found for EMS ID %', NEW.id;
+                    NEW.matched_person_ids = matching_person_ids;
+                    NEW.person_id = matching_person_ids[1];
+                    NEW.person_match_status = 'matched_by_automation';
+                    return NEW;
+                ELSE
+                    raise debug 'Multiple person matches found for EMS ID %', NEW.id;
+                    NEW.matched_person_ids = matching_person_ids;
+                    NEW.person_match_status = 'multiple_matches_by_automation';
+                    NEW.person_id = NULL;
+                    return NEW;
+                END IF;
+            END IF;
+        END IF;
     END IF;
-
-    --
-    -- Check to see if there are other EMS patients with the same demographics as NEW
-    --
-    select id from ems__incidents e where
-    e.incident_number = NEW.incident_number
-    and e.id !=  NEW.id
-    and e.pcr_patient_age = NEW.pcr_patient_age
-    and e.pcr_patient_race = NEW.pcr_patient_race
-    and e.pcr_patient_gender = NEW.pcr_patient_gender
-    limit 1
-    into other_matching_ems_id;
-
-    --
-    -- Stop if multiple identical PCRs 
-    -- todo: we could potentially try to match multiple records to multiple people?
-    --
-    IF other_matching_ems_id IS NOT NULL THEN
-        raise debug 'Multiple EMS patients with same demographic characteristcs found - aborting person match.';
-        return NEW;
-    END IF;
-
-    --
-    -- Query for matching person records
-    --
-    SELECT
-        COALESCE(array_agg(p.id), ARRAY[]::integer[])
-    FROM
-        people_list_view p
-        left join lookups.drvr_ethncty ethncty_lkp on ethncty_lkp.id = p.prsn_ethnicity_id
-        left join lookups.gndr gndr_lkp on gndr_lkp.id = p.prsn_gndr_id
-    WHERE
-        p.crash_pk = NEW.crash_pk
-        and p.prsn_age = NEW.pcr_patient_age
-        AND gndr_lkp.label ilike NEW.pcr_patient_gender
-        AND NEW.pcr_patient_race ilike CONCAT('%', ethncty_lkp.label, '%')
-        into matching_person_ids;
-
-    raise debug 'Found % matching people records', array_length(matching_person_ids, 1);
-
-    IF array_length(matching_person_ids, 1) IS NULL THEN
-        -- no match
-        raise debug 'No person match found for EMS ID %', NEW.id;
-        NEW.person_match_status = 'unmatched';
-        NEW.matched_person_ids = NULL;
-        NEW.person_id = NULL;
-    ELSIF array_length(matching_person_ids, 1) = 1 THEN
-        raise debug 'One person match found for EMS ID %', NEW.id;
-        NEW.matched_person_ids = matching_person_ids;
-        NEW.person_id = matching_person_ids[1];
-        NEW.person_match_status = 'matched_by_automation';
-    ELSE
-        raise debug 'Multiple person matches found for EMS ID %', NEW.id;
-        NEW.matched_person_ids = matching_person_ids;
-        NEW.person_match_status = 'multiple_matches_by_automation';
-        NEW.person_id = NULL;
-    END IF;
+    NEW._match_event_name = null;
     return NEW;
 END;
 $function$;
 
-drop trigger if exists ems_person_match_trigger on ems__incidents;
 
-create trigger ems_person_match_trigger BEFORE UPDATE ON ems__incidents FOR EACH ROW WHEN 
-    (old.crash_pk IS DISTINCT FROM new.crash_pk) EXECUTE FUNCTION ems_person_ems_match();
+drop trigger if exists ems_update_handle_record_match on ems__incidents;
+
+create trigger ems_update_handle_match_trigger before update on ems__incidents
+for each row execute function ems_update_handle_record_match();
+
+-- delete trigger which is now redundant
+drop trigger if exists ems_update_person_crash_id_trigger on ems__incidents;
+drop function if exists ems_update_person_crash_id;
+
 
 --
--- Update this function to ignore updates 
+-- This function runs **after** updates to the EMS record
 --
-CREATE OR REPLACE FUNCTION public.ems_update_incident_crash_pk()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-DECLARE
-    matching_person_record RECORD;
+create or replace function public.ems_update_incident_crash_pk()
+returns trigger
+language plpgsql
+as $function$
 BEGIN
     raise debug '**function: ems_update_incident_crash_pk **';
     IF NEW.person_id is null
@@ -170,25 +256,204 @@ BEGIN
         raise debug 'person_id is null. aborting for EMS ID %', NEW.id;
         return null;
     END IF;
-    -- Find matching person record
-    SELECT id, crash_pk INTO matching_person_record 
-    FROM people_list_view 
-    WHERE id = NEW.person_id;
-    
-    -- Update crash_pk of related EMS if not already matched to a person and match was not automatic
-    IF NEW.person_match_status = 'matched_by_manual_qa' THEN
-        raise debug 'updating crash_pk and crash_match_status of related EMS records to matched by manual/qa for incident # %', NEW.incident_number;
-        UPDATE ems__incidents 
-        SET 
-            crash_pk = matching_person_record.crash_pk,
-            updated_by = NEW.updated_by,
-            crash_match_status = 'matched_by_manual_qa'
-        WHERE
-            id != NEW.id
-            AND incident_number = NEW.incident_number
-            AND crash_pk is distinct from matching_person_record.crash_pk
-            AND person_id IS NULL;
-    END IF;
+    -- Update crash_pk of related EMS if not already matched to a person
+    raise debug 'updating crash_pk and crash_match_status of related EMS records to matched by manual/qa for incident # %', NEW.incident_number;
+    UPDATE ems__incidents 
+    SET 
+        crash_pk = NEW.crash_pk,
+        updated_by = NEW.updated_by,
+        crash_match_status = NEW.crash_match_status,
+        _match_event_name = 'sync_crash_pk_on_person_match'
+    WHERE
+        id != NEW.id
+        AND incident_number = NEW.incident_number
+        AND crash_pk is distinct from NEW.crash_pk
+        AND person_id IS NULL;
     RETURN null;
 END;
 $function$;
+
+
+
+
+--
+-- add person match and match event to the matching trigger
+--
+CREATE OR REPLACE FUNCTION public.update_crash_ems_match()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $function$
+DECLARE
+    matching_ems RECORD;
+    ems_record RECORD;
+    ems_cleanup_count INTEGER;
+    match_count INTEGER;
+    matched_crash_ids INTEGER[];
+    updated_matched_crash_ids INTEGER[];
+    remaining_crash_ids_count INTEGER;
+    meters_threshold INTEGER := 1200;
+    -- 30 min threshold equates to a 60 minute window (+/- 30 minutes of crash timestamp)
+    time_threshold INTERVAL := '30 minutes';
+BEGIN
+    -- Find all EMS records near the crash location + time
+    FOR matching_ems IN (
+        SELECT 
+            e.id,
+            e.incident_received_datetime,
+            e.geometry,
+            e.crash_match_status
+        FROM 
+            ems__incidents e
+        WHERE
+            e.incident_received_datetime  >= (NEW.crash_timestamp - time_threshold)
+            AND e.incident_received_datetime  <= (NEW.crash_timestamp + time_threshold)
+            AND e.geometry IS NOT NULL
+            AND NEW.position IS NOT NULL
+            AND ST_DWithin(e.geometry::geography, NEW.position::geography, meters_threshold)
+    ) LOOP
+        -- Find all crashes which match this EMS record location + time
+        SELECT 
+        COALESCE(array_agg(c.id), ARRAY[]::integer[])
+        FROM crashes c
+        WHERE 
+            c.is_deleted = false
+            and not c.is_temp_record
+            AND matching_ems.incident_received_datetime  >= (c.crash_timestamp - time_threshold)
+            AND matching_ems.incident_received_datetime  <= (c.crash_timestamp + time_threshold)
+            AND c.position IS NOT NULL
+            AND ST_DWithin(matching_ems.geometry::geography, c.position::geography, meters_threshold)
+        INTO matched_crash_ids;
+            
+        -- Get the count from the array length (handling when array_length is null as 0)
+        SELECT COALESCE(array_length(matched_crash_ids, 1), 0) INTO match_count;
+
+        -- For records that have been manually matched we want to only update the matched_crash_pks column
+        IF matching_ems.crash_match_status = 'matched_by_manual_qa' THEN
+            UPDATE ems__incidents 
+            SET matched_crash_pks = matched_crash_ids
+            WHERE id = matching_ems.id;
+        -- If the record has not been manually matched
+        ELSE
+          IF match_count = 0 THEN
+              UPDATE ems__incidents 
+              SET crash_pk = NULL,
+                  matched_crash_pks = NULL,
+                  _match_event_name = 'reset_crash_match'
+                  --todo: obvi test this
+              WHERE id = matching_ems.id;
+          ELSIF match_count = 1 THEN
+              -- this EMS record is only matched to one crash - we can assign the crash_pk and matched_crash_pks
+              UPDATE ems__incidents 
+              SET crash_pk = NEW.id,
+                  crash_match_status = 'matched_by_automation',
+                  matched_crash_pks = matched_crash_ids,
+                  _match_event_name = 'match_crash_by_automation'
+              WHERE id = matching_ems.id;
+          ELSE
+              -- multiple matching crashes found - can assign the matched_crash_pks but not crash_pk
+              UPDATE ems__incidents 
+              SET
+                  crash_pk = NULL,
+                  matched_crash_pks = matched_crash_ids,
+                  _match_event_name = 'reset_crash_match'
+              WHERE id = matching_ems.id;
+          END IF;
+        END IF;
+    END LOOP;
+
+    IF TG_OP = 'UPDATE' THEN
+        --
+        -- Check if there are any EMS records that reference this crash
+        --
+        SELECT COUNT(*) INTO ems_cleanup_count
+        FROM ems__incidents 
+        WHERE NEW.id = ANY(matched_crash_pks);
+
+        raise debug '% EMS records need to be checked for possible update', ems_cleanup_count;
+        
+        IF ems_cleanup_count > 0 THEN
+            --
+            -- Check for EMS records that were previously matched to this crash but should no longer be
+            --
+            FOR ems_record IN (
+                SELECT 
+                    id, 
+                    incident_number,
+                    matched_crash_pks, 
+                    crash_match_status,
+                    crash_pk,
+                    incident_received_datetime,
+                    geometry
+                FROM ems__incidents
+                WHERE NEW.id = ANY(matched_crash_pks)
+                    --
+                    -- If the incident matches any of these conditions, it should NOT be matched
+                    -- to this crash
+                    --
+                    AND (
+                        incident_received_datetime < (NEW.crash_timestamp - time_threshold)
+                        OR incident_received_datetime > (NEW.crash_timestamp + time_threshold)
+                        OR geometry IS NULL
+                        OR NEW.position IS NULL
+                        OR NEW.is_deleted IS TRUE
+                        OR (NOT ST_DWithin(geometry::geography, NEW.position::geography, meters_threshold))
+                    )
+            )
+            LOOP
+                raise debug 'Handling cleanup for EMS incident # %, ID %', ems_record.incident_number, ems_record.id;
+
+                -- Remove the this crash ID from the EMS record's matched_crash_pks
+                SELECT array_remove(ems_record.matched_crash_pks, NEW.id) INTO updated_matched_crash_ids;
+                SELECT COALESCE(array_length(updated_matched_crash_ids, 1), 0) INTO remaining_crash_ids_count;
+
+                raise debug 'remaining_crash_ids_count: %', remaining_crash_ids_count;
+                raise debug 'updated_matched_crash_ids: %', updated_matched_crash_ids;
+                --
+                -- Update the EMS records based on remaining match count
+                --
+                IF ems_record.crash_match_status = 'matched_by_manual_qa' THEN
+                    -- For manually matched records, only update the crash ID array
+                    raise debug 'Updating matched_crash_pks for manually matched EMS incident # %, ID % to %', ems_record.incident_number, ems_record.id, NULLIF(updated_matched_crash_ids, '{}');
+                    if updated_matched_crash_ids = '{}' then
+                        UPDATE ems__incidents
+                        SET
+                            matched_crash_pks = NULL,
+                            matched_person_ids = NULL
+                            -- todo: ????? how to retrigger persion matching if crash changes to matched_by_automatiON?
+                        WHERE id = ems_record.id;
+                    ELSE
+                        -- todo
+                    END IF;
+                ELSIF remaining_crash_ids_count = 0 THEN
+                    -- No other crashes matched to this EMS record
+                    raise debug 'Updating EMS incident # %, ID % as `unmatched`', ems_record.incident_number, ems_record.id;
+                    UPDATE ems__incidents 
+                    SET crash_pk = NULL,
+                        matched_crash_pks = NULL,
+                        _match_event_name = 'reset_crash_match'
+                        -- todo: test obvi
+                    WHERE id = ems_record.id;
+                ELSIF remaining_crash_ids_count = 1 THEN
+                    -- One crash remaining: match it to the EMS record
+                    raise debug 'Matching EMS incident # %, ID % to crash ID %', ems_record.incident_number, ems_record.id, updated_matched_crash_ids[1];
+                    UPDATE ems__incidents 
+                    SET crash_pk = updated_matched_crash_ids[1],
+                        matched_crash_pks = updated_matched_crash_ids,
+                        _match_event_name = 'reset_crash_match'
+                        -- todo make sure this triggers person match?? and can we not use `crash_match_status` and let trigger handle?
+                    WHERE id = ems_record.id;
+                ELSE
+                    -- Multiple crashes matches remaining
+                    raise debug 'Updating matched_crash_pks for EMS incident # %, ID % which still has multiple matches', ems_record.incident_number, ems_record.id;
+                    UPDATE ems__incidents 
+                    SET crash_pk = NULL,
+                        matched_crash_pks = updated_matched_crash_ids,
+                        _match_event_name = 'reset_crash_match'
+                    WHERE id = ems_record.id;
+                END IF;
+            END LOOP;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$function$

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from "next/navigation";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import DataCard from "@/components/DataCard";
-import { emsDataCards } from "@/configs/emsDataCards";
 import { useMutation, useQuery } from "@/utils/graphql";
 import {
   GET_EMS_RECORDS,
@@ -21,7 +20,9 @@ import EMSLinkRecordButton, {
 import EMSLinkToPersonButton, {
   EMSLinkToPersonButtonProps,
 } from "@/components/EMSLinkToPersonButton";
+import { emsDataCards } from "@/configs/emsDataCards";
 import { emsMatchingPeopleColumns } from "@/configs/emsMatchingPeopleColumns";
+import { getMutationVariables } from "@/configs/emsRelatedRecordTable";
 import { PeopleListRow } from "@/types/peopleList";
 import { FaTruckMedical } from "react-icons/fa6";
 import { parseISO, subHours, addHours } from "date-fns";
@@ -233,6 +234,7 @@ export default function EMSDetailsPage({
             header="EMS patient(s)"
             columns={emsDataCards.patient}
             mutation={UPDATE_EMS_INCIDENT}
+            getMutationVariables={getMutationVariables}
             onSaveCallback={onSaveCallback}
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -39,6 +39,7 @@ const EMSLinkRecordButton: React.FC<
         crash_pk: null,
         person_id: null,
         crash_match_status: "unmatched",
+        person_match_status: "unmatched"
       };
     } else if (record.matched_crash_pks.length === 1) {
       updates = {

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -66,7 +66,7 @@ const EMSLinkRecordButton: React.FC<
                   await updateEMSRecord({
                     id: record.id,
                     updates: {
-                      _match_event_name: "unmatch_by_manual_qa",
+                      _match_event_name: "unmatch_crash_by_manual_qa",
                       crash_pk: null,
                       person_id: null,
                     },

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -6,7 +6,6 @@ import { FaLink } from "react-icons/fa6";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import AlignedLabel from "@/components/AlignedLabel";
 import { useMutation } from "@/utils/graphql";
-import { useMemo } from "react";
 
 const allowedLinkRecordRoles = ["vz-admin", "editor"];
 
@@ -28,34 +27,6 @@ const EMSLinkRecordButton: React.FC<
   const isLinkingThisRecord =
     additionalProps?.selectedEmsPcr &&
     record.id === additionalProps?.selectedEmsPcr.id;
-
-  /**
-   * Hook that gets the variables to be used in the reset button mutation
-   */
-  const resetButtonUpdates = useMemo(() => {
-    let updates = {};
-    if (record.matched_crash_pks === null) {
-      updates = {
-        crash_pk: null,
-        person_id: null,
-        crash_match_status: "unmatched",
-        person_match_status: "unmatched"
-      };
-    } else if (record.matched_crash_pks.length === 1) {
-      updates = {
-        crash_pk: record.matched_crash_pks[0],
-        person_id: null,
-        crash_match_status: "matched_by_automation",
-      };
-    } else if (record.matched_crash_pks.length > 1) {
-      updates = {
-        crash_pk: null,
-        person_id: null,
-        crash_match_status: "multiple_matches_by_automation",
-      };
-    }
-    return updates;
-  }, [record]);
 
   const { mutate: updateEMSRecord } = useMutation(mutation);
 
@@ -95,7 +66,8 @@ const EMSLinkRecordButton: React.FC<
                   await updateEMSRecord({
                     id: record.id,
                     updates: {
-                      crash_match_status: "unmatched_by_manual_qa",
+                      // TODO: implement this
+                      _match_event_name: "unmatched_by_manual_qa",
                       crash_pk: null,
                       person_id: null,
                     },
@@ -109,7 +81,9 @@ const EMSLinkRecordButton: React.FC<
                 onClick={async () => {
                   await updateEMSRecord({
                     id: record.id,
-                    updates: resetButtonUpdates,
+                    updates: {
+                      _match_event_name: "reset_crash_match",
+                    },
                   });
                   await onSaveCallback();
                 }}

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -66,8 +66,7 @@ const EMSLinkRecordButton: React.FC<
                   await updateEMSRecord({
                     id: record.id,
                     updates: {
-                      // TODO: implement this
-                      _match_event_name: "unmatched_by_manual_qa",
+                      _match_event_name: "unmatch_by_manual_qa",
                       crash_pk: null,
                       person_id: null,
                     },

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -21,6 +21,16 @@ interface RelatedRecordTableProps<
    */
   mutation: string;
   /**
+   * Function to generate the complete mutation variables payload
+   * If not provided, uses default behavior
+   */
+  getMutationVariables?: (
+    record: T,
+    column: ColDataCardDef<T>,
+    value: unknown,
+    defaultVariables: { id: number; updates: Record<string, unknown> }
+  ) => Record<string, unknown>;
+  /**
    * Graphql mutation that will be passed to rowActionComponent, if present
    */
   rowActionMutation?: string;
@@ -89,6 +99,7 @@ export default function RelatedRecordTable<
   records,
   columns,
   mutation,
+  getMutationVariables,
   rowActionMutation,
   isValidating,
   noRowsMessage,
@@ -138,6 +149,7 @@ export default function RelatedRecordTable<
                   onSaveCallback={onSaveCallback}
                   record={record}
                   mutation={mutation}
+                  getMutationVariables={getMutationVariables}
                   rowActionMutation={rowActionMutation}
                   rowActionComponent={rowActionComponent}
                   rowActionComponentAdditionalProps={

--- a/editor/components/RelatedRecordTableRow.tsx
+++ b/editor/components/RelatedRecordTableRow.tsx
@@ -30,7 +30,16 @@ interface RelatedRecordTableRowProps<
    * Graphql mutation that will be exectuted when a row is edited
    */
   mutation: string;
-
+  /**
+   * Function to generate the complete mutation variables payload
+   * If not provided, uses default behavior
+   */
+  getMutationVariables?: (
+    record: T,
+    column: ColDataCardDef<T>,
+    value: unknown,
+    defaultVariables: { id: number; updates: Record<string, unknown> }
+  ) => Record<string, unknown>;
   /**
    * Graphql mutation that will be exectuted in the rowActionComponent
    */
@@ -68,6 +77,7 @@ export default function RelatedRecordTableRow<
   record,
   columns,
   mutation,
+  getMutationVariables,
   rowActionMutation,
   isValidating,
   onSaveCallback,
@@ -107,12 +117,16 @@ export default function RelatedRecordTableRow<
       ? editColumn.relationship?.foreignKey
       : editColumn.path;
 
-    const variables = {
+    const defaultVariables = {
       id: recordId,
       updates: {
         [saveColumnName]: value,
       },
     };
+
+    const variables = getMutationVariables
+      ? getMutationVariables(record, editColumn, value, defaultVariables)
+      : defaultVariables;
 
     await mutate(variables);
     await onSaveCallback();

--- a/editor/configs/emsRelatedRecordTable.ts
+++ b/editor/configs/emsRelatedRecordTable.ts
@@ -21,15 +21,20 @@ export const emsRelatedRecordCols = [
  */
 export const getMutationVariables = (
   _record: EMSPatientCareRecord,
-  _column: ColDataCardDef<EMSPatientCareRecord>,
-  _value: unknown,
+  column: ColDataCardDef<EMSPatientCareRecord>,
+  value: unknown,
   defaultVariables: { id: number; updates: Record<string, unknown> }
 ): Record<string, unknown> => {
+  if (column.path !== "person_id") {
+    return defaultVariables;
+  }
   return {
     id: defaultVariables.id,
     updates: {
       ...defaultVariables.updates,
-      _match_event_name: "match_person_by_manual_qa",
+      _match_event_name: value
+        ? "match_person_by_manual_qa"
+        : "unmatch_person_by_manual_qa",
     },
   };
 };

--- a/editor/configs/emsRelatedRecordTable.ts
+++ b/editor/configs/emsRelatedRecordTable.ts
@@ -1,4 +1,6 @@
 import { ALL_EMS_COLUMNS } from "./emsColumns";
+import { EMSPatientCareRecord } from "@/types/ems";
+import { ColDataCardDef } from "@/types/types";
 
 export const emsRelatedRecordCols = [
   ALL_EMS_COLUMNS.unit_nbr,
@@ -12,3 +14,22 @@ export const emsRelatedRecordCols = [
   ALL_EMS_COLUMNS.incident_number,
   ALL_EMS_COLUMNS.crash_match_status,
 ];
+
+/**
+ * Custom mutation variable handler which adds the `_match_event_name` prop
+ * to the record update payload
+ */
+export const getMutationVariables = (
+  _record: EMSPatientCareRecord,
+  _column: ColDataCardDef<EMSPatientCareRecord>,
+  _value: unknown,
+  defaultVariables: { id: number; updates: Record<string, unknown> }
+): Record<string, unknown> => {
+  return {
+    id: defaultVariables.id,
+    updates: {
+      ...defaultVariables.updates,
+      _match_event_name: "match_person_by_manual_qa",
+    },
+  };
+};

--- a/editor/queries/ems.ts
+++ b/editor/queries/ems.ts
@@ -142,7 +142,7 @@ export const UPDATE_EMS_INCIDENT_CRASH_AND_PERSON = gql`
       where: { id: { _eq: $id } }
       _set: {
         person_id: $person_id
-        crash_match_status: "matched_by_manual_qa"
+        _match_event_name: "match_person_by_manual_qa"
       }
     ) {
       affected_rows

--- a/editor/testing.md
+++ b/editor/testing.md
@@ -61,6 +61,7 @@ The below features should be tested with each role. Features with role-based acc
 - Crash map: crash map displays crash location with nearmap aerials
 - Crash map: edit crash location by dragging map
 - Crash map: edit crash location by keying in lat/lon
+- Observe in change log that council district, jurisdiction, APD sector, engineer area update when crash location is edited to a distant position
 - Crash map: in edit mode, use the address search to find a location within Austin metro area
 - Crash map: verify **Location ID** updates when crash is moved to another intersection
 - Crash map: validation restricts keying in lat/lon with alpha characters
@@ -158,6 +159,9 @@ refresh materialized view location_crashes_view;
 - The **Select person** button is displayed for each EMS patient row
 - Click **Select person** to enable the **Select match** button to appear next to any unlinked person records in the **Associated people records** table
 - Click the **Person ID** column for any **EMS Patients** row to manually edit a person ID value
+- - Click the **Person ID** column submit an invalid person ID value and verify an error message is displayed
+- Use the falafel menu to **Reset** an incident matched to a person ID
+- Use the falafel menu to modify an incident to be **Match not found**
 
 #### These steps test the DB trigger that matches EMS records to crashes
 


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/23198

Like I mentioned yesterday, I am looking for your feedback about this approach in general in addition to your feedback on the all the details. If you look through the commit history (e.g. [here](https://github.com/cityofaustin/vision-zero/pull/1811/commits/15e8f4f887bff3751057e5e554441c21f92b992f)) you can get a sense of how lost I was before switching to the event-based approach.

I've thought a little about what this might look like as an external API living outside the DB, but I think we'd need a fairly complex solution (probably with a redis queue or what have you) to try and orchestrate all of the different updates going on with the `ems__incidents table` 🤔 

A few out-of-scope items to consider:

* Backfill the existing EMS records to see what can be automatically matched to a person record
* Figure out what (if any) fields we want to show in the EMS UI wrt to person matching
* Think through if the non-CR3 matching trigger should be reworked to tie into the event handler

## Testing

Start your local stack with a fresh replica and apply migrations and metadata.

## Part 1 - VZE

In the VZE, navigate to EMS incident `25145-0421`: http://localhost:3002/editor/ems/25145-0421

Use the **Select person** button to match the 34yo/female to person ID `3525212`.

Observe that the other EMS patient is matched automatically to person ID `3525336` and that both EMS patients have a **Crash match status** of **Matched by review/QA** with the **Crash ID** populated as well.

Now edit one of the patient records by using the falafel dropdown menu to **Reset** the match status. Obsever that the record reverts to a **Crash match status** of **Multiple** and the **Crash ID** and **Person ID** columns are blank.

Now use the falafel menu and select the **Match not found** option. Observe that the record has a **Crash match status** of **Unmatched by review/QA** and the crash and person ID columns are blank.

Now edit the same patient record by clicking into the empty **Person ID** field and inputting its matching person ID. Click the **Save** button and observe that the record now has a **Crash match status** of **Matched by review/QA** with the **Crash ID** populated as well.

Lastly, use the falafel menu to **Reset** the match status of both records. We're going to continue testing with these records using your DB client.

## Part 2 - DB Client

Enable debug messaging

```sql
set client_min_messages to 'DEBUG';
```

Bring up the two EMS records we've been working with by querying the `incident_number`:

```sql
select
    id,
    incident_number,
    crash_pk,
    pcr_patient_age,
    pcr_patient_gender,
    pcr_patient_race,
    crash_match_status,
    matched_crash_pks,
    person_id,
    person_match_status,
    matched_person_ids
from ems__incidents
where incident_number = '25145-0421';
```

Your results should look like this:

```
| id     | incident_number | crash_pk | pcr_patient_age | pcr_patient_gender | pcr_patient_race          | crash_match_status             | matched_crash_pks | person_id | person_match_status | matched_person_ids |
| ------ | --------------- | -------- | --------------- | ------------------ | ------------------------- | ------------------------------ | ----------------- | --------- | ------------------- | ------------------ |
| 620546 | 25145-0421      |          | 34              | Female             | Black or African American | multiple_matches_by_automation | {1365190,1365726} |           | unmatched           |                    |
| 620946 | 25145-0421      |          | 6               | Female             | Black or African American | multiple_matches_by_automation | {1365726,1365190} |           | unmatched           |                    |
```

Now simulate the VZE update by matching one EMS record to its person record:

```sql
update ems__incidents set person_id = 3525212, _match_event_name = 'match_person_by_manual_qa' where id = 620546;
```

The debug output should look like this.

```
DEBUG:  **function: ems_update_handle_record_match_event for EMS ID: 620546 **, event: match_person_by_manual_qa
DEBUG:  updating EMS record ID 620546 crash_pk to 1365726 to match updated person_id
DEBUG:  **function: ems_update_incident_crash_pk **
DEBUG:  updating crash_pk and crash_match_status of related EMS records to matched by manual/qa for incident # 25145-0421
DEBUG:  **function: ems_update_handle_record_match_event for EMS ID: 620946 **, event: sync_crash_pk_on_person_match
DEBUG:  Doing person matching for EMS record ID 620946 matched to crash 1365726
DEBUG:  **function: find_matching_person_ids**
DEBUG:  Found 1 matching people records
DEBUG:  One person match found for EMS ID 620946
DEBUG:  **function: ems_update_incident_crash_pk **
DEBUG:  updating crash_pk and crash_match_status of related EMS records to matched by manual/qa for incident # 25145-0421
```

Re-query `25145-0421` and observe that both records have been updated with person-level matches.

### Part 3 - Back to the VZE

Looking good so far! Now we will observe what happens when a record is matched at the crash and person level automatically.

To start off, visit incident `25164-0580` in the VZE UI: http://localhost:3002/editor/ems/25164-0580. There are two ems records that were automatically matched to a crash. Had our new trigger been in place, these records would have been automatically matched to person records.

Navigate to the crash details page for the matching crash (CRIS ID `20864150`): http://localhost:3002/editor/crashes/20864150

Edit the crash location by changing the crash location's latitude to `31`. Scroll down to the EMS related records card (`shift` + `e` ) and notice that there are no EMS records associated with this crash.

Scroll to the top of the page and restore the crash location latitude to it's original value by setting it to `30.46882804`. Take another look at the EMS related records, and see we have two matched EMS records. Use the hyperlinked **Incident** column to navigate to the EMS details page for these records: http://localhost:3002/editor/ems/25164-0580.

Observe that one of these records was matched automatically to person ID `3529166`. While the other is not matched because their is no exact demographic match to a person record.

### Part 3 - Still in the VZE

Let's test *one* more case. Visit EMS incident `25069-0413` and see that it has multiple matches: http://localhost:3002/editor/ems/25069-0413. Now visit the crash details page for CRIS ID `20695335` ([link](http://localhost:3002/editor/crashes/20719399)) and set the crashe's latitude to `31`. 

Now navigate back to incident `25069-0413` and observe that both EMS records have been automatically matched to a person! Very good.

Go back to the crash details page for CRIS ID `20695335` ([link](http://localhost:3002/editor/crashes/20719399)), and restore it to the correct latitude: `30.38520478`. Save your changes and head back to EMS incident `25069-0413`. Observe that the EMS records once again have a match status of **Multiple**.

👍 Thank you for testing my PR. Please try hard to break it.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
