### PR TITLE
EMS details page: fixes person ID input bug

### DIFF
--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -25,6 +25,7 @@ import EMSLinkToPersonButton, {
 import { emsMatchingPeopleColumns } from "@/configs/emsMatchingPeopleColumns";
 import { emsNonCR3Columns } from "@/configs/nonCR3Columns";
 import { emsDataCards } from "@/configs/emsDataCards";
+import { getMutationVariables } from "@/configs/emsRelatedRecordTable";
 import { PeopleListRow } from "@/types/peopleList";
 import { FaTruckMedical } from "react-icons/fa6";
 import { parseISO, subHours, addHours } from "date-fns";
@@ -269,6 +270,7 @@ export default function EMSDetailsPage({
             header="EMS patient(s)"
             columns={emsDataCards.patient}
             mutation={UPDATE_EMS_PCR}
+            getMutationVariables={getMutationVariables}
             onSaveCallback={onSaveCallback}
             rowActionComponent={EMSLinkRecordButton}
             rowActionComponentAdditionalProps={linkRecordButtonProps}

--- a/editor/testing.md
+++ b/editor/testing.md
@@ -175,7 +175,8 @@ refresh materialized view location_crashes_view;
 - The **Select person** button is displayed for each EMS patient row
 - Click **Select person** to enable the **Select match** button to appear next to any unlinked person records in the **Associated people records** table
 - Click the **Person ID** column for any **EMS Patients** row to manually edit a person ID value
-- - Click the **Person ID** column and save an invalid person ID value and verify an error message is displayed
+- Click the **Person ID** column and save an invalid person ID value and verify an error message is displayed
+- Locate an **unmatched** EMS record, then click the **Person ID** column and save a valid person ID value
 - Use the falafel menu to **Reset** an incident matched to a person ID
 - Use the falafel menu to modify an incident to be **Match not found**
 - The **Possible non-CR3 matches** card should display either no records if there are no matches, one match, or multiple possible matches depending on the non-CR3 match status


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/24836

## Testing

**URL to test:** [Netlify](https://deploy-preview-1865--atd-vze-staging.netlify.app/editor/crashes)

1. Use the EMS list page to navigate to an EMS record that is **Unmatched**. 
2. From the **EMS patient(s)** table, click into the **Person ID** column and enter the value `1` and save it.
3. Confirm that your changes are saved and the row's **Crash ID** is populated correctly
4. Edit the record again by clearing the `1` from the **Person ID** input. Confirm that the **Crash ID** remains populated after saving
5. Scroll to the right of the table, and use the falafel menu to **Reset** the match status of the record
6. ☝️ Please make sure to do this so that others can repeat the test!
7. To see the bug, repeat these steps in staging 👍 



---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
