### PR TITLE
Ability to customize column visibility on related record tables

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -188,6 +188,7 @@ export default function CrashDetailsPage({
             columns={unitRelatedRecordCols}
             mutation={UPDATE_UNIT}
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
           />
         </Col>
       </Row>
@@ -201,6 +202,7 @@ export default function CrashDetailsPage({
             columns={peopleRelatedRecordCols}
             mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
           />
         </Col>
       </Row>

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -233,7 +233,6 @@ export default function CrashDetailsPage({
             columns={chargeRelatedRecordCols}
             mutation={""}
             onSaveCallback={onSaveCallback}
-            localStorageKey=""
           />
         </Col>
       </Row>

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -216,6 +216,7 @@ export default function CrashDetailsPage({
             columns={emsRelatedRecordCols}
             mutation=""
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
           />
         </Col>
       </Row>

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -189,6 +189,7 @@ export default function CrashDetailsPage({
             mutation={UPDATE_UNIT}
             onSaveCallback={onSaveCallback}
             shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPageUnits"
           />
         </Col>
       </Row>
@@ -203,6 +204,7 @@ export default function CrashDetailsPage({
             mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
             shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPagePeople"
           />
         </Col>
       </Row>
@@ -217,6 +219,7 @@ export default function CrashDetailsPage({
             mutation=""
             onSaveCallback={onSaveCallback}
             shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPageEmsPatientCare"
           />
         </Col>
       </Row>
@@ -230,6 +233,7 @@ export default function CrashDetailsPage({
             columns={chargeRelatedRecordCols}
             mutation={""}
             onSaveCallback={onSaveCallback}
+            localStorageKey=""
           />
         </Col>
       </Row>

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -184,7 +184,7 @@ export default function CrashDetailsPage({
             records={crash.units || []}
             isValidating={isValidating}
             noRowsMessage="No unit records found"
-            headerTitle="Units"
+            header="Units"
             columns={unitRelatedRecordCols}
             mutation={UPDATE_UNIT}
             onSaveCallback={onSaveCallback}
@@ -199,7 +199,7 @@ export default function CrashDetailsPage({
             records={crash.people_list_view || []}
             isValidating={isValidating}
             noRowsMessage="No people records found"
-            headerTitle="People"
+            header="People"
             columns={peopleRelatedRecordCols}
             mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
@@ -213,7 +213,7 @@ export default function CrashDetailsPage({
           <RelatedRecordTable
             records={crash.ems__incidents || []}
             isValidating={isValidating}
-            headerTitle={<EMSCardHeader />}
+            header={<EMSCardHeader />}
             noRowsMessage="No EMS records found"
             columns={emsRelatedRecordCols}
             mutation=""
@@ -229,7 +229,7 @@ export default function CrashDetailsPage({
             records={crash.charges_cris || []}
             isValidating={isValidating}
             noRowsMessage="No charge records found"
-            headerTitle="Charges"
+            header="Charges"
             columns={chargeRelatedRecordCols}
             mutation={""}
             onSaveCallback={onSaveCallback}

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -184,7 +184,7 @@ export default function CrashDetailsPage({
             records={crash.units || []}
             isValidating={isValidating}
             noRowsMessage="No unit records found"
-            header="Units"
+            headerTitle="Units"
             columns={unitRelatedRecordCols}
             mutation={UPDATE_UNIT}
             onSaveCallback={onSaveCallback}
@@ -198,7 +198,7 @@ export default function CrashDetailsPage({
             records={crash.people_list_view || []}
             isValidating={isValidating}
             noRowsMessage="No people records found"
-            header="People"
+            headerTitle="People"
             columns={peopleRelatedRecordCols}
             mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
@@ -211,7 +211,7 @@ export default function CrashDetailsPage({
           <RelatedRecordTable
             records={crash.ems__incidents || []}
             isValidating={isValidating}
-            header={<EMSCardHeader />}
+            headerTitle={<EMSCardHeader />}
             noRowsMessage="No EMS records found"
             columns={emsRelatedRecordCols}
             mutation=""
@@ -225,7 +225,7 @@ export default function CrashDetailsPage({
             records={crash.charges_cris || []}
             isValidating={isValidating}
             noRowsMessage="No charge records found"
-            header="Charges"
+            headerTitle="Charges"
             columns={chargeRelatedRecordCols}
             mutation={""}
             onSaveCallback={onSaveCallback}

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -230,7 +230,7 @@ export default function EMSDetailsPage({
             records={ems_pcrs}
             isValidating={isValidating}
             noRowsMessage="No patients found"
-            headerTitle="EMS patient(s)"
+            header="EMS patient(s)"
             columns={emsDataCards.patient}
             mutation={UPDATE_EMS_INCIDENT}
             onSaveCallback={onSaveCallback}
@@ -247,7 +247,7 @@ export default function EMSDetailsPage({
             records={matchingPeople ? matchingPeople : []}
             isValidating={isValidating}
             noRowsMessage="No people found"
-            headerTitle="Possible people matches"
+            header="Possible people matches"
             columns={emsMatchingPeopleColumns}
             mutation=""
             onSaveCallback={onSaveCallback}

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -230,7 +230,7 @@ export default function EMSDetailsPage({
             records={ems_pcrs}
             isValidating={isValidating}
             noRowsMessage="No crashes found"
-            header="EMS patient(s)"
+            headerTitle="EMS patient(s)"
             columns={emsDataCards.patient}
             mutation={UPDATE_EMS_INCIDENT}
             onSaveCallback={onSaveCallback}
@@ -247,7 +247,7 @@ export default function EMSDetailsPage({
             records={matchingPeople ? matchingPeople : []}
             isValidating={isValidating}
             noRowsMessage="No people found"
-            header="Possible people matches"
+            headerTitle="Possible people matches"
             columns={emsMatchingPeopleColumns}
             mutation=""
             onSaveCallback={onSaveCallback}

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -237,7 +237,6 @@ export default function EMSDetailsPage({
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}
             rowActionMutation={UPDATE_EMS_INCIDENT}
-            shouldShowColumnVisibilityPicker={true}
           />
         </Col>
       </Row>

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -237,6 +237,7 @@ export default function EMSDetailsPage({
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}
             rowActionMutation={UPDATE_EMS_INCIDENT}
+            shouldShowColumnVisibilityPicker={true}
           />
         </Col>
       </Row>
@@ -252,6 +253,7 @@ export default function EMSDetailsPage({
             onSaveCallback={onSaveCallback}
             rowActionComponent={EMSLinkToPersonButton}
             rowActionComponentAdditionalProps={linkToPersonButtonProps}
+            shouldShowColumnVisibilityPicker={true}
           />
         </Col>
       </Row>

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -237,7 +237,6 @@ export default function EMSDetailsPage({
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}
             rowActionMutation={UPDATE_EMS_INCIDENT}
-            localStorageKey=""
           />
         </Col>
       </Row>

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -229,7 +229,7 @@ export default function EMSDetailsPage({
           <RelatedRecordTable<EMSPatientCareRecord, EMSLinkRecordButtonProps>
             records={ems_pcrs}
             isValidating={isValidating}
-            noRowsMessage="No crashes found"
+            noRowsMessage="No patients found"
             headerTitle="EMS patient(s)"
             columns={emsDataCards.patient}
             mutation={UPDATE_EMS_INCIDENT}
@@ -237,6 +237,7 @@ export default function EMSDetailsPage({
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}
             rowActionMutation={UPDATE_EMS_INCIDENT}
+            localStorageKey=""
           />
         </Col>
       </Row>
@@ -253,6 +254,7 @@ export default function EMSDetailsPage({
             rowActionComponent={EMSLinkToPersonButton}
             rowActionComponentAdditionalProps={linkToPersonButtonProps}
             shouldShowColumnVisibilityPicker={true}
+            localStorageKey="emsPossiblePeople"
           />
         </Col>
       </Row>

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -58,7 +58,7 @@ export default function NotesCard<T extends Record<string, unknown>>({
         noRowsMessage="No notes found"
         isValidating={false}
         header="Notes"
-        additionalHeaderComponent={<AddNoteButton onClick={handleOpenModal} />}
+        headerButton={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}
         localStorageKey=""

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -61,7 +61,6 @@ export default function NotesCard<T extends Record<string, unknown>>({
         headerButton={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}
-        localStorageKey=""
       />
 
       <NotesModal

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -57,7 +57,7 @@ export default function NotesCard<T extends Record<string, unknown>>({
         rowActionMutation={updateMutation}
         noRowsMessage="No notes found"
         isValidating={false}
-        header="Notes"
+        headerTitle="Notes"
         headerComponent={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -58,7 +58,7 @@ export default function NotesCard<T extends Record<string, unknown>>({
         noRowsMessage="No notes found"
         isValidating={false}
         header="Notes"
-        headerComponent={<AddNoteButton onClick={handleOpenModal} />}
+        additionalHeaderComponent={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}
         localStorageKey=""

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -57,7 +57,7 @@ export default function NotesCard<T extends Record<string, unknown>>({
         rowActionMutation={updateMutation}
         noRowsMessage="No notes found"
         isValidating={false}
-        headerTitle="Notes"
+        header="Notes"
         headerComponent={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -61,6 +61,7 @@ export default function NotesCard<T extends Record<string, unknown>>({
         headerComponent={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}
+        localStorageKey=""
       />
 
       <NotesModal

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -7,7 +7,6 @@ import { ColDataCardDef } from "@/types/types";
 import AlignedLabel from "@/components/AlignedLabel";
 import DeleteNoteButton from "@/components/DeleteNoteButton";
 import PermissionsRequired from "@/components/PermissionsRequired";
-import { Card } from "react-bootstrap";
 
 const allowedNoteRoles = ["vz-admin", "editor"];
 
@@ -58,12 +57,8 @@ export default function NotesCard<T extends Record<string, unknown>>({
         rowActionMutation={updateMutation}
         noRowsMessage="No notes found"
         isValidating={false}
-        header={
-          <div className="d-flex justify-content-between">
-            <Card.Title>Notes</Card.Title>
-            <AddNoteButton onClick={handleOpenModal} />
-          </div>
-        }
+        header="Notes"
+        headerComponent={<AddNoteButton onClick={handleOpenModal} />}
         onSaveCallback={onSaveCallback}
         rowActionComponent={DeleteNoteButton}
       />

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -42,7 +42,7 @@ interface RelatedRecordTableProps<
   header: React.ReactNode;
 
   /**
-   * Optional component to be rendered alongside the tite in the card header
+   * Optional component to be rendered alongside the title in the card header
    */
   headerComponent?: React.ReactNode;
 
@@ -65,7 +65,8 @@ interface RelatedRecordTableProps<
    */
   onSaveCallback: () => Promise<void>;
 
-  /** Use an empty string if table does not have column visibility settings */
+  /** The key to use when saving and loading table data to local storage.
+   * Use an empty string if table does not have column visibility settings */
   localStorageKey: string;
 }
 

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -105,7 +105,7 @@ export default function RelatedRecordTable<
   rowActionMutation,
   isValidating,
   noRowsMessage,
-  header,
+  headerTitle,
   onSaveCallback,
   rowActionComponent,
   rowActionComponentAdditionalProps,

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -5,7 +5,6 @@ import RelatedRecordTableRow from "@/components/RelatedRecordTableRow";
 import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
 import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 import { ColDataCardDef } from "@/types/types";
-import { ColumnVisibilitySetting } from "@/types/types";
 
 interface RelatedRecordTableProps<
   T extends Record<string, unknown>,
@@ -124,23 +123,13 @@ export default function RelatedRecordTable<
     setIsColVisibilityLocalStorageLoaded,
   ] = useState(false);
 
-  /**
-   * Initialize column visibility from provided columns
-   */
-  const [columnVisibilitySettings, setColumnVisibilitySettings] = useState<
-    ColumnVisibilitySetting[]
-  >(
-    columns
-      .filter((col) => !col.exportOnly)
-      .map((col) => ({
-        path: String(col.path),
-        isVisible: !col.defaultHidden,
-        label: col.label,
-      }))
-  );
-
-  /** Columns that should be visible based on user column visibility settings */
-  const visibleColumns = useVisibleColumns(columns, columnVisibilitySettings);
+  /** Use custom hook to get array of visible columns, column visibility settings,
+   * and state setter function */
+  const {
+    visibleColumns,
+    columnVisibilitySettings,
+    setColumnVisibilitySettings,
+  } = useVisibleColumns(columns);
 
   return (
     <Card>

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -39,7 +39,7 @@ interface RelatedRecordTableProps<
   /**
    * The card header to be rendered as a <Card.Title>
    */
-  headerTitle: React.ReactNode;
+  header: React.ReactNode;
 
   /**
    * Optional component to be rendered alongside the tite in the card header
@@ -109,7 +109,7 @@ export default function RelatedRecordTable<
   rowActionMutation,
   isValidating,
   noRowsMessage,
-  headerTitle,
+  header,
   onSaveCallback,
   rowActionComponent,
   rowActionComponentAdditionalProps,
@@ -144,7 +144,7 @@ export default function RelatedRecordTable<
     <Card>
       <Card.Header>
         <div className="d-flex justify-content-between">
-          <Card.Title>{headerTitle}</Card.Title>
+          <Card.Title>{header}</Card.Title>
           <div className="d-flex justify-content-end gap-2">
             {headerComponent && headerComponent}
             {shouldShowColumnVisibilityPicker && (

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -36,7 +36,7 @@ interface RelatedRecordTableProps<
    */
   noRowsMessage?: string;
   /**
-   * The card header string to be rendered as a <Card.Title>
+   * The card header to be rendered as a <Card.Title>
    */
   headerTitle: React.ReactNode;
 

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -42,9 +42,10 @@ interface RelatedRecordTableProps<
   header: React.ReactNode;
 
   /**
-   * Optional component to be rendered alongside the title in the card header
+   * Optional button component to be rendered in the rightmost of the card header,
+   * left of the column visibility picker if there is one
    */
-  additionalHeaderComponent?: React.ReactNode;
+  headerButton?: React.ReactNode;
 
   /**
    * Enable column visibility picker
@@ -114,7 +115,7 @@ export default function RelatedRecordTable<
   onSaveCallback,
   rowActionComponent,
   rowActionComponentAdditionalProps,
-  additionalHeaderComponent,
+  headerButton,
   shouldShowColumnVisibilityPicker,
   localStorageKey,
 }: RelatedRecordTableProps<T, P>) {
@@ -147,7 +148,7 @@ export default function RelatedRecordTable<
         <div className="d-flex justify-content-between">
           <Card.Title>{header}</Card.Title>
           <div className="d-flex justify-content-end gap-2">
-            {additionalHeaderComponent && additionalHeaderComponent}
+            {headerButton && headerButton}
             {shouldShowColumnVisibilityPicker && (
               <TableSettingsMenu
                 columnVisibilitySettings={columnVisibilitySettings}

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -48,7 +48,7 @@ interface RelatedRecordTableProps<
   headerButton?: React.ReactNode;
 
   /**
-   * Enable column visibility picker
+   * Show a column visibility picker
    */
   shouldShowColumnVisibilityPicker?: boolean;
 

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -133,7 +133,7 @@ export default function RelatedRecordTable<
 
   return (
     <Card>
-      <Card.Header className="d-flex justify-content-between align-items-center">
+      <Card.Header className="d-flex justify-content-between">
         {typeof header === "string" ? (
           <Card.Title>{header}</Card.Title>
         ) : (

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -3,8 +3,9 @@ import Table from "react-bootstrap/Table";
 import RelatedRecordTableRow from "@/components/RelatedRecordTableRow";
 import TableSettingsMenu from "@/components/TableSettingsMenu";
 import { ColDataCardDef } from "@/types/types";
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { ColumnVisibilitySetting } from "@/types/types";
+import { useVisibleColumns } from "@/components/TableSettingsMenu";
 
 interface RelatedRecordTableProps<
   T extends Record<string, unknown>,
@@ -63,6 +64,9 @@ interface RelatedRecordTableProps<
    * Callback function to be executed after a row edit is saved
    */
   onSaveCallback: () => Promise<void>;
+
+  /** Use an empty string if table does not have column visibility settings */
+  localStorageKey: string;
 }
 
 export interface RowActionComponentProps<
@@ -111,7 +115,13 @@ export default function RelatedRecordTable<
   rowActionComponentAdditionalProps,
   headerComponent,
   shouldShowColumnVisibilityPicker,
+  localStorageKey,
 }: RelatedRecordTableProps<T, P>) {
+  const [
+    isColVisibilityLocalStorageLoaded,
+    setIsColVisibilityLocalStorageLoaded,
+  ] = useState(false);
+
   /**
    * Initialize column visibility from provided columns
    */
@@ -127,25 +137,8 @@ export default function RelatedRecordTable<
       }))
   );
 
-  /**
-   * Construct the table's visibile columns
-   */
-  const visibleColumns = useMemo(
-    () =>
-      columns.filter((col) => {
-        const colFromVisibilitySettings = columnVisibilitySettings.find(
-          (visibleColumn) => visibleColumn.path === col.path
-        );
-        /**
-         * if a matching column is found in the visibility settings, use it
-         * otherwise the column is visible unless it's exportOnly or defaultHidden
-         */
-        return colFromVisibilitySettings
-          ? colFromVisibilitySettings.isVisible
-          : !col.exportOnly && !col.defaultHidden;
-      }),
-    [columns, columnVisibilitySettings]
-  );
+  /** Columns that should be visible based on user column visibility settings */
+  const visibleColumns = useVisibleColumns(columns, columnVisibilitySettings);
 
   return (
     <Card>
@@ -158,6 +151,13 @@ export default function RelatedRecordTable<
               <TableSettingsMenu
                 columnVisibilitySettings={columnVisibilitySettings}
                 setColumnVisibilitySettings={setColumnVisibilitySettings}
+                localStorageKey={localStorageKey}
+                isColVisibilityLocalStorageLoaded={
+                  isColVisibilityLocalStorageLoaded
+                }
+                setIsColVisibilityLocalStorageLoaded={
+                  setIsColVisibilityLocalStorageLoaded
+                }
               ></TableSettingsMenu>
             )}
           </div>

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -144,25 +144,27 @@ export default function RelatedRecordTable<
 
   return (
     <Card>
-      <Card.Header>
-        <div className="d-flex justify-content-between">
+      <Card.Header className="d-flex justify-content-between align-items-center">
+        {typeof header === "string" ? (
           <Card.Title>{header}</Card.Title>
-          <div className="d-flex justify-content-end gap-2">
-            {headerButton && headerButton}
-            {shouldShowColumnVisibilityPicker && (
-              <TableColumnVisibilityMenu
-                columnVisibilitySettings={columnVisibilitySettings}
-                setColumnVisibilitySettings={setColumnVisibilitySettings}
-                localStorageKey={localStorageKey}
-                isColVisibilityLocalStorageLoaded={
-                  isColVisibilityLocalStorageLoaded
-                }
-                setIsColVisibilityLocalStorageLoaded={
-                  setIsColVisibilityLocalStorageLoaded
-                }
-              ></TableColumnVisibilityMenu>
-            )}
-          </div>
+        ) : (
+          <div>{header}</div>
+        )}
+        <div className="d-flex gap-2">
+          {headerButton && headerButton}
+          {shouldShowColumnVisibilityPicker && (
+            <TableColumnVisibilityMenu
+              columnVisibilitySettings={columnVisibilitySettings}
+              setColumnVisibilitySettings={setColumnVisibilitySettings}
+              localStorageKey={localStorageKey}
+              isColVisibilityLocalStorageLoaded={
+                isColVisibilityLocalStorageLoaded
+              }
+              setIsColVisibilityLocalStorageLoaded={
+                setIsColVisibilityLocalStorageLoaded
+              }
+            ></TableColumnVisibilityMenu>
+          )}
         </div>
       </Card.Header>
       <Card.Body>

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -66,9 +66,9 @@ interface RelatedRecordTableProps<
    */
   onSaveCallback: () => Promise<void>;
 
-  /** The key to use when saving and loading table data to local storage.
-   * Use an empty string if table does not have column visibility settings */
-  localStorageKey: string;
+  /** The key to use when saving and loading table column visibility data to local storage.
+   * Optional because not all tables have col visibility settings enabled */
+  localStorageKey?: string;
 }
 
 export interface RowActionComponentProps<

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -44,7 +44,7 @@ interface RelatedRecordTableProps<
   /**
    * Optional component to be rendered alongside the title in the card header
    */
-  headerComponent?: React.ReactNode;
+  additionalHeaderComponent?: React.ReactNode;
 
   /**
    * Enable column visibility picker
@@ -114,7 +114,7 @@ export default function RelatedRecordTable<
   onSaveCallback,
   rowActionComponent,
   rowActionComponentAdditionalProps,
-  headerComponent,
+  additionalHeaderComponent,
   shouldShowColumnVisibilityPicker,
   localStorageKey,
 }: RelatedRecordTableProps<T, P>) {
@@ -147,7 +147,7 @@ export default function RelatedRecordTable<
         <div className="d-flex justify-content-between">
           <Card.Title>{header}</Card.Title>
           <div className="d-flex justify-content-end gap-2">
-            {headerComponent && headerComponent}
+            {additionalHeaderComponent && additionalHeaderComponent}
             {shouldShowColumnVisibilityPicker && (
               <TableSettingsMenu
                 columnVisibilitySettings={columnVisibilitySettings}

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import Card from "react-bootstrap/Card";
 import Table from "react-bootstrap/Table";
 import RelatedRecordTableRow from "@/components/RelatedRecordTableRow";
-import TableSettingsMenu from "@/components/TableSettingsMenu";
-import { useVisibleColumns } from "@/components/TableSettingsMenu";
+import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
+import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 import { ColDataCardDef } from "@/types/types";
 import { ColumnVisibilitySetting } from "@/types/types";
 
@@ -150,7 +150,7 @@ export default function RelatedRecordTable<
           <div className="d-flex justify-content-end gap-2">
             {headerButton && headerButton}
             {shouldShowColumnVisibilityPicker && (
-              <TableSettingsMenu
+              <TableColumnVisibilityMenu
                 columnVisibilitySettings={columnVisibilitySettings}
                 setColumnVisibilitySettings={setColumnVisibilitySettings}
                 localStorageKey={localStorageKey}
@@ -160,7 +160,7 @@ export default function RelatedRecordTable<
                 setIsColVisibilityLocalStorageLoaded={
                   setIsColVisibilityLocalStorageLoaded
                 }
-              ></TableSettingsMenu>
+              ></TableColumnVisibilityMenu>
             )}
           </div>
         </div>

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -1,11 +1,11 @@
+import { useState } from "react";
 import Card from "react-bootstrap/Card";
 import Table from "react-bootstrap/Table";
 import RelatedRecordTableRow from "@/components/RelatedRecordTableRow";
 import TableSettingsMenu from "@/components/TableSettingsMenu";
-import { ColDataCardDef } from "@/types/types";
-import { useState } from "react";
-import { ColumnVisibilitySetting } from "@/types/types";
 import { useVisibleColumns } from "@/components/TableSettingsMenu";
+import { ColDataCardDef } from "@/types/types";
+import { ColumnVisibilitySetting } from "@/types/types";
 
 interface RelatedRecordTableProps<
   T extends Record<string, unknown>,

--- a/editor/components/RelatedRecordTable.tsx
+++ b/editor/components/RelatedRecordTable.tsx
@@ -36,10 +36,9 @@ interface RelatedRecordTableProps<
    */
   noRowsMessage?: string;
   /**
-   * The card header string or component to be rendered in the table's card header. If a string is
-   * provided, it will be rendered as a <Card.Title>
+   * The card header string to be rendered as a <Card.Title>
    */
-  header: React.ReactNode;
+  headerTitle: React.ReactNode;
 
   /**
    * Optional component to be rendered alongside the tite in the card header
@@ -152,7 +151,7 @@ export default function RelatedRecordTable<
     <Card>
       <Card.Header>
         <div className="d-flex justify-content-between">
-          <Card.Title>{header}</Card.Title>
+          <Card.Title>{headerTitle}</Card.Title>
           <div className="d-flex justify-content-end gap-2">
             {headerComponent && headerComponent}
             {shouldShowColumnVisibilityPicker && (

--- a/editor/components/TableColumnVisibilityMenu.tsx
+++ b/editor/components/TableColumnVisibilityMenu.tsx
@@ -37,7 +37,8 @@ interface TableColumnVisibilityMenuProps {
 }
 
 /**
- * Construct the table's visible columns
+ * Custom hook that is used in tables with column visibility settings
+ * and constructs the table's visible columns
  */
 export const useVisibleColumns = <T extends Record<string, unknown>>(
   columns: ColDataCardDef<T>[],

--- a/editor/components/TableColumnVisibilityMenu.tsx
+++ b/editor/components/TableColumnVisibilityMenu.tsx
@@ -11,7 +11,7 @@ import { FaGear } from "react-icons/fa6";
 import { ColumnVisibilitySetting } from "@/types/types";
 import { ColDataCardDef } from "@/types/types";
 
-interface TableSettingsMenuProps {
+interface TableColumnVisibilityMenuProps {
   /**
    *  Array of columns and their visibility settings
    */
@@ -63,13 +63,13 @@ export const useVisibleColumns = <T extends Record<string, unknown>>(
 /**
  * Table component that controls column visibility
  */
-export default function TableSettingsMenu({
+export default function TableColumnVisibilityMenu({
   columnVisibilitySettings,
   setColumnVisibilitySettings,
   isColVisibilityLocalStorageLoaded,
   setIsColVisibilityLocalStorageLoaded,
   localStorageKey,
-}: TableSettingsMenuProps) {
+}: TableColumnVisibilityMenuProps) {
   const handleUpdateColVisibility = useCallback(
     (columns: ColumnVisibilitySetting[], path: string) => {
       const updatedColVisibilitySettings = columns.map((col) => {

--- a/editor/components/TableColumnVisibilityMenu.tsx
+++ b/editor/components/TableColumnVisibilityMenu.tsx
@@ -31,9 +31,9 @@ interface TableColumnVisibilityMenuProps {
    */
   setIsColVisibilityLocalStorageLoaded: Dispatch<SetStateAction<boolean>>;
   /**
-   * The key to use when saving and loading table data to local storage
+   * The key to use when saving and loading table column visibility data to local storage.
    */
-  localStorageKey: string;
+  localStorageKey?: string;
 }
 
 /**
@@ -96,6 +96,13 @@ export default function TableColumnVisibilityMenu({
   useEffect(() => {
     if (isColVisibilityLocalStorageLoaded) {
       return;
+    }
+
+    // Throw an error if localStorageKey was not provided
+    if (!localStorageKey) {
+      throw new Error(
+        "localStorageKey is required to load column visibility settings"
+      );
     }
 
     /**

--- a/editor/components/TableColumnVisibilityMenu.tsx
+++ b/editor/components/TableColumnVisibilityMenu.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useMemo,
   useEffect,
+  useState,
 } from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
@@ -37,14 +38,28 @@ interface TableColumnVisibilityMenuProps {
 }
 
 /**
- * Custom hook that is used in tables with column visibility settings
- * and constructs the table's visible columns
+ * Custom hook that is used in tables with column visibility settings.
+ * It initializes the state for column visibility settings and returns it along with
+ * the state setter and an array of visible columns
  */
 export const useVisibleColumns = <T extends Record<string, unknown>>(
-  columns: ColDataCardDef<T>[],
-  columnVisibilitySettings: ColumnVisibilitySetting[]
-) =>
-  useMemo(
+  columns: ColDataCardDef<T>[]
+) => {
+  /**
+   * Initialize column visibility from provided columns
+   */
+  const [columnVisibilitySettings, setColumnVisibilitySettings] = useState<
+    ColumnVisibilitySetting[]
+  >(
+    columns
+      .filter((col) => !col.exportOnly)
+      .map((col) => ({
+        path: String(col.path),
+        isVisible: !col.defaultHidden,
+        label: col.label,
+      }))
+  );
+  const visibleColumns = useMemo(
     () =>
       columns.filter((col) => {
         const colFromVisibilitySettings = columnVisibilitySettings.find(
@@ -60,6 +75,15 @@ export const useVisibleColumns = <T extends Record<string, unknown>>(
       }),
     [columns, columnVisibilitySettings]
   );
+  return {
+    /** Columns that should be visible based on user column visibility settings */
+    visibleColumns,
+    /** State of column visibility settings */
+    columnVisibilitySettings,
+    /** Sets state of column visibility settings */
+    setColumnVisibilitySettings,
+  };
+};
 
 /**
  * Table component that controls column visibility

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -30,7 +30,7 @@ interface PaginationControlProps {
    */
   setQueryConfig: Dispatch<SetStateAction<QueryConfig>>;
   /**
-   * The number of records displayed on the peach
+   * The number of records displayed on the page
    */
   recordCount: number;
   /**
@@ -86,8 +86,6 @@ export default function TablePaginationControls({
     recordCount === 0 || queryConfig.offset === 0 || isLoading;
   const pageRightButtonDisabled =
     totalRecordCount <= queryConfig.limit || isLoading;
-
-  console.log(recordCount);
 
   return (
     <ButtonToolbar>

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -22,6 +22,9 @@ interface PaginationControlProps {
   isLoading: boolean;
   onClickDownload: () => void;
   exportable: boolean;
+  isColVisibilityLocalStorageLoaded: boolean;
+  setIsColVisibilityLocalStorageLoaded: Dispatch<SetStateAction<boolean>>;
+  localStorageKey: string;
 }
 
 /**
@@ -37,6 +40,9 @@ export default function TablePaginationControls({
   isLoading,
   onClickDownload,
   exportable,
+  localStorageKey,
+  isColVisibilityLocalStorageLoaded,
+  setIsColVisibilityLocalStorageLoaded,
 }: PaginationControlProps) {
   const currentPageNum = queryConfig.offset / queryConfig.limit + 1;
 
@@ -118,6 +124,11 @@ export default function TablePaginationControls({
       <TableSettingsMenu
         columnVisibilitySettings={columnVisibilitySettings}
         setColumnVisibilitySettings={setColumnVisibilitySettings}
+        localStorageKey={localStorageKey}
+        isColVisibilityLocalStorageLoaded={isColVisibilityLocalStorageLoaded}
+        setIsColVisibilityLocalStorageLoaded={
+          setIsColVisibilityLocalStorageLoaded
+        }
       />
     </ButtonToolbar>
   );

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -5,7 +5,7 @@ import ButtonGroup from "react-bootstrap/ButtonGroup";
 import ButtonToolbar from "react-bootstrap/ButtonToolbar";
 import { FaAngleLeft, FaAngleRight, FaDownload } from "react-icons/fa6";
 import AlignedLabel from "./AlignedLabel";
-import TableSettingsMenu from "@/components/TableSettingsMenu";
+import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
 import { QueryConfig } from "@/types/queryBuilder";
 import { ColumnVisibilitySetting } from "@/types/types";
 import "react-datepicker/dist/react-datepicker.css";
@@ -157,7 +157,7 @@ export default function TablePaginationControls({
           <FaAngleRight />
         </Button>
       </ButtonGroup>
-      <TableSettingsMenu
+      <TableColumnVisibilityMenu
         columnVisibilitySettings={columnVisibilitySettings}
         setColumnVisibilitySettings={setColumnVisibilitySettings}
         localStorageKey={localStorageKey}

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -11,19 +11,55 @@ import { ColumnVisibilitySetting } from "@/types/types";
 import "react-datepicker/dist/react-datepicker.css";
 
 interface PaginationControlProps {
+  /**
+   *  Array of columns and their visibility settings
+   */
   columnVisibilitySettings: ColumnVisibilitySetting[];
+  /**
+   * Sets the column visibility settings
+   */
   setColumnVisibilitySettings: Dispatch<
     SetStateAction<ColumnVisibilitySetting[]>
   >;
+  /**
+   * The graphql query configuration
+   */
   queryConfig: QueryConfig;
+  /**
+   * Sets the queryConfig
+   */
   setQueryConfig: Dispatch<SetStateAction<QueryConfig>>;
+  /**
+   * The number of records displayed on the peach
+   */
   recordCount: number;
+  /**
+   * The total number of records that match the query
+   */
   totalRecordCount: number;
+  /**
+   * Are the query results loading
+   */
   isLoading: boolean;
+  /**
+   * Function that opens the export modal when download button is clicked
+   */
   onClickDownload: () => void;
+  /**
+   * Should the table have the download button
+   */
   exportable: boolean;
+  /**
+   * Has the local storage item for column visibility been loaded
+   */
   isColVisibilityLocalStorageLoaded: boolean;
+  /**
+   * Set whether the column visibility local storage item has loaded
+   */
   setIsColVisibilityLocalStorageLoaded: Dispatch<SetStateAction<boolean>>;
+  /**
+   * The key to use when saving and loading table data to local storage
+   */
   localStorageKey: string;
 }
 
@@ -50,6 +86,8 @@ export default function TablePaginationControls({
     recordCount === 0 || queryConfig.offset === 0 || isLoading;
   const pageRightButtonDisabled =
     totalRecordCount <= queryConfig.limit || isLoading;
+
+  console.log(recordCount);
 
   return (
     <ButtonToolbar>

--- a/editor/components/TableSettingsMenu.tsx
+++ b/editor/components/TableSettingsMenu.tsx
@@ -7,8 +7,8 @@ import {
 } from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
-import { ColumnVisibilitySetting } from "@/types/types";
 import { FaGear } from "react-icons/fa6";
+import { ColumnVisibilitySetting } from "@/types/types";
 import { ColDataCardDef } from "@/types/types";
 
 interface TableSettingsMenuProps {

--- a/editor/components/TableSettingsMenu.tsx
+++ b/editor/components/TableSettingsMenu.tsx
@@ -12,12 +12,27 @@ import { FaGear } from "react-icons/fa6";
 import { ColDataCardDef } from "@/types/types";
 
 interface TableSettingsMenuProps {
+  /**
+   *  Array of columns and their visibility settings
+   */
   columnVisibilitySettings: ColumnVisibilitySetting[];
+  /**
+   * Sets the column visibility settings
+   */
   setColumnVisibilitySettings: Dispatch<
     SetStateAction<ColumnVisibilitySetting[]>
   >;
+  /**
+   * Has the local storage item for column visibility been loaded
+   */
   isColVisibilityLocalStorageLoaded: boolean;
+  /**
+   * Set whether the column visibility local storage item has loaded
+   */
   setIsColVisibilityLocalStorageLoaded: Dispatch<SetStateAction<boolean>>;
+  /**
+   * The key to use when saving and loading table data to local storage
+   */
   localStorageKey: string;
 }
 

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -13,7 +13,7 @@ import TablePaginationControls from "@/components/TablePaginationControls";
 import TableResetFiltersToggle from "@/components/TableResetFiltersToggle";
 import TableSearch, { SearchSettings } from "@/components/TableSearch";
 import TableSearchFieldSelector from "@/components/TableSearchFieldSelector";
-import { useVisibleColumns } from "@/components/TableSettingsMenu";
+import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 import { QueryConfigSchema } from "@/schema/queryBuilder";
 import { Filter, QueryConfig } from "@/types/queryBuilder";
 import { ColDataCardDef, ColumnVisibilitySetting } from "@/types/types";

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -1,26 +1,27 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Spinner from "react-bootstrap/Spinner";
-import isEqual from "lodash/isEqual";
-import cloneDeep from "lodash/cloneDeep";
-import { useQuery } from "@/utils/graphql";
 import Table from "@/components/Table";
-import TableSearch, { SearchSettings } from "@/components/TableSearch";
-import TableDateSelector from "@/components/TableDateSelector";
-import { makeDateFilterFromMode } from "@/utils/dates";
-import TableSearchFieldSelector from "@/components/TableSearchFieldSelector";
-import { useQueryBuilder, useExportQuery } from "@/utils/queryBuilder";
-import { QueryConfig, Filter } from "@/types/queryBuilder";
-import { ColDataCardDef, ColumnVisibilitySetting } from "@/types/types";
 import TableAdvancedSearchFilterMenu from "@/components/TableAdvancedSearchFilterMenu";
-import TableAdvancedSearchFilterToggle from "@/components/TableAdvancedSearchFilterToggle";
+import TableAdvancedSearchFilterToggle, {
+  useActiveSwitchFilterCount,
+} from "@/components/TableAdvancedSearchFilterToggle";
+import TableDateSelector from "@/components/TableDateSelector";
 import TableExportModal from "@/components/TableExportModal";
 import TablePaginationControls from "@/components/TablePaginationControls";
-import { useActiveSwitchFilterCount } from "@/components/TableAdvancedSearchFilterToggle";
 import TableResetFiltersToggle from "@/components/TableResetFiltersToggle";
-import { QueryConfigSchema } from "@/schema/queryBuilder";
+import TableSearch, { SearchSettings } from "@/components/TableSearch";
+import TableSearchFieldSelector from "@/components/TableSearchFieldSelector";
 import { useVisibleColumns } from "@/components/TableSettingsMenu";
+import { QueryConfigSchema } from "@/schema/queryBuilder";
+import { Filter, QueryConfig } from "@/types/queryBuilder";
+import { ColDataCardDef, ColumnVisibilitySetting } from "@/types/types";
+import { makeDateFilterFromMode } from "@/utils/dates";
+import { useQuery } from "@/utils/graphql";
+import { useExportQuery, useQueryBuilder } from "@/utils/queryBuilder";
+import cloneDeep from "lodash/cloneDeep";
+import isEqual from "lodash/isEqual";
 
 interface TableProps<T extends Record<string, unknown>> {
   columns: ColDataCardDef<T>[];

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -16,7 +16,7 @@ import TableSearchFieldSelector from "@/components/TableSearchFieldSelector";
 import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 import { QueryConfigSchema } from "@/schema/queryBuilder";
 import { Filter, QueryConfig } from "@/types/queryBuilder";
-import { ColDataCardDef, ColumnVisibilitySetting } from "@/types/types";
+import { ColDataCardDef } from "@/types/types";
 import { makeDateFilterFromMode } from "@/utils/dates";
 import { useQuery } from "@/utils/graphql";
 import { useExportQuery, useQueryBuilder } from "@/utils/queryBuilder";
@@ -68,20 +68,6 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   ] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
 
-  /**
-   * Initialize column visibility from provided columns
-   */
-  const [columnVisibilitySettings, setColumnVisibilitySettings] = useState<
-    ColumnVisibilitySetting[]
-  >(
-    columns
-      .filter((col) => !col.exportOnly)
-      .map((col) => ({
-        path: String(col.path),
-        isVisible: !col.defaultHidden,
-        label: col.label,
-      }))
-  );
   const [searchSettings, setSearchSettings] = useState<SearchSettings>({
     searchString: String(initialQueryConfig.searchFilter.value),
     searchColumn: initialQueryConfig.searchFilter.column,
@@ -90,8 +76,13 @@ export default function TableWrapper<T extends Record<string, unknown>>({
     ...initialQueryConfig,
   });
 
-  /** Columns that should be visible based on user column visibility settings */
-  const visibleColumns = useVisibleColumns(columns, columnVisibilitySettings);
+  /** Use custom hook to get array of visible columns, column visibility settings,
+   * and state setter function */
+  const {
+    visibleColumns,
+    columnVisibilitySettings,
+    setColumnVisibilitySettings,
+  } = useVisibleColumns(columns);
 
   const query = useQueryBuilder(
     queryConfig,


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/23455#issuecomment-3050264437

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-1814--atd-vze-staging.netlify.app/editor/crashes)

**Steps to test:**
1. Go to the crashes list page. Make sure the column visibility settings menu is still working the same. Refresh the page and see your changes persist.
2. Repeat step 1 for the EMS list page.
3. Now go to an EMS incident that has been matched to a crash. You should see a gear button in the Possible people matches table. Open dev tools and see the local storage item `emsPossiblePeople_columnVisibility`. Test unselecting columns and refreshing to see your changes persist. 
4. Click on the crash id for the incident to be rerouted to the crash details page. You should see gear buttons in the People, Units, and EMS patient care tables. Find them in dev tools local storage.
5. Make changes to the column visibility for all of these tables, refresh to see your changes persist.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
