### PR TITLE
Ability to select table page size

### DIFF
--- a/editor/components/TablePageSizeSelector.tsx
+++ b/editor/components/TablePageSizeSelector.tsx
@@ -40,7 +40,7 @@ export default function TablePageSizeSelector({
               const draftQueryConfig = produce(
                 queryConfig,
                 (draftQueryConfig) => {
-                  // type gaurd which enables us to assert that the selected page limit is allowed
+                  // type guard which enables us to assert that the selected page limit is allowed
                   if (
                     !ALLOWED_QUERY_PAGE_SIZES.includes(
                       newPageLimit as AllowedPageSize
@@ -49,7 +49,7 @@ export default function TablePageSizeSelector({
                     return;
                   }
                   draftQueryConfig.limit = newPageLimit as AllowedPageSize;
-                  // reset the current offset to return to the 1st page os results
+                  // reset the current offset to return to the 1st page of results
                   draftQueryConfig.offset = 0;
                   return draftQueryConfig;
                 }

--- a/editor/components/TablePageSizeSelector.tsx
+++ b/editor/components/TablePageSizeSelector.tsx
@@ -18,7 +18,7 @@ interface TablePageSizeSelectorProps {
 }
 
 /**
- * Table component that controls column visibility
+ * Table component that controls the the query limit, aka the page size
  */
 export default function TablePageSizeSelector({
   queryConfig,

--- a/editor/components/TablePageSizeSelector.tsx
+++ b/editor/components/TablePageSizeSelector.tsx
@@ -1,0 +1,68 @@
+import { Dispatch, SetStateAction } from "react";
+import { QueryConfig } from "@/types/queryBuilder";
+import Form from "react-bootstrap/form";
+import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Tooltip from "react-bootstrap/Tooltip";
+import { produce } from "immer";
+import { ALLOWED_QUERY_PAGE_SIZES, AllowedPageSize } from "@/utils/constants";
+
+interface TablePageSizeSelectorProps {
+  /**
+   * The graphql query configuration
+   */
+  queryConfig: QueryConfig;
+  /**
+   * Sets the queryConfig
+   */
+  setQueryConfig: Dispatch<SetStateAction<QueryConfig>>;
+}
+
+/**
+ * Table component that controls column visibility
+ */
+export default function TablePageSizeSelector({
+  queryConfig,
+  setQueryConfig,
+}: TablePageSizeSelectorProps) {
+  return (
+    <div className="my-auto me-2">
+      <OverlayTrigger
+        placement="top"
+        overlay={<Tooltip id="page-left-tooltip">Page size</Tooltip>}
+      >
+        <Form.Group className="d-flex">
+          <Form.Select
+            size="sm"
+            value={queryConfig.limit}
+            className="text-secondary"
+            onChange={(e) => {
+              const newPageLimit = Number(e.target.value);
+              const draftQueryConfig = produce(
+                queryConfig,
+                (draftQueryConfig) => {
+                  // type gaurd which enables us to assert that the selected page limit is allowed
+                  if (
+                    !ALLOWED_QUERY_PAGE_SIZES.includes(
+                      newPageLimit as AllowedPageSize
+                    )
+                  ) {
+                    return;
+                  }
+                  draftQueryConfig.limit = newPageLimit as AllowedPageSize;
+                  // reset the current offset to return to the 1st page os results
+                  draftQueryConfig.offset = 0;
+                  return draftQueryConfig;
+                }
+              );
+              setQueryConfig(draftQueryConfig);
+            }}
+          >
+            {ALLOWED_QUERY_PAGE_SIZES.map((value) => (
+              <option value={value}>{value.toLocaleString()}</option>
+            ))}
+          </Form.Select>
+        </Form.Group>
+      </OverlayTrigger>
+    </div>
+  );
+}

--- a/editor/components/TablePageSizeSelector.tsx
+++ b/editor/components/TablePageSizeSelector.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from "react";
 import { QueryConfig } from "@/types/queryBuilder";
-import Form from "react-bootstrap/form";
+import Form from "react-bootstrap/Form";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import { produce } from "immer";

--- a/editor/components/TablePageSizeSelector.tsx
+++ b/editor/components/TablePageSizeSelector.tsx
@@ -58,7 +58,7 @@ export default function TablePageSizeSelector({
             }}
           >
             {ALLOWED_QUERY_PAGE_SIZES.map((value) => (
-              <option value={value}>{value.toLocaleString()}</option>
+              <option key={value} value={value}>{value.toLocaleString()}</option>
             ))}
           </Form.Select>
         </Form.Group>

--- a/editor/components/TablePaginationControls.tsx
+++ b/editor/components/TablePaginationControls.tsx
@@ -4,10 +4,12 @@ import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import ButtonToolbar from "react-bootstrap/ButtonToolbar";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Spinner from "react-bootstrap/Spinner";
 import Tooltip from "react-bootstrap/Tooltip";
 import { FaAngleLeft, FaAngleRight, FaDownload } from "react-icons/fa6";
 import AlignedLabel from "./AlignedLabel";
 import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
+import TablePageSizeSelector from "@/components/TablePageSizeSelector";
 import { QueryConfig } from "@/types/queryBuilder";
 import { ColumnVisibilitySetting } from "@/types/types";
 
@@ -94,13 +96,16 @@ export default function TablePaginationControls({
 
   return (
     <ButtonToolbar>
+      <div className="d-flex align-items-center mx-2">
+        {isLoading && <Spinner variant="primary" />}
+      </div>
       <div className="text-nowrap text-secondary d-flex align-items-center me-2">
-        {totalRecordCount > 0 && (
+        {!isLoading && totalRecordCount > 0 && (
           <>
-            <span>{`Showing ${currentPageRowRange[0].toLocaleString()}-${currentPageRowRange[1].toLocaleString()} of ${totalRecordCount.toLocaleString()} results`}</span>
+            <span>{`${currentPageRowRange[0].toLocaleString()}-${currentPageRowRange[1].toLocaleString()} of ${totalRecordCount.toLocaleString()} results`}</span>
           </>
         )}
-        {totalRecordCount <= 0 && <span>No results</span>}
+        {!isLoading && totalRecordCount <= 0 && <span>No results</span>}
       </div>
       <ButtonGroup className="me-2" aria-label="Table pagniation controls">
         <OverlayTrigger
@@ -152,7 +157,10 @@ export default function TablePaginationControls({
           </Button>
         </OverlayTrigger>
       </ButtonGroup>
-
+      <TablePageSizeSelector
+        queryConfig={queryConfig}
+        setQueryConfig={setQueryConfig}
+      />
       {exportable && (
         <OverlayTrigger
           placement="top"

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
-import Spinner from "react-bootstrap/Spinner";
 import Table from "@/components/Table";
 import TableAdvancedSearchFilterToggle, {
   useActiveSwitchFilterCount,

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -310,10 +310,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
               />
             </Col>
           )}
-          <Col className="d-flex justify-content-end align-items-center mt-2">
-            {isLoading && <Spinner variant="primary" />}
-          </Col>
-          <Col className="d-flex justify-content-end mt-2" xs="auto">
+          <Col className="d-flex justify-content-end mt-2">
             <TablePaginationControls
               columnVisibilitySettings={columnVisibilitySettings}
               setColumnVisibilitySettings={setColumnVisibilitySettings}

--- a/editor/types/queryBuilder.ts
+++ b/editor/types/queryBuilder.ts
@@ -1,9 +1,5 @@
 import { TableMapConfig } from "@/types/tableMapConfig";
-import {
-  AllowedPageSize,
-  ExportPageSize,
-  MAX_RECORD_EXPORT_LIMIT,
-} from "@/utils/constants";
+import { AllowedPageSize, ExportPageSize } from "@/utils/constants";
 
 /**
  * The types we currently support as filter values

--- a/editor/types/queryBuilder.ts
+++ b/editor/types/queryBuilder.ts
@@ -1,5 +1,5 @@
 import { TableMapConfig } from "@/types/tableMapConfig";
-import { ALLOWED_QUERY_PAGE_SIZES, AllowedPageSize } from "@/utils/constants";
+import { AllowedPageSize, MAX_RECORD_EXPORT_LIMIT } from "@/utils/constants";
 
 /**
  * The types we currently support as filter values
@@ -120,7 +120,7 @@ export interface QueryConfig {
   /**
    * The record limit
    */
-  limit: AllowedPageSize;
+  limit: AllowedPageSize | typeof MAX_RECORD_EXPORT_LIMIT;
   /**
    * The query offset (for pagination)
    */

--- a/editor/types/queryBuilder.ts
+++ b/editor/types/queryBuilder.ts
@@ -1,4 +1,5 @@
 import { TableMapConfig } from "@/types/tableMapConfig";
+import { ALLOWED_QUERY_PAGE_SIZES, AllowedPageSize } from "@/utils/constants";
 
 /**
  * The types we currently support as filter values
@@ -119,7 +120,7 @@ export interface QueryConfig {
   /**
    * The record limit
    */
-  limit: number;
+  limit: AllowedPageSize;
   /**
    * The query offset (for pagination)
    */

--- a/editor/types/queryBuilder.ts
+++ b/editor/types/queryBuilder.ts
@@ -1,5 +1,9 @@
 import { TableMapConfig } from "@/types/tableMapConfig";
-import { AllowedPageSize, MAX_RECORD_EXPORT_LIMIT } from "@/utils/constants";
+import {
+  AllowedPageSize,
+  ExportPageSize,
+  MAX_RECORD_EXPORT_LIMIT,
+} from "@/utils/constants";
 
 /**
  * The types we currently support as filter values
@@ -120,7 +124,7 @@ export interface QueryConfig {
   /**
    * The record limit
    */
-  limit: AllowedPageSize | typeof MAX_RECORD_EXPORT_LIMIT;
+  limit: AllowedPageSize | ExportPageSize;
   /**
    * The query offset (for pagination)
    */

--- a/editor/utils/constants.ts
+++ b/editor/utils/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_QUERY_LIMIT = 50;
-export const MAX_RECORD_EXPORT_LIMIT = 1_000_000 as const;
+export const MAX_RECORD_EXPORT_LIMIT = 1_000_000;
 export type ExportPageSize = typeof MAX_RECORD_EXPORT_LIMIT;
 
 export const COLORS = {
@@ -8,5 +8,5 @@ export const COLORS = {
   warning: "#ffd22f",
 };
 
-export const ALLOWED_QUERY_PAGE_SIZES = [50, 250, 1000, 5000] as const;
+export const ALLOWED_QUERY_PAGE_SIZES = [10, 50, 250, 1000] as const;
 export type AllowedPageSize = (typeof ALLOWED_QUERY_PAGE_SIZES)[number];

--- a/editor/utils/constants.ts
+++ b/editor/utils/constants.ts
@@ -4,5 +4,8 @@ export const MAX_RECORD_EXPORT_LIMIT = 1_000_000;
 export const COLORS = {
   primary: "#1176d0",
   danger: "#dd0426",
-  warning: "#ffd22f"
+  warning: "#ffd22f",
 };
+
+export const ALLOWED_QUERY_PAGE_SIZES = [50, 250, 1000, 5000] as const;
+export type AllowedPageSize = (typeof ALLOWED_QUERY_PAGE_SIZES)[number];

--- a/editor/utils/constants.ts
+++ b/editor/utils/constants.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_QUERY_LIMIT = 50;
 export const MAX_RECORD_EXPORT_LIMIT = 1_000_000 as const;
+export type ExportPageSize = typeof MAX_RECORD_EXPORT_LIMIT;
 
 export const COLORS = {
   primary: "#1176d0",

--- a/editor/utils/constants.ts
+++ b/editor/utils/constants.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_QUERY_LIMIT = 50;
-export const MAX_RECORD_EXPORT_LIMIT = 1_000_000;
+export const MAX_RECORD_EXPORT_LIMIT = 1_000_000 as const;
 
 export const COLORS = {
   primary: "#1176d0",


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/24160

This adds a basic page-size selector to our fancy table component. I think it might be cool to have different page sizes/defaults between the map and list view. Or maybe a checkbox on the map view that says **Load all records** —something like that. Anyway, I left that out of scope.

<img width="455" height="184" alt="Screenshot 2025-08-14 at 2 08 12 PM" src="https://github.com/user-attachments/assets/88984d33-6f4d-4cdd-a349-53e5e83eeac1" />

## Testing

**URL to test:** Local because we're branched from a branch's branch

Visit the crashes, Locations, and fatalities list views and test out the different page sizes. Refresh your page and confirm that the page size persists.

Confirm that when you hover over the page size dropdown a tooltip appears that says **Page size**

Also, notice how the loading spinner now replaces the "1-100 of 62,934 results" text until the page has loaded.

Lastly, how do you feel about these page size options: 50, 250, 1,000, 5,000?

---

#### Ship list

- [x] Check migrations for any conflicts with latest migrations in `main` branch
- [x] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [x] Product manager approved
