### PR TITLE
Ability to customize column visibility on data cards

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -132,6 +132,8 @@ export default function CrashDetailsPage({
             columns={crashDataCards.summary}
             mutation={UPDATE_CRASH}
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPageSummary"
           />
         </Col>
         <Col sm={12} md={6} lg={4} className="mb-3">
@@ -142,6 +144,8 @@ export default function CrashDetailsPage({
             columns={crashDataCards.flags}
             mutation={UPDATE_CRASH}
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPageFlags"
           />
         </Col>
         <Col sm={12} md={6} lg={4} className="mb-3">
@@ -152,6 +156,8 @@ export default function CrashDetailsPage({
             columns={crashDataCards.other}
             mutation={UPDATE_CRASH}
             onSaveCallback={onSaveCallback}
+            shouldShowColumnVisibilityPicker={true}
+            localStorageKey="crashPageOther"
           />
         </Col>
       </Row>

--- a/editor/components/DataCard.tsx
+++ b/editor/components/DataCard.tsx
@@ -14,6 +14,8 @@ import { ColDataCardDef } from "@/types/types";
 import { LookupTableOption } from "@/types/relationships";
 import { useAuth0 } from "@auth0/auth0-react";
 import { hasRole } from "@/utils/auth";
+import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
+import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 
 export interface HeaderActionComponentProps<T extends Record<string, unknown>> {
   record: T;
@@ -22,13 +24,41 @@ export interface HeaderActionComponentProps<T extends Record<string, unknown>> {
 }
 
 interface DataCardProps<T extends Record<string, unknown>> {
+  /**
+   * The record that contains the data to be displayed
+   */
   record: T;
+  /**
+   * The tables column definitions
+   */
   columns: ColDataCardDef<T>[];
+  /**
+   * Graphql mutation that will be executed when a row is edited
+   */
   mutation: string;
+  /**
+   * If the SWR refetcher is (re)validating
+   */
   isValidating: boolean;
+  /**
+   * Title to be used in the card header
+   */
   title: string;
+  /**
+   * Callback function to be executed after a row is edited
+   */
   onSaveCallback: () => Promise<void>;
+  /**
+   * Optional component that will render in the card header
+   */
   headerActionComponent?: React.ComponentType<HeaderActionComponentProps<T>>;
+  /**
+   * Show a column visibility picker
+   */
+  shouldShowColumnVisibilityPicker?: boolean;
+  /** The key to use when saving and loading table column visibility data to local storage.
+   * Optional because not all tables have col visibility settings enabled */
+  localStorageKey?: string;
 }
 
 /**
@@ -42,7 +72,14 @@ export default function DataCard<T extends Record<string, unknown>>({
   title,
   onSaveCallback,
   headerActionComponent: HeaderActionComponent,
+  shouldShowColumnVisibilityPicker,
+  localStorageKey,
 }: DataCardProps<T>) {
+  const [
+    isColVisibilityLocalStorageLoaded,
+    setIsColVisibilityLocalStorageLoaded,
+  ] = useState(false);
+
   const [editColumn, setEditColumn] = useState<ColDataCardDef<T> | null>(null);
   const { mutate, loading: isMutating } = useMutation(mutation);
   const [query, typename] = useLookupQuery(
@@ -87,6 +124,14 @@ export default function DataCard<T extends Record<string, unknown>>({
 
   const onCancel = () => setEditColumn(null);
 
+  /** Use custom hook to get array of visible columns, column visibility settings,
+   * and state setter function */
+  const {
+    visibleColumns,
+    columnVisibilitySettings,
+    setColumnVisibilitySettings,
+  } = useVisibleColumns(columns);
+
   return (
     <Card>
       <Card.Header className="d-flex justify-content-between border-none">
@@ -98,11 +143,24 @@ export default function DataCard<T extends Record<string, unknown>>({
             onSaveCallback={onSaveCallback}
           />
         )}
+        {shouldShowColumnVisibilityPicker && (
+          <TableColumnVisibilityMenu
+            columnVisibilitySettings={columnVisibilitySettings}
+            setColumnVisibilitySettings={setColumnVisibilitySettings}
+            localStorageKey={localStorageKey}
+            isColVisibilityLocalStorageLoaded={
+              isColVisibilityLocalStorageLoaded
+            }
+            setIsColVisibilityLocalStorageLoaded={
+              setIsColVisibilityLocalStorageLoaded
+            }
+          ></TableColumnVisibilityMenu>
+        )}
       </Card.Header>
       <Card.Body>
         <Table responsive hover>
           <tbody>
-            {columns.map((col) => {
+            {visibleColumns.map((col) => {
               const isEditingThisColumn = col.path === editColumn?.path;
               return (
                 <tr

--- a/editor/components/TableColumnVisibilityMenu.tsx
+++ b/editor/components/TableColumnVisibilityMenu.tsx
@@ -200,7 +200,7 @@ export default function TableColumnVisibilityMenu({
     <Dropdown>
       <Dropdown.Toggle
         variant="outline-primary"
-        className="border-0 hide-toggle"
+        className="border-0 hide-toggle pb-2"
         id="column-visibility-picker"
       >
         <FaGear />


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/23572

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Netlify

**Steps to test:**
1. Go to the crashes page. Flags and Other datacards should now have the column visibility gear picker
2. Test editing these col viz settings, refreshing your page they should persist.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
