### PR TITLE
Handle errors when fetching a new access token

### DIFF
--- a/editor/components/AppNavBar.tsx
+++ b/editor/components/AppNavBar.tsx
@@ -46,8 +46,11 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
           </Navbar.Brand>
           <EnvironmentBadge />
         </Col>
-        <Col className="d-none d-md-flex justify-content-end align-items-center">
-          <NavBarSearch />
+        <Col className="d-flex justify-content-end align-items-center">
+          {/* Hide navbar  search on xs and sm */}
+          <div className="d-none d-md-flex">
+            <NavBarSearch />
+          </div>
           <Dropdown align="end">
             <Dropdown.Toggle id="avatar-toggle" as={DropdownAnchorToggle}>
               <Image

--- a/editor/components/SidebarLayout.tsx
+++ b/editor/components/SidebarLayout.tsx
@@ -12,8 +12,6 @@ import AppBreadCrumb from "@/components/AppBreadCrumb";
 import AppFooter from "@/components/AppFooter";
 import { darkModeLocalStorageKey } from "@/components/DarkModeToggle";
 
-const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
-
 /**
  * The app sidebar component
  */

--- a/editor/components/SidebarLayout.tsx
+++ b/editor/components/SidebarLayout.tsx
@@ -86,7 +86,7 @@ export default function SidebarLayout({ children }: { children: ReactNode }) {
           onLogin={() =>
             loginWithRedirect({
               appState: {
-                returnTo: BASE_PATH + pathName,
+                returnTo: pathName,
               },
             })
           }

--- a/editor/components/TableColumnVisibilityMenu.tsx
+++ b/editor/components/TableColumnVisibilityMenu.tsx
@@ -157,7 +157,7 @@ export default function TableColumnVisibilityMenu({
         columnVisibilityFromStorageString
       );
     } catch {
-      console.error(
+      console.warn(
         "Unable to parse column visibility from local storage. Using default visibility instead"
       );
       setIsColVisibilityLocalStorageLoaded(true);

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -140,7 +140,7 @@ export default function TableWrapper<T extends Record<string, unknown>>({
     try {
       queryConfigFromStorage = JSON.parse(configFromStorageString);
     } catch {
-      console.error(
+      console.warn(
         "Unable to parse queryConfig from local storage. Using default config instead"
       );
       setIsQueryConfigLocalStorageLoaded(true);

--- a/editor/contexts/Auth.tsx
+++ b/editor/contexts/Auth.tsx
@@ -1,5 +1,7 @@
 "use client";
-import { Auth0Provider } from "@auth0/auth0-react";
+import { Auth0Provider, AppState } from "@auth0/auth0-react";
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
 
 const DOMAIN = process.env.NEXT_PUBLIC_AUTH0_DOMAIN!;
 const CLIENT_ID = process.env.NEXT_PUBLIC_AUTH0_CLIENT_ID!;
@@ -18,6 +20,20 @@ export default function AuthProvider({
     (typeof window !== "undefined" && window.location.origin + BASE_PATH) ||
     undefined;
 
+  const router = useRouter();
+
+  /**
+   * Callback function that routes the user to their original destination
+   * after login
+   */
+  const onRedirectCallback = useCallback(
+    (appState: AppState | undefined) => {
+      const returnTo = appState?.returnTo || window.location.pathname;
+      router.push(returnTo);
+    },
+    [router]
+  );
+
   return (
     <Auth0Provider
       domain={DOMAIN}
@@ -35,6 +51,7 @@ export default function AuthProvider({
       }}
       useRefreshTokens={true}
       cacheLocation="localstorage"
+      onRedirectCallback={onRedirectCallback}
     >
       {children}
     </Auth0Provider>

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -69,7 +69,8 @@ export const formatRoleName = (role: string): string => {
  * };
  */
 export const useGetToken = (): (() => Promise<string | undefined>) => {
-  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+  const { isAuthenticated, getAccessTokenSilently, loginWithRedirect } =
+    useAuth0();
   return useCallback(async (): Promise<string | undefined> => {
     if (!isAuthenticated) {
       return;
@@ -78,9 +79,15 @@ export const useGetToken = (): (() => Promise<string | undefined>) => {
       const accessToken = await getAccessTokenSilently();
       return accessToken;
     } catch (err) {
-      console.error("Error getting access token:", err);
+      console.warn(
+        "Redirecting to login page due to error getting access token:",
+        err
+      );
+      loginWithRedirect({
+        appState: { returnTo: window.location.pathname },
+      });
     }
-    // we can ignore getAccessTokenSilently in our dep array - 
+    // we can ignore getAccessTokenSilently and loginWithRedirect in our dep array -
     // Auth0 didn't bother to memoize it for us and `isAuthenticated`
     // has us covered.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useAuth0, User } from "@auth0/auth0-react";
+import { usePathname, useRouter } from "next/navigation";
 
 /**
  * Add our claims to the Auth0 ID token—these are
@@ -69,6 +70,7 @@ export const formatRoleName = (role: string): string => {
  * };
  */
 export const useGetToken = (): (() => Promise<string | undefined>) => {
+  const pathname = usePathname();
   const { isAuthenticated, getAccessTokenSilently, loginWithRedirect } =
     useAuth0();
   return useCallback(async (): Promise<string | undefined> => {
@@ -84,12 +86,12 @@ export const useGetToken = (): (() => Promise<string | undefined>) => {
         err
       );
       loginWithRedirect({
-        appState: { returnTo: window.location.pathname },
+        appState: { returnTo: pathname },
       });
     }
     // we can ignore getAccessTokenSilently and loginWithRedirect in our dep array -
     // Auth0 didn't bother to memoize it for us and `isAuthenticated`
     // has us covered.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated]);
+  }, [isAuthenticated, pathname]);
 };

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useAuth0, User } from "@auth0/auth0-react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 
 /**
  * Add our claims to the Auth0 ID token—these are


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/24371

## Testing

**URL to test:** [Netlify](https://deploy-preview-1845--atd-vze-staging.netlify.app/)

**Steps to test:**

1. Login to the VZE deploy preview on Netlify
2. Visit the `/locations` list view
3. We can simulate a refresh token expiration by manually editing the Auth0 data saved in local storage. Using your browser's dev console find the key/value pair that contains the `access_token` and `refresh_token` properties. It will be named `@@auth0spajs@@::random-string`. Take notice—there is a similar storage key that holds the `id_token` object which is not of concern here.
4. Invalidate your refresh token by making two changes to the local storage value:
- change the `expiresAt` property to be `0` (or any date in the past): this ensures a token refresh will be attempted.
- corrupt the `refresh_token` property by adding one or more characters to its string: this ensures the token refresh will fail.

5. Save your changes to the token object, now click on one of the list view table's column headers to sort the table. Once you click the column header, this will initiate a token refetch, and the app should redirect you to the sign in page. This may happen very quickly before you are immediately returned to the locations page—this is because your Auth0 session is still valid. We have successfully tested this bug fix!
6. Now sign out of the app. Without signing back in, try to visit a crash details URL such as https://deploy-preview-1845--atd-vze-staging.netlify.app/editor/crashes/20712641. Complete the sign in flow and confirm that you are redirected to the correct page after signing in. This is the new `onRedirectCallback` handler in action 🎉 


---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
