### PR TITLE
Add a fatalities map view

### DIFF
--- a/database/metadata/databases/default/tables/public_fatalities_view.yaml
+++ b/database/metadata/databases/default/tables/public_fatalities_view.yaml
@@ -42,66 +42,72 @@ select_permissions:
   - role: editor
     permission:
       columns:
-        - case_id
-        - crash_date_ct
-        - crash_pk
-        - crash_time_ct
-        - crash_timestamp
-        - cris_crash_id
-        - engineering_area_id
-        - law_enforcement_ytd_fatality_num
-        - location
-        - person_id
-        - record_locator
-        - unit_id
-        - victim_name
-        - year
         - ytd_fatal_crash
         - ytd_fatality
+        - crash_pk
+        - cris_crash_id
+        - engineering_area_id
+        - person_id
+        - unit_id
+        - latitude
+        - longitude
+        - case_id
+        - crash_date_ct
+        - crash_time_ct
+        - law_enforcement_ytd_fatality_num
+        - location
+        - record_locator
+        - victim_name
+        - year
+        - crash_timestamp
       filter: {}
       allow_aggregations: true
     comment: ""
   - role: readonly
     permission:
       columns:
-        - case_id
-        - crash_date_ct
-        - crash_pk
-        - crash_time_ct
-        - crash_timestamp
-        - cris_crash_id
-        - engineering_area_id
-        - law_enforcement_ytd_fatality_num
-        - location
-        - person_id
-        - record_locator
-        - unit_id
-        - victim_name
-        - year
         - ytd_fatal_crash
         - ytd_fatality
+        - crash_pk
+        - cris_crash_id
+        - engineering_area_id
+        - person_id
+        - unit_id
+        - latitude
+        - longitude
+        - case_id
+        - crash_date_ct
+        - crash_time_ct
+        - law_enforcement_ytd_fatality_num
+        - location
+        - record_locator
+        - victim_name
+        - year
+        - crash_timestamp
       filter: {}
       allow_aggregations: true
     comment: ""
   - role: vz-admin
     permission:
       columns:
-        - case_id
-        - crash_date_ct
-        - crash_pk
-        - crash_time_ct
-        - crash_timestamp
-        - cris_crash_id
-        - engineering_area_id
-        - law_enforcement_ytd_fatality_num
-        - location
-        - person_id
-        - record_locator
-        - unit_id
-        - victim_name
-        - year
         - ytd_fatal_crash
         - ytd_fatality
+        - crash_pk
+        - cris_crash_id
+        - engineering_area_id
+        - person_id
+        - unit_id
+        - latitude
+        - longitude
+        - case_id
+        - crash_date_ct
+        - crash_time_ct
+        - law_enforcement_ytd_fatality_num
+        - location
+        - record_locator
+        - victim_name
+        - year
+        - crash_timestamp
       filter: {}
       allow_aggregations: true
     comment: ""

--- a/database/metadata/databases/default/tables/public_fatalities_view.yaml
+++ b/database/metadata/databases/default/tables/public_fatalities_view.yaml
@@ -51,6 +51,7 @@ select_permissions:
         - unit_id
         - latitude
         - longitude
+        - address_primary
         - case_id
         - crash_date_ct
         - crash_time_ct
@@ -75,6 +76,7 @@ select_permissions:
         - unit_id
         - latitude
         - longitude
+        - address_primary
         - case_id
         - crash_date_ct
         - crash_time_ct
@@ -99,6 +101,7 @@ select_permissions:
         - unit_id
         - latitude
         - longitude
+        - address_primary
         - case_id
         - crash_date_ct
         - crash_time_ct

--- a/database/migrations/default/1755804607237_recreate_fatalities_view/down.sql
+++ b/database/migrations/default/1755804607237_recreate_fatalities_view/down.sql
@@ -1,0 +1,99 @@
+DROP view public.fatalities_view;
+
+CREATE
+OR REPLACE VIEW "public"."fatalities_view" AS
+SELECT
+  people.id AS person_id,
+  crashes.id AS crash_pk,
+  crashes.cris_crash_id,
+  crashes.record_locator,
+  units.id AS unit_id,
+  concat_ws(
+    ' ' :: text,
+    people.prsn_first_name,
+    people.prsn_mid_name,
+    people.prsn_last_name
+  ) AS victim_name,
+  to_char(
+    (
+      crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+    ),
+    'yyyy' :: text
+  ) AS year,
+  crashes.crash_timestamp,
+  concat_ws(
+    ' ' :: text,
+    crashes.rpt_block_num,
+    crashes.rpt_street_pfx,
+    crashes.rpt_street_name,
+    '(',
+    crashes.rpt_sec_block_num,
+    crashes.rpt_sec_street_pfx,
+    crashes.rpt_sec_street_name,
+    ')'
+  ) AS location,
+  to_char(
+    (
+      crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+    ),
+    'YYYY-MM-DD' :: text
+  ) AS crash_date_ct,
+  to_char(
+    (
+      crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+    ),
+    'HH24:MI:SS' :: text
+  ) AS crash_time_ct,
+  row_number() OVER (
+    PARTITION BY (
+      EXTRACT(
+        year
+        FROM
+          (
+            crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+          )
+      )
+    )
+    ORDER BY
+      (
+        (
+          crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+        )
+      )
+  ) AS ytd_fatality,
+  dense_rank() OVER (
+    PARTITION BY (
+      EXTRACT(
+        year
+        FROM
+          (
+            crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+          )
+      )
+    )
+    ORDER BY
+      (
+        (
+          crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+        )
+      ),
+      crashes.id
+  ) AS ytd_fatal_crash,
+  crashes.case_id,
+  crashes.law_enforcement_ytd_fatality_num,
+  crashes.engineering_area_id
+FROM
+  (
+    (
+      people
+      LEFT JOIN units ON ((people.unit_id = units.id))
+    )
+    LEFT JOIN crashes ON ((units.crash_pk = crashes.id))
+  )
+WHERE
+  (
+    (crashes.in_austin_full_purpose = true)
+    AND (people.prsn_injry_sev_id = 4)
+    AND (crashes.private_dr_fl = false)
+    AND (crashes.is_deleted = false)
+  );

--- a/database/migrations/default/1755804607237_recreate_fatalities_view/up.sql
+++ b/database/migrations/default/1755804607237_recreate_fatalities_view/up.sql
@@ -1,4 +1,4 @@
--- Adds longitude and latitude to fatalitiies_view for mapping purposes
+-- Adds longitude, latitude, and address_primary to fatalitiies_view for mapping purposes
 DROP view public.fatalities_view;
 
 CREATE
@@ -10,6 +10,7 @@ SELECT
   crashes.record_locator,
   crashes.longitude,
   crashes.latitude,
+  crashes.address_primary,
   units.id AS unit_id,
   concat_ws(
     ' ' :: text,

--- a/database/migrations/default/1755804607237_recreate_fatalities_view/up.sql
+++ b/database/migrations/default/1755804607237_recreate_fatalities_view/up.sql
@@ -1,0 +1,102 @@
+-- Adds longitude and latitude to fatalitiies_view for mapping purposes
+DROP view public.fatalities_view;
+
+CREATE
+OR REPLACE VIEW "public"."fatalities_view" AS
+SELECT
+  people.id AS person_id,
+  crashes.id AS crash_pk,
+  crashes.cris_crash_id,
+  crashes.record_locator,
+  crashes.longitude,
+  crashes.latitude,
+  units.id AS unit_id,
+  concat_ws(
+    ' ' :: text,
+    people.prsn_first_name,
+    people.prsn_mid_name,
+    people.prsn_last_name
+  ) AS victim_name,
+  to_char(
+    (
+      crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+    ),
+    'yyyy' :: text
+  ) AS year,
+  crashes.crash_timestamp,
+  concat_ws(
+    ' ' :: text,
+    crashes.rpt_block_num,
+    crashes.rpt_street_pfx,
+    crashes.rpt_street_name,
+    '(',
+    crashes.rpt_sec_block_num,
+    crashes.rpt_sec_street_pfx,
+    crashes.rpt_sec_street_name,
+    ')'
+  ) AS location,
+  to_char(
+    (
+      crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+    ),
+    'YYYY-MM-DD' :: text
+  ) AS crash_date_ct,
+  to_char(
+    (
+      crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+    ),
+    'HH24:MI:SS' :: text
+  ) AS crash_time_ct,
+  row_number() OVER (
+    PARTITION BY (
+      EXTRACT(
+        year
+        FROM
+          (
+            crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+          )
+      )
+    )
+    ORDER BY
+      (
+        (
+          crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+        )
+      )
+  ) AS ytd_fatality,
+  dense_rank() OVER (
+    PARTITION BY (
+      EXTRACT(
+        year
+        FROM
+          (
+            crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+          )
+      )
+    )
+    ORDER BY
+      (
+        (
+          crashes.crash_timestamp AT TIME ZONE 'US/Central' :: text
+        )
+      ),
+      crashes.id
+  ) AS ytd_fatal_crash,
+  crashes.case_id,
+  crashes.law_enforcement_ytd_fatality_num,
+  crashes.engineering_area_id
+FROM
+  (
+    (
+      people
+      LEFT JOIN units ON ((people.unit_id = units.id))
+    )
+    LEFT JOIN crashes ON ((units.crash_pk = crashes.id))
+  )
+WHERE
+  (
+    (crashes.in_austin_full_purpose = true)
+    AND (people.prsn_injry_sev_id = 4)
+    AND (crashes.private_dr_fl = false)
+    AND (crashes.is_deleted = false)
+  );

--- a/editor/configs/fatalitiesListViewColumns.tsx
+++ b/editor/configs/fatalitiesListViewColumns.tsx
@@ -75,4 +75,16 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     label: "Engineering Area",
     sortable: true,
   },
+  {
+    path: "latitude",
+    label: "latitude",
+    exportOnly: true,
+    fetchAlways: true,
+  },
+  {
+    path: "longitude",
+    label: "longitude",
+    exportOnly: true,
+    fetchAlways: true,
+  },
 ];

--- a/editor/configs/fatalitiesListViewColumns.tsx
+++ b/editor/configs/fatalitiesListViewColumns.tsx
@@ -87,4 +87,16 @@ export const fatalitiesListViewColumns: ColDataCardDef<fatalitiesListRow>[] = [
     exportOnly: true,
     fetchAlways: true,
   },
+  {
+    path: "crash_timestamp",
+    label: "crash_timestamp",
+    exportOnly: true,
+    fetchAlways: true,
+  },
+  {
+    path: "address_primary",
+    label: "address_primary",
+    exportOnly: true,
+    fetchAlways: true,
+  },
 ];

--- a/editor/configs/fatalitiesListViewTable.ts
+++ b/editor/configs/fatalitiesListViewTable.ts
@@ -289,4 +289,28 @@ export const fatalitiesListViewQueryConfig: QueryConfig = {
     }),
   },
   filterCards: fatalitiesListViewFilterCards,
+  mapConfig: {
+    isActive: false,
+    layerProps: {
+      id: "points-layer",
+      type: "circle",
+      paint: {
+        "circle-radius": [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          // zoom is 5 (or less)
+          5,
+          6,
+          // zoom is 20 (or greater)
+          20,
+          8,
+        ],
+        "circle-color": "#007cbf",
+        "circle-stroke-width": 0.5,
+        "circle-stroke-color": "#ffffff",
+      },
+    },
+    geojsonTransformerName: "latLon",
+  },
 };

--- a/editor/styles/global.scss
+++ b/editor/styles/global.scss
@@ -10,7 +10,7 @@ $sea-green: #09814a;
 $rojo: #dd0426;
 $jonquil: #ffd22f;
 $dark-grey: rgb(42.5, 47.5, 52.5);
-$night-mode-background: #212529;
+$dark-mode-background: #212529;
 
 /* override bootstrap with our palette */
 $white: #ffffff;
@@ -44,8 +44,22 @@ $sidebarWidth: 4.6rem;
 [data-bs-theme="dark"] .app-navbar,
 .app-sidebar,
 .crash-injury-indicator {
-  background-color: $night-mode-background !important;
+  background-color: $dark-mode-background !important;
 }
+
+[data-bs-theme="dark"] .mapboxgl-popup-tip {
+  border-bottom-color: $dark-grey !important;
+  border-top-color: $dark-grey !important;
+}
+
+[data-bs-theme="dark"] .mapboxgl-popup-content {
+  background-color: $dark-grey !important;
+}
+
+[data-bs-theme="light"] .mapboxgl-popup-content {
+  background-color: $white !important;
+}
+
 
 [data-bs-theme="light"] .app-sidebar {
   background-color: $light !important;
@@ -105,7 +119,8 @@ $sidebarWidth: 4.6rem;
 // Custom tooltip styles prevent the y-scrollbar from briefly flashing
 // and causing a layout shift
 .tooltip {
-  position: fixed !important; /* Override Bootstrap's absolute positioning */
+  position: fixed !important;
+  /* Override Bootstrap's absolute positioning */
   z-index: 9999;
   pointer-events: none;
 }
@@ -123,8 +138,8 @@ $sidebarWidth: 4.6rem;
 }
 
 [data-bs-theme="dark"] .edit-address-button {
-  background-color: $night-mode-background !important;
-  border-color: $night-mode-background !important;
+  background-color: $dark-mode-background !important;
+  border-color: $dark-mode-background !important;
   color: $white;
 
   &:hover {
@@ -195,6 +210,7 @@ $sidebarWidth: 4.6rem;
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -304,7 +320,7 @@ to make sure it renders on top is a common fix */
   height: 100%;
 }
 
-/* Pushes the mapbox contral area down to make room for our custom button */
+/* Pushes the mapbox control area down to make room for our custom button */
 .table-map-container .mapboxgl-ctrl-top-right {
   margin-top: 2.5rem;
 }

--- a/editor/types/fatalitiesList.ts
+++ b/editor/types/fatalitiesList.ts
@@ -15,4 +15,6 @@ export type fatalitiesListRow = {
   engineering_area: EngineeringArea | null;
   longitude: number | null;
   latitude: number | null;
+  crash_timestamp: string | null;
+  address_primary: string | null;
 };

--- a/editor/types/fatalitiesList.ts
+++ b/editor/types/fatalitiesList.ts
@@ -13,4 +13,6 @@ export type fatalitiesListRow = {
   victim_name: string | null;
   recommendation: Recommendation | null;
   engineering_area: EngineeringArea | null;
+  longitude: number | null;
+  latitude: number | null;
 };

--- a/editor/types/types.ts
+++ b/editor/types/types.ts
@@ -40,7 +40,8 @@ export interface ColDataCardDef<T extends Record<string, unknown>> {
   exportOnly?: boolean;
   /**
    * Always include this column in graphql queries, regardless of if it is
-   * hidden or exportOnly
+   * hidden or exportOnly. Enables us to include data that our code depends on
+   * but is not necessarily rendered, e.g. lat/lon
    */
   fetchAlways?: boolean;
   /**

--- a/editor/types/types.ts
+++ b/editor/types/types.ts
@@ -39,7 +39,7 @@ export interface ColDataCardDef<T extends Record<string, unknown>> {
    */
   exportOnly?: boolean;
   /**
-   * Always include this column graphql queries, regardless of if it is
+   * Always include this column in graphql queries, regardless of if it is
    * hidden or exportOnly
    */
   fetchAlways?: boolean;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/24279

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Local bc migrations

**Steps to test:**
1. Apply migrations and metadata
2. Start your VZE and go to the Fatalities page, see that you can now toggle btwn list and map view
3. Zoom in, zoom out, move around the map. Click on the various map buttons
4. Refresh your page, map should still be toggled on, make sure the state of the toggle is being preserved in local storage
5. Click on the fatality dots, it should open the same popup as the crashes map with a link to the crash
6. Test in dark mode and light mode to see if the popups look okay
7. Test the down migration

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
