### PR TITLE
Update VZV header text to include note about date of crash vs. date of death

### DIFF
--- a/viewer/src/views/summary/Summary.jsx
+++ b/viewer/src/views/summary/Summary.jsx
@@ -59,10 +59,12 @@ const Summary = () => {
               <Row className="summary-child">
                 <Alert className="col-12 mb-0 banner">
                   <div className="mb-2">
-                    Austin is consistently ranked as one of America's best places to live, but too
-                    many of our fellow Austinites are killed or seriously injured in traffic crashes
-                    each year. To learn more about the City's transportation safety initiatives,
-                    visit Austin Transportation's Vision Zero Program{" "}
+                    Austin is consistently ranked as one of America's best
+                    places to live, but too many of our fellow Austinites are
+                    killed or seriously injured in traffic crashes each year. To
+                    learn more about the City's transportation safety
+                    initiatives, visit Austin Transportation's Vision Zero
+                    Program{" "}
                     <a
                       href="https://www.austintexas.gov/transportation-public-works/programs/vision-zero"
                       target="_blank"
@@ -82,9 +84,12 @@ const Summary = () => {
                   </div>
                   <div>
                     Data through {lastUpdated}. <strong>Crash data</strong>{" "}
-                    <InfoPopover config={popoverConfig.map.trafficCrashes} /> includes crashes that
-                    occurred within the current City of Austin Full Purpose jurisdiction, inclusive
-                    of all public safety jurisdictions.
+                    <InfoPopover config={popoverConfig.map.trafficCrashes} />{" "}
+                    includes crashes that occurred within the current City of
+                    Austin Full Purpose jurisdiction, inclusive of all public
+                    safety jurisdictions. Fatalities are recorded by crash date,
+                    not date of death, which may differ if a victim died after
+                    the date of the crash.
                   </div>
                 </Alert>
               </Row>


### PR DESCRIPTION
## Associated issues

https://github.com/cityofaustin/atd-data-tech/issues/29774

## Testing

**URL to test:** <!-- VZ URL or Netlify -->

https://deploy-preview-2114--vzv-staging.netlify.app/viewer/

**Steps to test:**

See the new text on the disclaimer

<img width="1318" height="215" alt="Screenshot 2026-08-17 at 11 23 27 AM" src="https://github.com/user-attachments/assets/de05a044-ef09-47ed-a8d8-3da504131392" />

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
