### PR TITLE
Improve handling of when table configs are updated

### DIFF
--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -155,7 +155,6 @@ export default function TableWrapper<T extends Record<string, unknown>>({
       queryConfigFromStorage &&
       queryConfigFromStorage?._version !== initialQueryConfig._version
     ) {
-      // deal with this
       const initialQueryConfigKeys = Object.keys(initialQueryConfig);
       const queryConfigFromStorageKeys = Object.keys(queryConfigFromStorage);
 

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -150,6 +150,8 @@ export default function TableWrapper<T extends Record<string, unknown>>({
      * Check if stored config version is current and add/remove unknown
      * properties if needed - this has the effect of bringing the old
      * config in sync with the latest settings
+     *
+     * Todo: nested properties (e.g., mapConfig) are not handled
      */
     if (
       queryConfigFromStorage &&
@@ -179,6 +181,8 @@ export default function TableWrapper<T extends Record<string, unknown>>({
           delete queryConfigFromStorage[key as keyof QueryConfig];
         });
       }
+      // we're now on the latest config version ✨
+      queryConfigFromStorage._version = initialQueryConfig._version;
     }
 
     /**

--- a/editor/configs/crashesListViewTable.ts
+++ b/editor/configs/crashesListViewTable.ts
@@ -265,6 +265,7 @@ const crashesListViewfilterCards: FilterGroup[] = [
 ];
 
 export const crashesListViewQueryConfig: QueryConfig = {
+  _version: 1,
   exportable: true,
   exportFilename: "crashes",
   tableName: "crashes_list_view",

--- a/editor/configs/emsListViewTable.ts
+++ b/editor/configs/emsListViewTable.ts
@@ -390,6 +390,7 @@ const emsListViewFilterCards: FilterGroup[] = [
 ];
 
 export const emsListViewQueryConfig: QueryConfig = {
+  _version: 1,
   exportable: true,
   exportFilename: "ems_patient_care_records",
   tableName: "ems__incidents",

--- a/editor/configs/fatalitiesListViewTable.ts
+++ b/editor/configs/fatalitiesListViewTable.ts
@@ -260,6 +260,7 @@ const fatalitiesListViewFilterCards: FilterGroup[] = [
 ];
 
 export const fatalitiesListViewQueryConfig: QueryConfig = {
+  _version: 1,
   exportable: true,
   exportFilename: "fatalities",
   tableName: "fatalities_view",

--- a/editor/configs/locationCrashesTable.ts
+++ b/editor/configs/locationCrashesTable.ts
@@ -43,6 +43,7 @@ const locationCrashesFiltercards: FilterGroup[] = [
 ];
 
 export const locationCrashesQueryConfig: QueryConfig = {
+  _version: 1,
   exportable: true,
   exportFilename: "location-crashes",
   tableName: "location_crashes_view",

--- a/editor/configs/locationsListViewTable.ts
+++ b/editor/configs/locationsListViewTable.ts
@@ -42,6 +42,7 @@ const locationsListViewFiltercards: FilterGroup[] = [
 ];
 
 export const locationsListViewQueryConfig: QueryConfig = {
+  _version: 1,
   exportable: true,
   exportFilename: "locations",
   tableName: "locations_list_view",

--- a/editor/schema/queryBuilder.ts
+++ b/editor/schema/queryBuilder.ts
@@ -3,6 +3,7 @@
  * need to be kept in sync in order to validate the queryConfig
  * that is parsed from local storage
  */
+import { TableMapConfigSchema } from "@/schema/tableMapConfig";
 import { z } from "zod";
 
 // Base types
@@ -75,6 +76,7 @@ const DateFilter = z.object({
 
 // Main QueryConfig schema
 export const QueryConfigSchema = z.object({
+  _version: z.number(),
   tableName: z.string(),
   limit: z.number(),
   offset: z.number(),
@@ -86,4 +88,5 @@ export const QueryConfigSchema = z.object({
   filterCards: z.array(FilterGroup),
   exportable: z.boolean().optional(),
   exportFilename: z.string().optional(),
+  mapConfig: TableMapConfigSchema.optional(),
 });

--- a/editor/schema/tableMapConfig.ts
+++ b/editor/schema/tableMapConfig.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const TableMapConfigSchema = z.object({
+  isActive: z.boolean(),
+  geojsonTransformerName: z.literal("latLon"),
+  layerProps: z.record(z.unknown()).optional(),
+  featureLimit: z.number().optional(),
+  popupComponentName: z.literal("locationTableMap").optional(),
+});
+

--- a/editor/types/queryBuilder.ts
+++ b/editor/types/queryBuilder.ts
@@ -114,6 +114,11 @@ export type DateFilterMode = "ytd" | "all" | "5y" | "1y" | "custom";
  */
 export interface QueryConfig {
   /**
+   * The current version of the config—is arbitrary and should be incremented when
+   * changes are made to the config so that earlier version can be migrated when possible
+   */
+  _version: number;
+  /**
    * Table (or view) name to query - todo: specify table schema?
    */
   tableName: string;


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/24932

This PR makes it so that you don't have to click that **Reset** filters button on table views in order to see updates to the table. This was previously necessary whenever we added new filters, or when we added a map to a view that previously didn't have one (as is done int he parent PR).

## Testing

We must  test on local because we're off of chia's branch.

1. Use your db client to run `refresh materialized view location_crashes_view`. This will take a minute or two.
2. Navigate to any location details page, such as `http://localhost:3002/editor/locations/6DE627CF2B`
3. Scroll down to the **Crashes** table, and notice that the list/map toggle is visible and you can click the **Map** toggle to switch to the map view.
4. Open your browser's dev console and locate the local storage item called `locationCrashesQueryConfig`.  Edit the value of this key by pasting the below config. Notice that it has no `_version` property, it has no `mapConfig` property, and it has a key called `oranges`. 

```json
{
  "oranges": 3,
  "exportable": true,
  "exportFilename": "location-crashes",
  "tableName": "location_crashes_view",
  "limit": 50,
  "offset": 0,
  "sortColName": "crash_timestamp",
  "sortAsc": false,
  "searchFilter": {
    "id": "search",
    "value": "",
    "column": "case_id",
    "operator": "_ilike",
    "wildcard": true
  },
  "searchFields": [
    { "label": "Case ID", "value": "case_id" },
    { "label": "Crash ID", "value": "record_locator" },
    { "label": "Primary address", "value": "address_primary" },
    { "label": "Secondary address", "value": "address_secondary" },
    { "label": "Collision type", "value": "collsn_desc" }
  ],
  "dateFilter": {
    "column": "crash_timestamp",
    "mode": "5y",
    "filters": [
      {
        "id": "date_start",
        "operator": "_gte",
        "value": "2020-10-02T04:00:00.000Z",
        "column": "crash_timestamp"
      }
    ]
  },
  "filterCards": [
    {
      "id": "primary_filter_card",
      "label": "Crash type",
      "groupOperator": "_or",
      "filterGroups": [
        {
          "id": "cr3_crashes",
          "label": "CR3 crashes",
          "groupOperator": "_and",
          "enabled": false,
          "inverted": false,
          "filters": [
            {
              "id": "cr3_crashes",
              "column": "type",
              "operator": "_eq",
              "value": "CR3"
            }
          ]
        },
        {
          "id": "non_cr3_crashes",
          "label": "Non-CR3 crashes",
          "groupOperator": "_and",
          "enabled": false,
          "inverted": false,
          "filters": [
            {
              "id": "cr3_crashes",
              "column": "type",
              "operator": "_eq",
              "value": "NON-CR3"
            }
          ]
        }
      ]
    }
  ]
}
```
5. After saving this updated config, refresh your page. Notices that the crashes config loads normally, and the **list/map** toggle is visible (with the **List** view currently active)
6. Nice! To see the old behavior, visit the same page in [Chia's PR's deploy preview](https://deploy-preview-1866--atd-vze-staging.netlify.app/editor/locations/36CD245FAC), and save this same config into the local storage value. Notice the **Reset** button is visible and you must click it to enable the map view.
7. Back in your local VZE, change the sort column on the location crashes table. Refresh the page, and confirm that the current sort column is persisted, and that clicking the **Reset** filters button restores the default sort.
8. Visit the Crashes, Fatalities, and EMS pages to confirm they load normally

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
