### PR TITLE
Fix React Complier/Nextjs v16 Linter errors

### DIFF
--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -10,7 +10,7 @@ import {
   TransformComponent,
   ReactZoomPanPinchRef,
 } from "react-zoom-pan-pinch";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { useForm, useWatch, SubmitHandler } from "react-hook-form";
 import { Crash } from "@/types/crashes";
 import { CrashDiagramOrientation } from "@/types/crashDiagramOrientation";
 import { UPDATE_CRASH } from "@/queries/crash";
@@ -103,7 +103,7 @@ export default function CrashDiagramCard({
     handleSubmit,
     formState: { isDirty },
     setValue,
-    watch,
+    control,
     reset,
   } = useForm({
     defaultValues,
@@ -124,7 +124,7 @@ export default function CrashDiagramCard({
     setIsSaved(true);
   };
 
-  const rotation = watch("rotation");
+  const rotation = useWatch({ control, name: "rotation" });
 
   // zoom image to scale "undefined" effectively zooming to fit entire image in frame
   const resetZoomToImage = () => {

--- a/editor/components/CrashSearchTypeahead.tsx
+++ b/editor/components/CrashSearchTypeahead.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback } from "react";
 import type { KeyboardEvent } from "react";
 import Form from "react-bootstrap/Form";
 import Spinner from "react-bootstrap/Spinner";
@@ -32,10 +32,15 @@ export default function CrashSearchTypeahead({
   const [searchInput, setSearchInput] = useState("");
   const [showDropdown, setShowDropdown] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [prevSelected, setPrevSelected] = useState(selected);
 
-  useEffect(() => {
-    if (!selected) setSearchInput("");
-  }, [selected]);
+  // Reset the input when the parent clears the selection (no effect needed)
+  if (selected !== prevSelected) {
+    setPrevSelected(selected);
+    if (!selected) {
+      setSearchInput("");
+    }
+  }
 
   // Constrain address search by time to reduce result count
   const minCrashTimestamp = useMemo(() => {

--- a/editor/components/DeleteTemporaryCrashModal.tsx
+++ b/editor/components/DeleteTemporaryCrashModal.tsx
@@ -163,11 +163,15 @@ export default function DeleteTemporaryCrashModal({
   const tempFatalityId =
     tempFatalities.length > 0 ? tempFatalities[0].id : null;
 
-  // Detect photo existence via the API
-  const [hasPhotoToTransfer, setHasPhotoToTransfer] = useState(false);
+  // Detect photo existence via the API. Derive "no photo" when the modal is
+  // closed or there is no fatality id, so we don't need a sync setState reset.
+  const [photoCheck, setPhotoCheck] = useState<{
+    personId: number | null;
+    hasPhoto: boolean;
+  }>({ personId: null, hasPhoto: false });
+
   useEffect(() => {
     if (!showModal || !tempFatalityId) {
-      setHasPhotoToTransfer(false);
       return;
     }
     let cancelled = false;
@@ -178,9 +182,13 @@ export default function DeleteTemporaryCrashModal({
           `${process.env.NEXT_PUBLIC_CR3_API_DOMAIN}/images/person/${tempFatalityId}`,
           { headers: { Authorization: `Bearer ${token}` } }
         );
-        if (!cancelled) setHasPhotoToTransfer(res.ok);
+        if (!cancelled) {
+          setPhotoCheck({ personId: tempFatalityId, hasPhoto: res.ok });
+        }
       } catch {
-        if (!cancelled) setHasPhotoToTransfer(false);
+        if (!cancelled) {
+          setPhotoCheck({ personId: tempFatalityId, hasPhoto: false });
+        }
       }
     };
     checkPhoto();
@@ -188,6 +196,12 @@ export default function DeleteTemporaryCrashModal({
       cancelled = true;
     };
   }, [showModal, tempFatalityId, getToken]);
+
+  const hasPhotoToTransfer =
+    showModal &&
+    tempFatalityId !== null &&
+    photoCheck.personId === tempFatalityId &&
+    photoCheck.hasPhoto;
 
   const hasVictimPhotoToTransfer =
     tempFatalities.length > 0 && hasPhotoToTransfer;
@@ -288,7 +302,7 @@ export default function DeleteTemporaryCrashModal({
     editedCardFields,
     selectedTarget,
     targetRecommendation,
-    user?.email,
+    user,
     shouldTransferPhoto,
     tempFatalityId,
     targetFatalityPersonId,

--- a/editor/components/ImageUploadModal.tsx
+++ b/editor/components/ImageUploadModal.tsx
@@ -8,8 +8,8 @@ import {
   Spinner,
   CloseButton,
 } from "react-bootstrap";
-import { Dispatch, SetStateAction, useState, useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { Dispatch, SetStateAction, useState, useEffect, useMemo } from "react";
+import { useForm, useWatch } from "react-hook-form";
 import { useGetToken } from "@/utils/auth";
 import AlignedLabel from "@/components/AlignedLabel";
 import { LuTrash } from "react-icons/lu";
@@ -47,7 +47,6 @@ export default function ImageUploadModal({
   recordId,
 }: ImageUploadModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -58,7 +57,7 @@ export default function ImageUploadModal({
     handleSubmit,
     reset,
     formState: { errors },
-    watch,
+    control,
   } = useForm<FormData>({
     mode: "onChange",
     defaultValues: {
@@ -67,25 +66,32 @@ export default function ImageUploadModal({
     },
   });
 
-  const file = watch("file");
+  const file = useWatch({ control, name: "file" });
 
   const url = `${process.env.NEXT_PUBLIC_CR3_API_DOMAIN}/images/${imageType}/${recordId}`;
 
-  // Keeps track of file updates and errors to update preview URL
-  useEffect(() => {
-    setError(null);
+  // Create a preview object URL when a valid file is selected; revoke on change
+  const previewUrl = useMemo(() => {
     if (file && file.length > 0 && !errors.file) {
-      const url = URL.createObjectURL(file[0]);
-      setPreviewUrl(url);
-
-      // Return cleanup function that revokes this specific URL
-      return () => {
-        URL.revokeObjectURL(url);
-      };
-    } else {
-      setPreviewUrl(null);
+      return URL.createObjectURL(file[0]);
     }
+    return null;
   }, [file, errors.file]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  // Clear upload errors when the selected file changes
+  const [prevFile, setPrevFile] = useState(file);
+  if (file !== prevFile) {
+    setPrevFile(file);
+    setError(null);
+  }
 
   /**  Uploads the image to the API */
   const onSubmit = async (data: FormData) => {
@@ -171,7 +177,6 @@ export default function ImageUploadModal({
       size="lg"
       onHide={handleClose}
       onExited={() => {
-        setPreviewUrl(null);
         reset();
       }}
     >

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import Spinner from "react-bootstrap/Spinner";
 import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
@@ -87,16 +87,31 @@ const getValidSearchField = (key: string | null): AnySearchField => {
   return foundSearchField || SEARCH_FIELDS[0];
 };
 
+const subscribeToNavSearchStorage = (onStoreChange: () => void) => {
+  window.addEventListener("storage", onStoreChange);
+  return () => window.removeEventListener("storage", onStoreChange);
+};
+
+const getNavSearchStorageSnapshot = () =>
+  localStorage.getItem(navSearchLocalStorageKey);
+
 /**
  * Allows users to search for and route to various record types
  * by typing in an ID
  */
 export default function NavBarSearch() {
-  const [searchField, setSearchField] = useState<AnySearchField>(
-    getValidSearchField(null)
+  const storedSearchKey = useSyncExternalStore(
+    subscribeToNavSearchStorage,
+    getNavSearchStorageSnapshot,
+    () => null
   );
+  const [searchFieldOverride, setSearchFieldOverride] =
+    useState<AnySearchField | null>(null);
+  const searchField =
+    searchFieldOverride ?? getValidSearchField(storedSearchKey);
   const [searchValue, setSearchValue] = useState("");
   const [searchClicked, setSearchClicked] = useState(false);
+  const [pendingRoute, setPendingRoute] = useState<string | null>(null);
   const logUserEvent = useLogUserEvent();
 
   const router = useRouter();
@@ -108,29 +123,19 @@ export default function NavBarSearch() {
     options: { keepPreviousData: false },
   });
 
-  useEffect(() => {
-    if (searchClicked && data?.length === 1) {
-      // we are casting our matchedRecord to bypass TS headaches. we have to
-      // trust that our queries are returning the objects we think they are
-      const matchedRecord = data[0] as Crash & Location & EMSPatientCareRecord;
-      const route = searchField.getUrl(matchedRecord);
-      router.push(route);
-      setSearchValue("");
-      setSearchClicked(false);
-    }
-  }, [searchClicked, data, router, searchField]);
+  // When a unique match arrives, prepare navigation during render (React-recommended)
+  if (searchClicked && data?.length === 1 && !pendingRoute) {
+    const matchedRecord = data[0] as Crash & Location & EMSPatientCareRecord;
+    setPendingRoute(searchField.getUrl(matchedRecord));
+    setSearchValue("");
+    setSearchClicked(false);
+  }
 
-  /**
-   * On init, check local storage for search key and use it
-   */
+  // Navigate as an effect — router is an external system
   useEffect(() => {
-    const searchKeyFromLocalStorage = localStorage.getItem(
-      navSearchLocalStorageKey
-    );
-    if (searchKeyFromLocalStorage) {
-      setSearchField(getValidSearchField(searchKeyFromLocalStorage));
-    }
-  }, []);
+    if (!pendingRoute) return;
+    router.push(pendingRoute);
+  }, [pendingRoute, router]);
 
   /**
    * Keep the selected search field key in sync w/ local storage
@@ -141,12 +146,13 @@ export default function NavBarSearch() {
 
   const onSearch = (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setPendingRoute(null);
     setSearchClicked(true);
     logUserEvent(`${userEventName}_${searchField.key}`);
   };
 
   const onSelectSearchField = (field: AnySearchField) => {
-    setSearchField(field);
+    setSearchFieldOverride(field);
     setSearchClicked(false);
   };
 
@@ -190,6 +196,7 @@ export default function NavBarSearch() {
             placeholder="Search..."
             onChange={(e) => {
               setSearchClicked(false);
+              setPendingRoute(null);
               setSearchValue(e.target.value.trim());
             }}
             type="search"

--- a/editor/components/PointMap.tsx
+++ b/editor/components/PointMap.tsx
@@ -2,7 +2,7 @@ import {
   ComponentType,
   useCallback,
   useEffect,
-  useMemo,
+  useState,
   Dispatch,
   SetStateAction,
   MutableRefObject,
@@ -157,10 +157,17 @@ export const PointMap = ({
    * of a hack to ensure that the marker is always rendered on top of
    * other map markers
    */
-  const dynamicMarkerKey = useMemo(() => {
-    if (!children) return "no-children";
-    return Date.now();
-  }, [children]);
+  const [markerGeneration, setMarkerGeneration] = useState(0);
+  const [prevChildren, setPrevChildren] = useState(children);
+  if (children !== prevChildren) {
+    setPrevChildren(children);
+    if (children) {
+      setMarkerGeneration((generation) => generation + 1);
+    }
+  }
+  const dynamicMarkerKey = children
+    ? `marker-${markerGeneration}`
+    : "no-children";
 
   return (
     <MapGL

--- a/editor/components/PopupWrapper.tsx
+++ b/editor/components/PopupWrapper.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Popup } from "react-map-gl";
 import { Button } from "react-bootstrap";
 import { GeoJsonProperties } from "geojson";
@@ -23,6 +23,14 @@ export default function PopupWrapper({
 }: PopupWrapperProps) {
   const selectedFeaturesLength = selectedFeatures?.length;
   const [activeFeatureIndex, setActiveFeatureIndex] = useState(0);
+  const [prevSelectedFeatures, setPrevSelectedFeatures] =
+    useState(selectedFeatures);
+
+  // Reset to the first feature when the selection set changes
+  if (selectedFeatures !== prevSelectedFeatures) {
+    setPrevSelectedFeatures(selectedFeatures);
+    setActiveFeatureIndex(0);
+  }
 
   const handleNext = () =>
     activeFeatureIndex === selectedFeaturesLength - 1
@@ -33,11 +41,6 @@ export default function PopupWrapper({
     activeFeatureIndex === 0
       ? setActiveFeatureIndex(selectedFeaturesLength - 1)
       : setActiveFeatureIndex(activeFeatureIndex - 1);
-
-  // reset popup active feature to first element if viewing new array of popups
-  useEffect(() => {
-    setActiveFeatureIndex(0);
-  }, [selectedFeatures]);
 
   return (
     <Popup

--- a/editor/components/TableDateSelector.tsx
+++ b/editor/components/TableDateSelector.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import Button from "react-bootstrap/Button";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import ButtonToolbar from "react-bootstrap/ButtonToolbar";
@@ -40,19 +40,19 @@ export default function TableDateSelector({
   queryConfig,
   setQueryConfig,
 }: TableSearchProps) {
-  const [customDateRange, setCustomDateRange] = useState<DateRange>({
-    start: null,
-    end: null,
-  });
-  const [isDatePickerDirty, setIsDatePickerDirty] = useState(false);
-
   const currentFilter = queryConfig.dateFilter;
+  const [customDateRange, setCustomDateRange] = useState<DateRange>(() =>
+    getDateRangeFromDateFilter(queryConfig)
+  );
+  const [isDatePickerDirty, setIsDatePickerDirty] = useState(false);
+  const [prevFilter, setPrevFilter] = useState(currentFilter);
 
-  useEffect(() => {
-    // keep custom range form in sync with queryConfig
+  // Keep the custom range form in sync when the active date filter changes
+  if (currentFilter !== prevFilter) {
+    setPrevFilter(currentFilter);
     setCustomDateRange(getDateRangeFromDateFilter(queryConfig));
     setIsDatePickerDirty(false);
-  }, [currentFilter, queryConfig]);
+  }
 
   if (!currentFilter) return;
 

--- a/editor/components/TableExportModal.tsx
+++ b/editor/components/TableExportModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
@@ -87,7 +87,6 @@ export default function TableExportModal<T extends Record<string, unknown>>({
    * TODO: exclude aggregations from export
    * https://github.com/cityofaustin/atd-data-tech/issues/20481
    */
-  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
   const logUserEvent = useLogUserEvent();
   const hasLoggedEvent = useRef(false);
 
@@ -113,25 +112,21 @@ export default function TableExportModal<T extends Record<string, unknown>>({
     }
   }, [show, eventName, logUserEvent]);
 
-  /**
-   * Hook which creates the CSV download blob when data becomes available
-   */
-  useEffect(() => {
-    if (!isLoading && data) {
-      const csvContent = unparse(formatTableData(data, columns), {
-        quotes: true,
-        header: true,
-      });
-      const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-      const url = URL.createObjectURL(blob);
-      setDownloadUrl(url);
-      return () => {
-        // cleanup on unmount
-        URL.revokeObjectURL(url);
-        setDownloadUrl(null);
-      };
-    }
-  }, [isLoading, data, columns]);
+  const handleDownload = () => {
+    if (!data) return;
+    const csvContent = unparse(formatTableData(data, columns), {
+      quotes: true,
+      header: true,
+    });
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = formatFileName(exportFilename);
+    anchor.click();
+    URL.revokeObjectURL(url);
+    onClose();
+  };
 
   if (error) {
     console.error(error);
@@ -165,13 +160,8 @@ export default function TableExportModal<T extends Record<string, unknown>>({
             </AlignedLabel>
           </Button>
         )}
-        {downloadUrl && (
-          <Button
-            href={downloadUrl || "#"}
-            download={formatFileName(exportFilename)}
-            as="a"
-            onClick={onClose}
-          >
+        {!isLoading && data && (
+          <Button onClick={handleDownload}>
             <AlignedLabel>
               <LuDownload className="me-2" />
               Download

--- a/editor/components/TableSearch.tsx
+++ b/editor/components/TableSearch.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { produce } from "immer";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
@@ -19,7 +19,10 @@ export interface SearchSettings {
 }
 
 /**
- * Record search component that plugs into the query builder
+ * Record search component that plugs into the query builder.
+ *
+ * The input value is kept in local state so keystrokes do not re-render
+ * TableWrapper (and the full results table) on every change.
  */
 export default function TableSearch({
   queryConfig,
@@ -27,6 +30,19 @@ export default function TableSearch({
   searchSettings,
   setSearchSettings,
 }: TableSearchProps) {
+  const [localSearchString, setLocalSearchString] = useState(
+    searchSettings.searchString
+  );
+  const [prevExternalSearchString, setPrevExternalSearchString] = useState(
+    searchSettings.searchString
+  );
+
+  // Sync from parent when filters are reset (or search is cleared elsewhere)
+  if (searchSettings.searchString !== prevExternalSearchString) {
+    setPrevExternalSearchString(searchSettings.searchString);
+    setLocalSearchString(searchSettings.searchString);
+  }
+
   return (
     <form onSubmit={(e) => e.preventDefault()} className="flex-grow-1">
       <InputGroup className="d-flex flex-nowrap align-self-start">
@@ -38,47 +54,52 @@ export default function TableSearch({
           aria-label="Crash search"
           aria-describedby="search-icon"
           onChange={(e) => {
-            if (e.target.value === "") {
+            const value = e.target.value;
+            setLocalSearchString(value);
+            if (value === "") {
               /**
                * trigger a new query to be built when the search input is cleared
                * otherwise user would need to click "submit" again
                */
-              const newQueryConfig = produce(queryConfig, (newQueryConfig) => {
-                newQueryConfig.searchFilter.value = "";
-                newQueryConfig.searchFilter.column =
-                  searchSettings.searchColumn;
-                // reset offset / pagination
-                newQueryConfig.offset = 0;
-                return newQueryConfig;
+              const newQueryConfig = produce(queryConfig, (draft) => {
+                draft.searchFilter.value = "";
+                draft.searchFilter.column = searchSettings.searchColumn;
+                draft.offset = 0;
+                return draft;
               });
               setQueryConfig(newQueryConfig);
+              setSearchSettings({
+                ...searchSettings,
+                searchString: "",
+              });
             }
-            searchSettings.searchString = e.target.value;
-            setSearchSettings({ ...searchSettings });
           }}
-          value={searchSettings.searchString}
+          value={localSearchString}
           type="search"
         />
         <Button
           disabled={
-            (queryConfig.searchFilter.value === searchSettings.searchString &&
+            (queryConfig.searchFilter.value === localSearchString &&
               queryConfig.searchFilter.column ===
                 searchSettings.searchColumn) ||
             // this second case keeps the search button disabled when switching search columns
             // when the input is empty
-            (queryConfig.searchFilter.value === searchSettings.searchString &&
-              searchSettings.searchString === "")
+            (queryConfig.searchFilter.value === localSearchString &&
+              localSearchString === "")
           }
           onClick={() => {
-            const newSearchString = searchSettings.searchString.trim();
-            const newQueryConfig = produce(queryConfig, (newQueryConfig) => {
-              newQueryConfig.searchFilter.value = newSearchString;
-              newQueryConfig.searchFilter.column = searchSettings.searchColumn;
-              // reset offset / pagination
-              newQueryConfig.offset = 0;
-              return newQueryConfig;
+            const newSearchString = localSearchString.trim();
+            setLocalSearchString(newSearchString);
+            setSearchSettings({
+              ...searchSettings,
+              searchString: newSearchString,
             });
-            // save new filter state
+            const newQueryConfig = produce(queryConfig, (draft) => {
+              draft.searchFilter.value = newSearchString;
+              draft.searchFilter.column = searchSettings.searchColumn;
+              draft.offset = 0;
+              return draft;
+            });
             setQueryConfig(newQueryConfig);
           }}
           type="submit"

--- a/editor/components/TableWrapper.tsx
+++ b/editor/components/TableWrapper.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import Table from "@/components/Table";
@@ -61,6 +68,86 @@ interface TableProps<T extends Record<string, unknown>> {
 }
 
 /**
+ * Parse and validate a QueryConfig string from localStorage.
+ * Returns initialQueryConfig when missing/invalid/outdated.
+ */
+function parseStoredQueryConfig(
+  raw: string | null,
+  initialQueryConfig: QueryConfig
+): QueryConfig {
+  if (!raw) {
+    return initialQueryConfig;
+  }
+
+  let parsed: QueryConfig;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    console.warn(
+      "Unable to parse queryConfig from local storage. Using default config instead"
+    );
+    return initialQueryConfig;
+  }
+
+  if (parsed?._version !== initialQueryConfig._version) {
+    // New config version found — wipe out the cached version from local storage
+    return initialQueryConfig;
+  }
+
+  try {
+    QueryConfigSchema.strict().parse(parsed);
+  } catch (err) {
+    console.error(
+      "Invalid QueryConfig found in local storage. Using default config instead."
+    );
+    console.error(err);
+    return initialQueryConfig;
+  }
+
+  /**
+   * If date mode filters (YTD, 1Y, 5Y, etc) are in use, bring them into sync
+   * with current date. Recalculate without mutating the parsed object.
+   */
+  if (parsed.dateFilter && parsed.dateFilter.mode !== "custom") {
+    const { mode, column } = parsed.dateFilter;
+    return {
+      ...parsed,
+      dateFilter: makeDateFilterFromMode(mode, parsed, column),
+    };
+  }
+
+  return parsed;
+}
+
+function areQueryConfigsDirty(
+  queryConfig: QueryConfig,
+  initialQueryConfig: QueryConfig
+): boolean {
+  const queryConfigMutable = cloneDeep(queryConfig);
+  const initialQueryConfigMutable = cloneDeep(initialQueryConfig);
+  /**
+   * Ignore date timestamps if not using a custom range
+   */
+  if (
+    queryConfig.dateFilter?.mode === initialQueryConfig.dateFilter?.mode &&
+    queryConfigMutable.dateFilter &&
+    queryConfig.dateFilter?.mode !== "custom"
+  ) {
+    queryConfigMutable.dateFilter = undefined;
+    initialQueryConfigMutable.dateFilter = undefined;
+  }
+  /**
+   * Ignore map toggle state — we don't want filters dirty when switching
+   * between map/list mode
+   */
+  if (queryConfigMutable.mapConfig && initialQueryConfigMutable.mapConfig) {
+    queryConfigMutable.mapConfig.isActive = true;
+    initialQueryConfigMutable.mapConfig.isActive = true;
+  }
+  return !isEqual(queryConfigMutable, initialQueryConfigMutable);
+}
+
+/**
  * The main abstracted table component with all the bells and whistles -
  * designed to interact with the Hasura GraphQL API
  */
@@ -74,22 +161,86 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   mapEventName,
   downloadEventName,
 }: TableProps<T>) {
-  const [areFiltersDirty, setAreFiltersDirty] = useState(false);
-  const [isQueryConfigLocalStorageLoaded, setIsQueryConfigLocalStorageLoaded] =
-    useState(false);
+  /**
+   * Client gate only — do NOT also wait on column-visibility localStorage here.
+   * TablePaginationControls must mount to load column visibility; blocking on
+   * that flag prevents the query from ever firing (blank /crashes page).
+   */
+  const isClient = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
+
+  const rawStoredConfig = useSyncExternalStore(
+    (onStoreChange) => {
+      window.addEventListener("storage", onStoreChange);
+      return () => window.removeEventListener("storage", onStoreChange);
+    },
+    () => localStorage.getItem(localStorageKey),
+    () => null
+  );
+
+  const configFromStorage = useMemo(
+    () => parseStoredQueryConfig(rawStoredConfig, initialQueryConfig),
+    [rawStoredConfig, initialQueryConfig]
+  );
+
+  const [queryConfigOverride, setQueryConfigOverride] =
+    useState<QueryConfig | null>(null);
+  const [prevLocalStorageKey, setPrevLocalStorageKey] =
+    useState(localStorageKey);
+  if (localStorageKey !== prevLocalStorageKey) {
+    setPrevLocalStorageKey(localStorageKey);
+    setQueryConfigOverride(null);
+  }
+
+  const queryConfig = queryConfigOverride ?? configFromStorage;
+  const setQueryConfig: Dispatch<SetStateAction<QueryConfig>> = (action) => {
+    setQueryConfigOverride((prev) => {
+      const base = prev ?? configFromStorage;
+      return typeof action === "function" ? action(base) : action;
+    });
+  };
+
   const [
     isColVisibilityLocalStorageLoaded,
     setIsColVisibilityLocalStorageLoaded,
   ] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
 
-  const [searchSettings, setSearchSettings] = useState<SearchSettings>({
-    searchString: String(initialQueryConfig.searchFilter.value),
-    searchColumn: initialQueryConfig.searchFilter.column,
-  });
-  const [queryConfig, setQueryConfig] = useState<QueryConfig>({
-    ...initialQueryConfig,
-  });
+  /**
+   * Draft search input; cleared when queryConfig.searchFilter changes
+   * (e.g. reset filters) so the input stays in sync without an effect.
+   */
+  const searchFilterKey = `${queryConfig.searchFilter.column}:${String(queryConfig.searchFilter.value)}`;
+  const [searchDraft, setSearchDraft] = useState<SearchSettings | null>(null);
+  const [prevSearchFilterKey, setPrevSearchFilterKey] =
+    useState(searchFilterKey);
+  if (searchFilterKey !== prevSearchFilterKey) {
+    setPrevSearchFilterKey(searchFilterKey);
+    setSearchDraft(null);
+  }
+  const searchSettings: SearchSettings = searchDraft ?? {
+    searchString: String(queryConfig.searchFilter.value),
+    searchColumn: queryConfig.searchFilter.column,
+  };
+  const setSearchSettings: Dispatch<SetStateAction<SearchSettings>> = (
+    action
+  ) => {
+    setSearchDraft((prev) => {
+      const base = prev ?? {
+        searchString: String(queryConfig.searchFilter.value),
+        searchColumn: queryConfig.searchFilter.column,
+      };
+      return typeof action === "function" ? action(base) : action;
+    });
+  };
+
+  const areFiltersDirty = useMemo(
+    () => areQueryConfigsDirty(queryConfig, initialQueryConfig),
+    [queryConfig, initialQueryConfig]
+  );
 
   /** Use custom hook to get array of visible columns, column visibility settings,
    * and state setter function */
@@ -129,9 +280,9 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   const exportQuery = useExportQuery(queryConfig, columns, contextFilters);
 
   const { data, aggregateData, isLoading, error, refetch } = useQuery<T>({
-    // don't fire first query until localstorage is loaded
+    // don't fire first query until client + column visibility are ready
     query:
-      isQueryConfigLocalStorageLoaded &&
+      isClient &&
       isColVisibilityLocalStorageLoaded &&
       visibleColumns.length > 0
         ? query
@@ -152,124 +303,12 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   const rows = data || [];
 
   /**
-   * Load queryConfig settings from localstorage
+   * Keep changes to query config in sync with localstorage (external store only)
    */
   useEffect(() => {
-    /**
-     * Try to load queryConfig
-     */
-    const configFromStorageString = localStorage.getItem(localStorageKey) || "";
-    let queryConfigFromStorage: QueryConfig | undefined;
-
-    try {
-      queryConfigFromStorage = JSON.parse(configFromStorageString);
-    } catch {
-      console.warn(
-        "Unable to parse queryConfig from local storage. Using default config instead"
-      );
-      setIsQueryConfigLocalStorageLoaded(true);
-      return;
-    }
-
-    if (
-      queryConfigFromStorage &&
-      queryConfigFromStorage?._version !== initialQueryConfig._version
-    ) {
-      // New config version found — wipe out the cached version from local storage
-      queryConfigFromStorage = initialQueryConfig;
-    }
-
-    /**
-     * Validate the query config we found in local storage
-     */
-    try {
-      QueryConfigSchema.strict().parse(queryConfigFromStorage);
-    } catch (err) {
-      console.error(
-        "Invalid QueryConfig found in local storage. Using default config instead."
-      );
-      console.error(err);
-      setIsQueryConfigLocalStorageLoaded(true);
-      return;
-    }
-    /**
-     * If date mode filters (YTD, 1Y, 5Y, etc) are in use, bring them into sync
-     * with current date. We do this by recalculating the date filter start / end
-     * dates and updating them in the config loaded from storage
-     */
-    if (
-      queryConfigFromStorage?.dateFilter &&
-      queryConfigFromStorage.dateFilter.mode !== "custom"
-    ) {
-      const { mode, column } = queryConfigFromStorage.dateFilter;
-
-      const newDateFilter = makeDateFilterFromMode(
-        mode,
-        queryConfigFromStorage,
-        column
-      );
-
-      queryConfigFromStorage.dateFilter = newDateFilter;
-    }
-
-    setIsQueryConfigLocalStorageLoaded(true);
-    if (queryConfigFromStorage) {
-      setQueryConfig(queryConfigFromStorage);
-    }
-  }, [localStorageKey, initialQueryConfig]);
-
-  /**
-   * Keep changes to query config in sync with localstorage
-   */
-  useEffect(() => {
-    if (isQueryConfigLocalStorageLoaded) {
-      localStorage.setItem(localStorageKey, JSON.stringify(queryConfig));
-    }
-  }, [isQueryConfigLocalStorageLoaded, queryConfig, localStorageKey]);
-
-  /**
-   * Keep the search settings string in sync with queryConfig changes
-   * this enables resetting the search input from a sibling component
-   * (like the 'reset filters' button)
-   */
-  useEffect(() => {
-    setSearchSettings({
-      searchString: String(queryConfig.searchFilter.value),
-      searchColumn: queryConfig.searchFilter.column,
-    });
-  }, [queryConfig.searchFilter]);
-
-  /**
-   * Manage dirty filter state to enable reset filters button
-   */
-  useEffect(() => {
-    const queryConfigMutable = cloneDeep(queryConfig);
-    const initialQueryConfigMutable = cloneDeep(initialQueryConfig);
-    /**
-     * Ignore date timestamps if not using a custom range
-     */
-    if (
-      queryConfig.dateFilter?.mode === initialQueryConfig.dateFilter?.mode &&
-      queryConfigMutable.dateFilter &&
-      queryConfig.dateFilter?.mode !== "custom"
-    ) {
-      /**
-       * date modes are equal for our purposes - so remove the filter properties before
-       * we pass the two configs through isEqual()
-       */
-      queryConfigMutable.dateFilter = undefined;
-      initialQueryConfigMutable.dateFilter = undefined;
-    }
-    /**
-     * Ignore map toggle state by setting the same value in both configs
-     *  - we don't want the filters dirty when switching between map/list mode
-     */
-    if (queryConfigMutable.mapConfig && initialQueryConfigMutable.mapConfig) {
-      queryConfigMutable.mapConfig.isActive = true;
-      initialQueryConfigMutable.mapConfig.isActive = true;
-    }
-    setAreFiltersDirty(!isEqual(queryConfigMutable, initialQueryConfigMutable));
-  }, [queryConfig, initialQueryConfig]);
+    if (!isClient) return;
+    localStorage.setItem(localStorageKey, JSON.stringify(queryConfig));
+  }, [isClient, queryConfig, localStorageKey]);
 
   /**
    * Hook to trigger refetch
@@ -279,10 +318,11 @@ export default function TableWrapper<T extends Record<string, unknown>>({
   }, [_refetch, refetch]);
 
   /**
-   * wait until the localstorage hook resolves to render anything
-   * to prevent filter UI elements from jumping
+   * Wait for client so filter UI uses localStorage on first paint
+   * (avoids a flash of defaults). Column visibility still loads after mount
+   * via TablePaginationControls — do not block render on that flag.
    */
-  if (!isQueryConfigLocalStorageLoaded) {
+  if (!isClient) {
     return;
   }
 

--- a/editor/eslint.config.mjs
+++ b/editor/eslint.config.mjs
@@ -13,13 +13,12 @@ const eslintConfig = defineConfig([
       "react-hooks/exhaustive-deps": "error",
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": "error",
-      // React Compiler rules newly enabled by eslint-config-next 16.
-      // Warn for now; fix and promote to error in a follow-up.
-      "react-hooks/set-state-in-effect": "warn",
-      "react-hooks/preserve-manual-memoization": "warn",
-      "react-hooks/purity": "warn",
-      "react-hooks/immutability": "warn",
-      "react-hooks/incompatible-library": "warn",
+      // React Compiler rules from eslint-config-next 16
+      "react-hooks/set-state-in-effect": "error",
+      "react-hooks/preserve-manual-memoization": "error",
+      "react-hooks/purity": "error",
+      "react-hooks/immutability": "error",
+      "react-hooks/incompatible-library": "error",
     },
   },
   // Override default ignores of eslint-config-next.

--- a/editor/eslint.config.mjs
+++ b/editor/eslint.config.mjs
@@ -13,11 +13,12 @@ const eslintConfig = defineConfig([
       "react-hooks/exhaustive-deps": "error",
       "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": "error",
-      // React Compiler rules from eslint-config-next 16
+      // Rules of React (useful with or without the React Compiler)
       "react-hooks/set-state-in-effect": "error",
-      "react-hooks/preserve-manual-memoization": "error",
       "react-hooks/purity": "error",
       "react-hooks/immutability": "error",
+      // Compiler-oriented: most valuable if/when we enable `reactCompiler: true` in next.config
+      "react-hooks/preserve-manual-memoization": "error",
       "react-hooks/incompatible-library": "error",
     },
   },

--- a/editor/utils/userEvents.ts
+++ b/editor/utils/userEvents.ts
@@ -38,7 +38,7 @@ export function useLogUserEvent() {
         );
       });
     },
-    [insertUserEvent, isAuthenticated, user?.email]
+    [insertUserEvent, isAuthenticated, user]
   );
 
   return logUserEvent;


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/25372

Here are the 5 main linter errors we tripped and a little bit I learned about each:

**`react-hooks/set-state-in-effect`**: Calling `setState` inside `useEffect` (ex: syncing props to state) causes an extra render after paint. We should prefer deriving state, adjusting during render, or event handlers. ([more info](https://react.dev/learn/you-might-not-need-an-effect))

**`react-hooks/immutability`**: Mutating props, state, or other values that React treats as snapshots (ex: `obj.field = x` then `setState(obj)`). Updates should create new objects/arrays. ([more info](https://react.dev/reference/rules/components-and-hooks-must-be-pure))

**`react-hooks/purity`**: Impure work during render (`Date.now()`, `Math.random()`, etc.). Render should be a pure function of props/state so Strict Mode / Compiler can safely re-run it. ([more info](https://react.dev/reference/rules/components-and-hooks-must-be-pure))

**`react-hooks/preserve-manual-memoization`**: Your `useMemo` / `useCallback` dependency list doesn’t match what the Compiler infers (ex: dependency array list `user?.email` but the callback closes over `user`). Manual memo must stay consistent so the Compiler can preserve it. ([more info](https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization))

**`react-hooks/incompatible-library`**: APIs that break Compiler memoization, in our case, React Hook Form’s `watch()`. Prefer `useWatch`, which is designed for render-phase subscription. ([more info](https://react-hook-form.com/docs/usewatch))


## Testing

**URL to test:** <!-- VZ URL or Netlify -->
https://deploy-preview-2101--vze-staging.netlify.app/editor/crashes

**Steps to test:**

I tried to identify the key functionality of the components and methods that were touched in this React Compiler lint refactor. Here's my checklist...

### Crashes list (`/crashes`)

- [ ] Table loads rows on first visit  
- [ ] Hard refresh, filters should restore and table still loads  
- [ ] Test the TableSearch input. Typing should feel snappy (no keystroke lag). The submit button should toggle from disable to active with keystrokes. Clicking submit should render results. Clearing input should reset query. Switching “Search by” column should work
- [ ] Date presets YTD / 1Y / 5Y / All refresh results. Custom date range + Apply works
- [ ] Advanced filters should work and resetting filters restores defaults and clears search. Reset hides when form is clean 
- [ ] Pagination / page size still work  
- [ ] Download icon pops modal, CSV downloads properly, modal closes. After, you should be able to reopen and download still works  
- [ ] Map view: Test the multi-feature popup next/prev. Click another group/stack of pins and the counter should reset to 1 of X  

### Navbar search

- [ ] Change search type (Case / Crash / EMS / Location). The selection should stick after refresh  
- [ ] Search a known Crash ID. It should navigate, then the input clears
- [ ] Try an Invalid ID. It should give an error. 

### Crash details

- [ ] Map marker shows at crash location. Edit/drag location. It should keep marker on top  
- [ ] Diagram: rotate / pan / zoom, the Save button should toggle from disabled to active when dirty. After save, it should persist after refresh  
- [ ] Diagram or victim photo upload: file preview appears. Cancel/close clears. Upload should refresh  

### Temp crash delete (editor/admin)

_If you don't have one, create a temp crash with something (like a Note) to transfer._

- [ ] From the banner, click Delete. In the modal, there is a typeahead search, select a target crash. Then the list shows what will transfer. Test transferring. 
- [ ] Cancel without deleting should work.
---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
