### PR TITLE
Add page titles to list view pages

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { notFound } from "next/navigation";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import ChangeLog from "@/components/ChangeLog";
@@ -33,6 +33,7 @@ import {
 } from "@/utils/shortcuts";
 import { formatAddresses } from "@/utils/formatters";
 import EMSCardHeader from "@/components/EMSCardHeader";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const typename = "crashes";
 
@@ -71,12 +72,13 @@ export default function CrashDetailsPage({
     await refetch();
   }, [refetch]);
 
-  // When data is loaded or updated this sets the title of the page inside the HTML head element
-  useEffect(() => {
-    if (!!data) {
-      document.title = `${data[0].record_locator} - ${formatAddresses(data[0])}`;
-    }
-  }, [data]);
+  // Set document title based on loaded crash data
+  useDocumentTitle(
+    data
+      ? `${data[0].record_locator} - ${formatAddresses(data[0])}`
+      : "Vision Zero Editor",
+    true // exclude the suffix
+  );
 
   if (!data) {
     // todo: loading spinner (would be nice to use a spinner inside cards)

--- a/editor/app/crashes/page.tsx
+++ b/editor/app/crashes/page.tsx
@@ -15,7 +15,7 @@ const localStorageKey = "crashesListViewQueryConfig";
 const allowedCreateCrashRecordRoles = ["vz-admin", "editor"];
 
 export default function Crashes() {
-  useDocumentTitle("Crashes - Vision Zero Editor");
+  useDocumentTitle("Crashes");
 
   const [refetch, setRefetch] = useState(false);
   const [showNewUserModal, setShowNewUserModal] = useState(false);

--- a/editor/app/crashes/page.tsx
+++ b/editor/app/crashes/page.tsx
@@ -8,11 +8,15 @@ import { crashesListViewColumns } from "@/configs/crashesListViewColumns";
 import { crashesListViewQueryConfig } from "@/configs/crashesListViewTable";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import TableWrapper from "@/components/TableWrapper";
+import { useDocumentTitle } from "@/utils/documentTitle";
+
 const localStorageKey = "crashesListViewQueryConfig";
 
 const allowedCreateCrashRecordRoles = ["vz-admin", "editor"];
 
 export default function Crashes() {
+  useDocumentTitle("Crashes - Vision Zero Editor");
+
   const [refetch, setRefetch] = useState(false);
   const [showNewUserModal, setShowNewUserModal] = useState(false);
   const onCloseModal = () => setShowNewUserModal(false);

--- a/editor/app/dashboard/page.tsx
+++ b/editor/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { FaMap, FaChartPie } from "react-icons/fa6";
 import DashboardLinkCard, {
   DashboardLinkCardProps,
 } from "@/components/DashboardLinkCard";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const VZV_ENDPOINT = process.env.NEXT_PUBLIC_VZV_ENDPOINT || "";
 

--- a/editor/app/dashboard/page.tsx
+++ b/editor/app/dashboard/page.tsx
@@ -51,6 +51,7 @@ const dashboardLinks: DashboardLinkCardProps[] = [
 ];
 
 export default function Dashboard() {
+  useDocumentTitle("Dashboard - Vision Zero Editor");
   return (
     <>
       <Row className="mt-3">

--- a/editor/app/dashboard/page.tsx
+++ b/editor/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ const dashboardLinks: DashboardLinkCardProps[] = [
 ];
 
 export default function Dashboard() {
-  useDocumentTitle("Dashboard - Vision Zero Editor");
+  useDocumentTitle("Dashboard");
   return (
     <>
       <Row className="mt-3">

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -10,7 +10,7 @@ import { useDocumentTitle } from "@/utils/documentTitle";
 const localStorageKey = "emsListQueryConfig";
 
 export default function EMS() {
-  useDocumentTitle("EMS - Vision Zero Editor");
+  useDocumentTitle("EMS");
   return (
     <div className="h-100 d-flex flex-column">
       <div className="d-flex">

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -5,10 +5,12 @@ import { emsListViewColumns } from "@/configs/emsColumns";
 import TableWrapper from "@/components/TableWrapper";
 import { emsListViewQueryConfig } from "@/configs/emsListViewTable";
 import { FaCircleInfo } from "react-icons/fa6";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const localStorageKey = "emsListQueryConfig";
 
 export default function EMS() {
+  useDocumentTitle("EMS - Vision Zero Editor");
   return (
     <div className="h-100 d-flex flex-column">
       <div className="d-flex">

--- a/editor/app/fatalities/page.tsx
+++ b/editor/app/fatalities/page.tsx
@@ -7,7 +7,7 @@ import { useDocumentTitle } from "@/utils/documentTitle";
 const localStorageKey = "fatalitiesListViewQueryConfig";
 
 export default function Fatalities() {
-  useDocumentTitle("Fatalities - Vision Zero Editor");
+  useDocumentTitle("Fatalities");
   return (
     <div className="h-100 d-flex flex-column">
       <div>

--- a/editor/app/fatalities/page.tsx
+++ b/editor/app/fatalities/page.tsx
@@ -2,9 +2,12 @@
 import { fatalitiesListViewColumns } from "@/configs/fatalitiesListViewColumns";
 import { fatalitiesListViewQueryConfig } from "@/configs/fatalitiesListViewTable";
 import TableWrapper from "@/components/TableWrapper";
+import { useDocumentTitle } from "@/utils/documentTitle";
+
 const localStorageKey = "fatalitiesListViewQueryConfig";
 
 export default function Fatalities() {
+  useDocumentTitle("Fatalities - Vision Zero Editor");
   return (
     <div className="h-100 d-flex flex-column">
       <div>

--- a/editor/app/locations/[location_id]/page.tsx
+++ b/editor/app/locations/[location_id]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMemo, useCallback, useEffect } from "react";
+import { useMemo, useCallback } from "react";
 import { notFound } from "next/navigation";
 import Col from "react-bootstrap/Col";
 import Card from "react-bootstrap/Card";
@@ -22,6 +22,7 @@ import {
   INSERT_LOCATION_NOTE,
   UPDATE_LOCATION_NOTE,
 } from "@/queries/locationNotes";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const typename = "atd_txdot_locations";
 
@@ -68,12 +69,13 @@ export default function LocationDetailsPage({
     await refetch();
   }, [refetch]);
 
-  // When data is loaded or updated this sets the title of the page inside the HTML head element
-  useEffect(() => {
-    if (!!data) {
-      document.title = `${data[0].location_id} - ${data[0].description}`;
-    }
-  }, [data]);
+  // Set document title based on loaded location data
+  useDocumentTitle(
+    data
+      ? `${data[0].location_id} - ${data[0].description}`
+      : "Vision Zero Editor",
+    true // exclude the suffix
+  );
 
   if (!data) {
     // todo: loading spinner (would be nice to use a spinner inside cards)

--- a/editor/app/locations/page.tsx
+++ b/editor/app/locations/page.tsx
@@ -2,10 +2,12 @@
 import { locationsListViewColumns } from "@/configs/locationsListViewColumns";
 import { locationsListViewQueryConfig } from "@/configs/locationsListViewTable";
 import TableWrapper from "@/components/TableWrapper";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const localStorageKey = "locationsListViewQueryConfig";
 
 export default function Locations() {
+  useDocumentTitle("Locations - Vision Zero Editor");
   return (
     <div className="h-100 d-flex flex-column">
       <div>

--- a/editor/app/locations/page.tsx
+++ b/editor/app/locations/page.tsx
@@ -7,7 +7,7 @@ import { useDocumentTitle } from "@/utils/documentTitle";
 const localStorageKey = "locationsListViewQueryConfig";
 
 export default function Locations() {
-  useDocumentTitle("Locations - Vision Zero Editor");
+  useDocumentTitle("Locations");
   return (
     <div className="h-100 d-flex flex-column">
       <div>

--- a/editor/app/upload-non-cr3/page.tsx
+++ b/editor/app/upload-non-cr3/page.tsx
@@ -24,10 +24,12 @@ import {
   FaCircleInfo,
   FaTriangleExclamation,
 } from "react-icons/fa6";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const MAX_ERRORS_TO_DISPLAY = 50;
 
 export default function UploadNonCr3() {
+  useDocumentTitle("Upload Non-CR3 records - Vision Zero Editor");
   const [parsing, setParsing] = useState(false);
   const [data, setData] = useState<NonCr3Upload[] | null>(null);
   const [validationErrors, setValidationErrors] = useState<

--- a/editor/app/upload-non-cr3/page.tsx
+++ b/editor/app/upload-non-cr3/page.tsx
@@ -29,7 +29,7 @@ import { useDocumentTitle } from "@/utils/documentTitle";
 const MAX_ERRORS_TO_DISPLAY = 50;
 
 export default function UploadNonCr3() {
-  useDocumentTitle("Upload Non-CR3 records - Vision Zero Editor");
+  useDocumentTitle("Upload Non-CR3 records");
   const [parsing, setParsing] = useState(false);
   const [data, setData] = useState<NonCr3Upload[] | null>(null);
   const [validationErrors, setValidationErrors] = useState<

--- a/editor/app/users/page.tsx
+++ b/editor/app/users/page.tsx
@@ -12,10 +12,12 @@ import UserModal from "@/components/UserModal";
 import { useUsersInfinite } from "@/utils/users";
 import { User } from "@/types/users";
 import { formatRoleName } from "@/utils/auth";
+import { useDocumentTitle } from "@/utils/documentTitle";
 
 const allowedCreateUserRoles = ["vz-admin"];
 
 export default function Users() {
+  useDocumentTitle("Users - Vision Zero Editor");
   const router = useRouter();
   const { users, isLoading, isValidating, error, mutate } = useUsersInfinite();
   const [showNewUserModal, setShowNewUserModal] = useState(false);

--- a/editor/app/users/page.tsx
+++ b/editor/app/users/page.tsx
@@ -17,7 +17,7 @@ import { useDocumentTitle } from "@/utils/documentTitle";
 const allowedCreateUserRoles = ["vz-admin"];
 
 export default function Users() {
-  useDocumentTitle("Users - Vision Zero Editor");
+  useDocumentTitle("Users");
   const router = useRouter();
   const { users, isLoading, isValidating, error, mutate } = useUsersInfinite();
   const [showNewUserModal, setShowNewUserModal] = useState(false);

--- a/editor/utils/documentTitle.ts
+++ b/editor/utils/documentTitle.ts
@@ -3,11 +3,14 @@
 import { useEffect } from "react";
 
 /**
- * Custom hook that sets the document title for the page; e.g. "Crashes - Vision Zero Editor"
+ * Custom hook that sets the document title for the page
  */
-export const useDocumentTitle = (title: string) => {
-  const suffix = " - Vision Zero Editor";
+export const useDocumentTitle = (
+  title: string,
+  excludeSuffix: boolean = false
+) => {
+  const suffix = excludeSuffix ? "" : " - Vision Zero Editor";
   useEffect(() => {
     document.title = title + suffix;
-  }, [title]);
+  }, [title, suffix]);
 };

--- a/editor/utils/documentTitle.ts
+++ b/editor/utils/documentTitle.ts
@@ -6,7 +6,8 @@ import { useEffect } from "react";
  * Custom hook that sets the document title for the page; e.g. "Crashes - Vision Zero Editor"
  */
 export const useDocumentTitle = (title: string) => {
+  const suffix = " - Vision Zero Editor";
   useEffect(() => {
-    document.title = title;
+    document.title = title + suffix;
   }, [title]);
 };

--- a/editor/utils/documentTitle.ts
+++ b/editor/utils/documentTitle.ts
@@ -1,16 +1,12 @@
-// hooks/useDocumentTitle.js
 "use client";
 
 import { useEffect } from "react";
 
-export function useDocumentTitle(title) {
+/**
+ * Custom hook that sets the document title for the page; e.g. "Crashes - Vision Zero Editor"
+ */
+export const useDocumentTitle = (title: string) => {
   useEffect(() => {
-    const originalTitle = document.title;
     document.title = title;
-
-    // Cleanup function to restore original title if needed
-    return () => {
-      document.title = originalTitle;
-    };
   }, [title]);
-}
+};

--- a/editor/utils/documentTitle.ts
+++ b/editor/utils/documentTitle.ts
@@ -1,0 +1,16 @@
+// hooks/useDocumentTitle.js
+"use client";
+
+import { useEffect } from "react";
+
+export function useDocumentTitle(title) {
+  useEffect(() => {
+    const originalTitle = document.title;
+    document.title = title;
+
+    // Cleanup function to restore original title if needed
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [title]);
+}


### PR DESCRIPTION
## Associated issues
Closes https://github.com/issues/assigned?issue=cityofaustin%7Catd-data-tech%7C24274

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
Netlify

**Steps to test:**
Go to all the list pages and see the page title update in your tab.
Check: Dashboard, Crashes, Fatalities, EMS, Locations, Upload non cr3, and users

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
