### PR TITLE
Dispatch EMS match events from people record inserts + updates 

### DIFF
--- a/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/down.sql
@@ -226,3 +226,5 @@ DROP COLUMN matched_person_ids,
 DROP COLUMN _match_event_name,
 drop constraint check_person_id_crash_pk_dependency;
 
+DROP TRIGGER IF EXISTS people_dispatch_ems_match_trigger ON people;
+DROP FUNCTION if EXISTS people_dispatch_ems_match();

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -311,7 +311,12 @@ BEGIN
             END IF;
         END IF;
     END IF;
-    -- todo: do we need this line?
+    -- 
+    -- Finally, we set NEW._match_event_name = null as a failsafe to make sure
+    -- that this function never returns before nullifying _match_event_name.
+    -- If _match_event_name is not nullified before this function returns we 
+    -- will fail a check constraint on this column
+    --
     NEW._match_event_name = null;
     return NEW;
 END;

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -491,7 +491,7 @@ $function$;
 
 DROP TRIGGER IF EXISTS people_dispatch_ems_match_trigger ON people;
 CREATE TRIGGER people_dispatch_ems_match_trigger AFTER
-UPDATE ON people FOR EACH ROW
+INSERT OR UPDATE ON people FOR EACH ROW
 EXECUTE FUNCTION people_dispatch_ems_match();
 
 -- delete this trigger/function which is now redundant

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -466,9 +466,8 @@ END;
 $function$;
 
 
-
 --
--- This is a new function which handles when a person record is inserted or updated
+-- This is a new function that triggers EMS re-matching when a person record is inserted or updated
 --
 CREATE
 OR REPLACE FUNCTION public.people_dispatch_ems_match() RETURNS trigger LANGUAGE plpgsql AS $function$

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -152,6 +152,8 @@ BEGIN
     -- `match_person_by_manual_qa` is set when a person match is selected through the VZE UI
     --
     IF NEW._match_event_name = 'match_person_by_manual_qa' and NEW.person_id is not null then
+        NEW.person_match_status = 'matched_by_manual_qa';
+
         -- 
         -- Keep the record's crash_pk in sync with the provided person_id -
         -- we must grab the new person record's crash_pk from their unit record
@@ -165,7 +167,7 @@ BEGIN
             raise debug 'updating EMS record ID % crash_pk to % to match updated person_id', NEW.id, matching_person_record_crash_pk;
             NEW.crash_pk = matching_person_record_crash_pk;
             NEW.crash_match_status = 'matched_by_manual_qa';
-            NEW.person_match_status = 'matched_by_manual_qa';
+
         END IF;
         -- clear the _match_event_name
         NEW._match_event_name = null;
@@ -227,6 +229,9 @@ BEGIN
             raise debug 'Reset EMS ID % crash_match_status to matched_by_automation', NEW.id;
             NEW.crash_pk = NEW.matched_crash_pks[1];
             NEW.crash_match_status = 'matched_by_automation';
+            NEW.person_id = NULL;
+            NEW.person_match_status = 'unmatched';
+            NEW.matched_person_ids = NULL;
             -- don't return here so that we proceed to person matching
         ELSE
             raise debug 'Reset EMS ID % to multiple_matches_by_automation', NEW.id;

--- a/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
+++ b/database/migrations/default/1750435376415_ems_person_match_auto/up.sql
@@ -156,9 +156,10 @@ BEGIN
         -- Keep the record's crash_pk in sync with the provided person_id -
         -- we must grab the new person record's crash_pk from their unit record
         --
-        SELECT crash_pk INTO matching_person_record_crash_pk
-        FROM units 
-        WHERE id = NEW.unit_id;
+        SELECT units.crash_pk INTO matching_person_record_crash_pk
+        FROM people
+        LEFT JOIN units on units.id = people.unit_id
+        WHERE people.id = NEW.person_id;
 
         IF matching_person_record_crash_pk IS DISTINCT FROM NEW.crash_pk then
             raise debug 'updating EMS record ID % crash_pk to % to match updated person_id', NEW.id, matching_person_record_crash_pk;

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -12,6 +12,7 @@ import {
   UPDATE_EMS_INCIDENT,
   UPDATE_EMS_INCIDENT_CRASH_AND_PERSON,
 } from "@/queries/ems";
+import { UPDATE_PERSON } from "@/queries/person";
 import { EMSPatientCareRecord } from "@/types/ems";
 import RelatedRecordTable from "@/components/RelatedRecordTable";
 import EMSLinkRecordButton, {
@@ -250,7 +251,7 @@ export default function EMSDetailsPage({
             noRowsMessage="No people found"
             header="Possible people matches"
             columns={emsMatchingPeopleColumns}
-            mutation=""
+            mutation={UPDATE_PERSON}
             onSaveCallback={onSaveCallback}
             rowActionComponent={EMSLinkToPersonButton}
             rowActionComponentAdditionalProps={linkToPersonButtonProps}


### PR DESCRIPTION
## Associated issues

This PR builds on https://github.com/cityofaustin/vision-zero/pull/1811 by taking people record inserts and edits into consideration.

## Testing

**URL to test:** Local

1. Start your local stack with a recent copy of prod
2. Apply migrations and metadata
3. Navigate to crash ID [17804147](http://localhost:3002/editor/crashes/17804147) and edit the crash location by moving it just a few feet. We do this to "backfill" the initial record matching state.
4. Scroll down to the **EMS Patient Care** card and notice that we have one EMS-person match and three unmatched records.
5. Navigate to the matched EMS incident by clicking on the link in the **EMS Patient Care** table or here: [#20215-0374](http://localhost:3002/editor/ems/20215-0374)
6. In the **Possible people matches** table, edit the **Race/Ethnicity** of person ID `391216` by changing the person's race from **White** to **Hispanic**. Upon saving your changes, notice that this person ID is now assigned to an EMS patient record. Although this kind of edit should be rare via the UI, demographic updates will be more common from CRIS. So we've now tested that case.
7. Notice that we have an EMS patient, age 17, that is unacconted for in the **Possible people matches** table. Use your DB client to create a person record that will match to this EMS record:

```sql
-- enable debug logging
set client_min_messages to 'DEBUG';

-- create person record
INSERT INTO
    people (id, prsn_nbr, prsn_age, prsn_ethnicity_id, prsn_gndr_id, unit_id, prsn_injry_sev_id)
VALUES
    (99999999, 9, 17, 2, 1, 285142, 2);
```

8. Refresh the incident details page and confirm that person ID `99999999` is now matched to an EMS patient record.
9. In the **Possible people matches** table, edit person ID `359980` by setting their age to `17`. Confirm that there is now only one EMS record matched to a person. Because we have two people records with same demographic identifiers, the trigger removed the automated match.
10. Use the inline **Select person** button to match the age 17 EMS patient to person ID `359980`
11. In the **Possible people matches** table, again edit person ID `359980` by setting their age back to `49`. Confirm that that this person is still matched to the age `17` EMS record. The match has persisted because you manually assigned it ✅
12. I am running additional tests using the CRIS import ETL, but you don't have to do that unless you'd really like to 😅 

That covers the testing for this PR. The parent PR has further testing that will need to be re-checked once this PR is merged 👍

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
