### PR TITLE
Adds min date clamping to date picker

### DIFF
--- a/viewer/src/views/nav/SideMapControlDateRange.jsx
+++ b/viewer/src/views/nav/SideMapControlDateRange.jsx
@@ -30,7 +30,6 @@ const clampToMinDate = (raw) => {
 
 const SideMapControlDateRange = ({ type }) => {
   const [start, setStart] = useState(dataStartDate);
-  const [realStart, setRealStart] = useState();
   const [end, setEnd] = useState(today);
 
   const { setMapDateRange: setMapDate } = React.useContext(StoreContext);

--- a/viewer/src/views/nav/SideMapControlDateRange.jsx
+++ b/viewer/src/views/nav/SideMapControlDateRange.jsx
@@ -4,20 +4,33 @@ import ThemedStyleSheet from "react-with-styles/lib/ThemedStyleSheet";
 import aphroditeInterface from "react-with-styles-interface-aphrodite";
 import DefaultTheme from "react-dates/lib/theme/DefaultTheme";
 import styled from "styled-components";
-import {
-  dataStartDate,
-  today,
-} from "../../constants/time";
+import { dataStartDate, today } from "../../constants/time";
 import { colors } from "../../constants/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCalendar, faRedoAlt } from "@fortawesome/free-solid-svg-icons";
+import {
+  faCalendar,
+  faInfoCircle,
+  faRedoAlt,
+} from "@fortawesome/free-solid-svg-icons";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
+import { parse, isValid } from "date-fns";
 
-const minDate = new Date("2014-01-01");
+const minDate = new Date(2014, 0, 1);
+const DATE_FORMAT = "MM/dd/yyyy";
+
+// Parses a fully-typed raw input string and, if it's an earlier-than-minDate
+// date, returns minDate. Returns null if there's nothing to clamp yet.
+const clampToMinDate = (raw) => {
+  if (!raw || raw.length !== DATE_FORMAT.length) return null; // still mid-typing
+  const parsed = parse(raw, DATE_FORMAT, new Date());
+  if (!isValid(parsed)) return null;
+  return parsed < minDate ? minDate : null;
+};
 
 const SideMapControlDateRange = ({ type }) => {
   const [start, setStart] = useState(dataStartDate);
+  const [realStart, setRealStart] = useState();
   const [end, setEnd] = useState(today);
 
   const { setMapDateRange: setMapDate } = React.useContext(StoreContext);
@@ -41,6 +54,19 @@ const SideMapControlDateRange = ({ type }) => {
     } else {
       setEnd(date);
     }
+  };
+
+  /**
+   * Raw date handlers intervene when user enters a date before the min data date
+   */
+  const handleStartDateRaw = (event) => {
+    const clamped = clampToMinDate(event.target.value);
+    if (clamped) setStart(clamped);
+  };
+
+  const handleEndDateRaw = (event) => {
+    const clamped = clampToMinDate(event.target.value);
+    if (clamped) setEnd(clamped);
   };
 
   // Create styled date input
@@ -85,47 +111,60 @@ const SideMapControlDateRange = ({ type }) => {
   `;
 
   return (
-    <StyledButtonContainer className="pe-0 picker-outline">
-      <StyledDatePicker
-        id={`map-start-date-${type}`}
-        selected={start}
-        onChange={handleStartDateChange}
-        dateFormat={"MM/dd/yyyy"}
-        minDate={minDate}
-        maxDate={today}
-        popperPlacement="bottom-start"
-      />
-      {"-"}
-      <StyledDatePicker
-        id={`map-end-date-${type}`}
-        selected={end}
-        onChange={handleEndDateChange}
-        dateFormat={"MM/dd/yyyy"}
-        minDate={minDate}
-        maxDate={today}
-        popperPlacement="bottom"
-        popperClassName="end-date-popper"
-      />
-      {/* Show reset button to restore default date range or show calendar icon if default*/}
-      {start !== dataStartDate || end !== today ? (
-        <StyledRedoButton
-          title="Reset to default date range"
-          icon={faRedoAlt}
-          color={colors.dark}
-          onClick={() => {
-            setStart(dataStartDate);
-            setEnd(today);
-          }}
+    <>
+      <StyledButtonContainer className="pe-0 picker-outline">
+        <StyledDatePicker
+          id={`map-start-date-${type}`}
+          selected={start}
+          onChange={handleStartDateChange}
+          onChangeRaw={handleStartDateRaw}
+          dateFormat={DATE_FORMAT}
+          minDate={minDate}
+          maxDate={today}
+          popperPlacement="bottom-start"
         />
-      ) : (
-        <StyledCalendarIcon
-          title="Default date range"
-          icon={faCalendar}
-          color={colors.dark}
-          onClick={() => null}
+        {"-"}
+        <StyledDatePicker
+          id={`map-end-date-${type}`}
+          selected={end}
+          onChange={handleEndDateChange}
+          onChangeRaw={handleEndDateRaw}
+          dateFormat={DATE_FORMAT}
+          minDate={minDate}
+          maxDate={today}
+          popperPlacement="bottom"
+          popperClassName="end-date-popper"
         />
-      )}
-    </StyledButtonContainer>
+        {/* Show reset button to restore default date range or show calendar icon if default*/}
+        {start !== dataStartDate || end !== today ? (
+          <StyledRedoButton
+            title="Reset to default date range"
+            icon={faRedoAlt}
+            color={colors.dark}
+            onClick={() => {
+              setStart(dataStartDate);
+              setEnd(today);
+            }}
+          />
+        ) : (
+          <StyledCalendarIcon
+            title="Default date range"
+            icon={faCalendar}
+            color={colors.dark}
+            onClick={() => null}
+          />
+        )}
+      </StyledButtonContainer>
+      <div className="form-text">
+        <span>
+          <FontAwesomeIcon
+            icon={faInfoCircle}
+           className="me-1"
+          />
+        </span>
+        <span>Data starts in 2014</span>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Associated issues

* As discussed [here](https://github.com/cityofaustin/vision-zero/pull/2088/changes#r3804672461), adds min date clamping functionality to https://github.com/cityofaustin/vision-zero/pull/2088.


## Testing

* Test Locally
* On the map view, set the start date to a date before 1/1/2014. It should update automatically to 1/1/2014. Repeat with the end date.

I don't like the behavior of the inputs auto-correcting while you're entering a date, but I can't find a clean fix for this without adding a submit button to allow users to manually apply filter changes. 

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
