### PR TITLE
Restrict crash report PDF access to editor and admin users  

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -397,6 +397,7 @@ def healthcheck():
 @app.route("/cr3/download/<record_locator>")
 @cross_origin(headers=CORS_HEADERS)
 @requires_auth
+@requires_roles(ADMIN_ROLE_NAME, EDITOR_ROLE_NAME)
 def download_crash_report(record_locator):
     """A valid access token is required to access this route"""
     # We only care for an integer string, anything else is not safe:

--- a/api/tests/test_cr3_endpoints.py
+++ b/api/tests/test_cr3_endpoints.py
@@ -24,7 +24,7 @@ class TestCR3Download:
         res = requests.get(f"{api_base_url}/cr3/download/{test_crash_record_locator}")
         assert res.status_code == 401
 
-    def test_download_with_auth(
+    def test_download_with_editor_auth(
         self, api_base_url, editor_user_headers, test_crash_record_locator
     ):
         """Test downloading a CR3 PDF with valid auth"""
@@ -45,6 +45,27 @@ class TestCR3Download:
         s3_res = requests.get(presigned_url)
         assert s3_res.status_code == 200
         assert s3_res.headers.get("Content-Type") == "application/pdf"
+
+    def test_download_with_admin_auth(
+        self, api_base_url, admin_user_headers, test_crash_record_locator
+    ):
+        """Test downloading a CR3 PDF as an admin user"""
+        res = requests.get(
+            f"{api_base_url}/cr3/download/{test_crash_record_locator}",
+            headers=admin_user_headers,
+        )
+        assert res.status_code == 200
+        assert "message" in res.json()
+
+    def test_download_forbidden_for_read_only(
+        self, api_base_url, read_only_user_headers, test_crash_record_locator
+    ):
+        """Test that read-only users cannot download a CR3 PDF"""
+        res = requests.get(
+            f"{api_base_url}/cr3/download/{test_crash_record_locator}",
+            headers=read_only_user_headers,
+        )
+        assert res.status_code == 403
 
     def test_download_nonexistent_crash_id(self, api_base_url, editor_user_headers):
         """Test downloading with negative crash ID"""

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -3,7 +3,11 @@ import Button from "react-bootstrap/Button";
 import { FaFilePdf } from "react-icons/fa6";
 import AlignedLabel from "@/components/AlignedLabel";
 import { Crash } from "@/types/crashes";
-import { useGetToken } from "@/utils/auth";
+import { hasRole, useGetToken } from "@/utils/auth";
+import { useAuth0 } from "@auth0/auth0-react";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
+
+const allowedCrashReportDownloadRoles = ["editor", "admin"];
 
 // Downloads pdf from the CR3 API and opens it in a new tab
 export const onDownloadCR3 = async ({
@@ -44,22 +48,39 @@ export const onDownloadCR3 = async ({
 export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
   const getToken = useGetToken();
 
+  const { user } = useAuth0();
+  const canDownloadCr3 = user
+    ? hasRole(allowedCrashReportDownloadRoles, user)
+    : false;
+
   const isCr3Stored = crash.cr3_stored_fl;
 
   return (
     <Card className="h-100">
       <Card.Header className="d-flex justify-content-between">
         <Card.Title>Narrative</Card.Title>
-        <Button
-          size="sm"
-          onClick={() => onDownloadCR3({ crash, getToken })}
-          disabled={!isCr3Stored}
+        <OverlayTrigger
+          placement="top"
+          overlay={
+            <Tooltip id="copy-address-tooltip" hidden={canDownloadCr3}>
+              Vision Zero team members can access crash reports - contact them for assistance
+            </Tooltip>
+          }
         >
-          <AlignedLabel>
-            <FaFilePdf className="me-2" />
-            <span>Open crash report</span>
-          </AlignedLabel>
-        </Button>
+            {/* load-bearing span that enables tooltips to render over the `disabled` button */}
+          <span>
+            <Button
+              size="sm"
+              onClick={() => onDownloadCR3({ crash, getToken })}
+              disabled={!isCr3Stored || !canDownloadCr3}
+            >
+              <AlignedLabel>
+                <FaFilePdf className="me-2" />
+                <span>Open crash report</span>
+              </AlignedLabel>
+            </Button>
+          </span>
+        </OverlayTrigger>
       </Card.Header>
       <Card.Body>
         <Card.Text>{crash.investigator_narrative || ""}</Card.Text>

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -7,7 +7,7 @@ import { hasRole, useGetToken } from "@/utils/auth";
 import { useAuth0 } from "@auth0/auth0-react";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
 
-export const allowedCrashReportDownloadRoles = ["editor", "admin"];
+export const allowedCrashReportDownloadRoles = ["editor", "vz-admin"];
 
 // Downloads pdf from the crash report API and opens it in a new tab
 export const onDownloadCrashReport = async ({
@@ -63,12 +63,13 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
           placement="top"
           overlay={
             <Tooltip id="copy-address-tooltip" hidden={canDownloadCrashReport}>
-              Vision Zero team members can access crash reports - contact them for assistance
+              Only Vision Zero team members can access crash reports - contact
+              them for assistance
             </Tooltip>
           }
         >
-            {/* load-bearing span that enables tooltips to render over the `disabled` button */}
-          <span>
+          {/* load-bearing span that enables tooltips to render over the `disabled` button */}
+          <span className="d-inline-block">
             <Button
               size="sm"
               onClick={() => onDownloadCrashReport({ crash, getToken })}

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -9,8 +9,8 @@ import { OverlayTrigger, Tooltip } from "react-bootstrap";
 
 const allowedCrashReportDownloadRoles = ["editor", "admin"];
 
-// Downloads pdf from the CR3 API and opens it in a new tab
-export const onDownloadCR3 = async ({
+// Downloads pdf from the crash report API and opens it in a new tab
+export const onDownloadCrashReport = async ({
   crash,
   getToken,
 }: {
@@ -30,7 +30,7 @@ export const onDownloadCR3 = async ({
     if (!response.ok) {
       const responseText = await response.text();
       console.error(responseText);
-      window.alert(`Failed to download CR3: ${String(responseText)}`);
+      window.alert(`Failed to download Crash report: ${String(responseText)}`);
     } else {
       const responseJson = await response.json();
       const win = window.open(responseJson.message, "_blank");
@@ -49,11 +49,11 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
   const getToken = useGetToken();
 
   const { user } = useAuth0();
-  const canDownloadCr3 = user
+  const canDownloadCrashReport = user
     ? hasRole(allowedCrashReportDownloadRoles, user)
     : false;
 
-  const isCr3Stored = crash.cr3_stored_fl;
+  const isCrashReportStored = crash.cr3_stored_fl;
 
   return (
     <Card className="h-100">
@@ -62,7 +62,7 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
         <OverlayTrigger
           placement="top"
           overlay={
-            <Tooltip id="copy-address-tooltip" hidden={canDownloadCr3}>
+            <Tooltip id="copy-address-tooltip" hidden={canDownloadCrashReport}>
               Vision Zero team members can access crash reports - contact them for assistance
             </Tooltip>
           }
@@ -71,8 +71,8 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
           <span>
             <Button
               size="sm"
-              onClick={() => onDownloadCR3({ crash, getToken })}
-              disabled={!isCr3Stored || !canDownloadCr3}
+              onClick={() => onDownloadCrashReport({ crash, getToken })}
+              disabled={!isCrashReportStored || !canDownloadCrashReport}
             >
               <AlignedLabel>
                 <FaFilePdf className="me-2" />

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -7,7 +7,7 @@ import { hasRole, useGetToken } from "@/utils/auth";
 import { useAuth0 } from "@auth0/auth0-react";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
 
-const allowedCrashReportDownloadRoles = ["editor", "admin"];
+export const allowedCrashReportDownloadRoles = ["editor", "admin"];
 
 // Downloads pdf from the crash report API and opens it in a new tab
 export const onDownloadCrashReport = async ({

--- a/editor/components/CrashNarrativeEditableCard.tsx
+++ b/editor/components/CrashNarrativeEditableCard.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
-import { Form, Nav, Tab } from "react-bootstrap";
+import { Form, Nav, OverlayTrigger, Tab, Tooltip } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { FaFilePdf } from "react-icons/fa6";
 import AlignedLabel from "@/components/AlignedLabel";
-import { onDownloadCrashReport } from "@/components/CrashNarrativeCard";
+import {
+  allowedCrashReportDownloadRoles,
+  onDownloadCrashReport,
+} from "@/components/CrashNarrativeCard";
 import { UPDATE_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { hasRole, useGetToken } from "@/utils/auth";
@@ -40,6 +43,9 @@ export default function CrashNarrativeEditableCard({
   const { user } = useAuth0();
 
   const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const canDownloadCrashReport = user
+    ? hasRole(allowedCrashReportDownloadRoles, user)
+    : false;
 
   const { mutate, loading: isSubmitting } = useMutation(UPDATE_CRASH);
 
@@ -81,16 +87,28 @@ export default function CrashNarrativeEditableCard({
               </Nav.Item>
             )}
           </Nav>
-          <Button
-            size="sm"
-            onClick={() => onDownloadCrashReport({ crash, getToken })}
-            disabled={!isCr3Stored}
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip id="copy-address-tooltip" hidden={canDownloadCrashReport}>
+                Vision Zero team members can access crash reports - contact them for assistance
+              </Tooltip>
+            }
           >
-            <AlignedLabel>
-              <FaFilePdf className="me-2" />
-              <span>Download CR3</span>
-            </AlignedLabel>
-          </Button>
+            {/* load-bearing span that enables tooltips to render over the `disabled` button */}
+            <span>
+              <Button
+                size="sm"
+                onClick={() => onDownloadCrashReport({ crash, getToken })}
+                disabled={!isCr3Stored || !canDownloadCrashReport}
+              >
+                <AlignedLabel>
+                  <FaFilePdf className="me-2" />
+                  <span>Download CR3</span>
+                </AlignedLabel>
+              </Button>
+            </span>
+          </OverlayTrigger>
         </Card.Header>
         <Card.Body>
           <Tab.Content>

--- a/editor/components/CrashNarrativeEditableCard.tsx
+++ b/editor/components/CrashNarrativeEditableCard.tsx
@@ -5,7 +5,7 @@ import Card from "react-bootstrap/Card";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { FaFilePdf } from "react-icons/fa6";
 import AlignedLabel from "@/components/AlignedLabel";
-import { onDownloadCR3 } from "@/components/CrashNarrativeCard";
+import { onDownloadCrashReport } from "@/components/CrashNarrativeCard";
 import { UPDATE_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { hasRole, useGetToken } from "@/utils/auth";
@@ -83,7 +83,7 @@ export default function CrashNarrativeEditableCard({
           </Nav>
           <Button
             size="sm"
-            onClick={() => onDownloadCR3({ crash, getToken })}
+            onClick={() => onDownloadCrashReport({ crash, getToken })}
             disabled={!isCr3Stored}
           >
             <AlignedLabel>

--- a/editor/components/CrashNarrativeEditableCard.tsx
+++ b/editor/components/CrashNarrativeEditableCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Form, Nav, OverlayTrigger, Tab, Tooltip } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
@@ -56,8 +56,6 @@ export default function CrashNarrativeEditableCard({
 
   const isCr3Stored = crash.cr3_stored_fl;
 
-  const cardRef = useRef<HTMLDivElement>(null);
-
   /**
    * Submits mutation to database on save button click
    */
@@ -73,7 +71,7 @@ export default function CrashNarrativeEditableCard({
   };
 
   return (
-    <Card className="h-100" ref={cardRef}>
+    <Card className="h-100">
       <Tab.Container
         activeKey={activeTab}
         onSelect={(tab) => tab && setActiveTab(tab)}
@@ -91,15 +89,21 @@ export default function CrashNarrativeEditableCard({
           </Nav>
           <OverlayTrigger
             placement="top"
-            container={cardRef}
+            popperConfig={{
+              strategy: "fixed",
+            }}
             overlay={
-              <Tooltip id="copy-address-tooltip" hidden={canDownloadCrashReport}>
-                Vision Zero team members can access crash reports - contact them for assistance
+              <Tooltip
+                id="copy-address-tooltip"
+                hidden={canDownloadCrashReport}
+              >
+                Only Vision Zero team members can access crash reports - contact
+                them for assistance
               </Tooltip>
             }
           >
             {/* load-bearing span that enables tooltips to render over the `disabled` button */}
-            <span>
+            <span className="display-inline-block">
               <Button
                 size="sm"
                 onClick={() => onDownloadCrashReport({ crash, getToken })}

--- a/editor/components/CrashNarrativeEditableCard.tsx
+++ b/editor/components/CrashNarrativeEditableCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Form, Nav, OverlayTrigger, Tab, Tooltip } from "react-bootstrap";
 import Button from "react-bootstrap/Button";
 import Card from "react-bootstrap/Card";
@@ -56,6 +56,8 @@ export default function CrashNarrativeEditableCard({
 
   const isCr3Stored = crash.cr3_stored_fl;
 
+  const cardRef = useRef<HTMLDivElement>(null);
+
   /**
    * Submits mutation to database on save button click
    */
@@ -71,7 +73,7 @@ export default function CrashNarrativeEditableCard({
   };
 
   return (
-    <Card className="h-100">
+    <Card className="h-100" ref={cardRef}>
       <Tab.Container
         activeKey={activeTab}
         onSelect={(tab) => tab && setActiveTab(tab)}
@@ -89,6 +91,7 @@ export default function CrashNarrativeEditableCard({
           </Nav>
           <OverlayTrigger
             placement="top"
+            container={cardRef}
             overlay={
               <Tooltip id="copy-address-tooltip" hidden={canDownloadCrashReport}>
                 Vision Zero team members can access crash reports - contact them for assistance
@@ -104,7 +107,7 @@ export default function CrashNarrativeEditableCard({
               >
                 <AlignedLabel>
                   <FaFilePdf className="me-2" />
-                  <span>Download CR3</span>
+                  <span>Open crash report</span>
                 </AlignedLabel>
               </Button>
             </span>

--- a/editor/testing.md
+++ b/editor/testing.md
@@ -112,7 +112,8 @@ The below features should be tested with each role. Features with role-based acc
 - Crash diagram: [role: admin, editor] Change diagram x, y, z, and rotate. Confirm that **Save** button enables when any of these properties are adjusted
 - Crash diagram: [role: admin, editor] Use **Save** button to save current x/y/z/rotate. Refresh the page and confirm the diagram initializes at the expected transform state. On load, confirm that **Save** button is disabled and says **Saved** with a checkmark icon.
 - Crash narrative: loads normally and is scrollable for long narratives
-- Crash narrative: download CR3 pdf
+- [role: admin, editor] Crash narrative: use **Open crash report** button to view crash report pdf
+- [role: readonly] Crash narrative: **Open crash report** button is disabled. Hover over button to see tooltip advising to contact the Vision Zero team for assistance
 - Crash data card: **Flags** card. Edit set **Private drive** to **No** and verify that warning banner appears with notification that the crash is not included in VZ statistical reporting
 - Crash data card: edit various field types:
   - Yes/No - e.g., **At intersection**
@@ -138,10 +139,11 @@ The below features should be tested with each role. Features with role-based acc
   - Edit person **Name** and person **Type**
   - Edit person **Zipcode** and verify only pattern xxxxx or xxxxx-xxxx is valid
   - Edit person **Injury severity** and verify the crash injury widget (top of page to the right of crash address) updates accordingly
-- Related records - **EMS Patient Care**
+- [role: editor, admin] Related records - **EMS Patient Care**
   - Use gear icon in top left of card header to toggle column visibility on/off. Refresh page and verify that settings are persisted
   - Verify records are populated (use EMS list view to find a crash with EMS records)
   - Verify records which were "automatically matched" are unmatched (disappear from table) when crash is moved +1200 meters
+  - [role: readonly] verify EMS related records card is not visible on crash details page
 - Record history: changes to crash, units, people are being tracked.
 - Record history: Details modal opens on row collect.
 - Record history: Card is collapseable and collapsed state is persisted when refreshing the page
@@ -154,7 +156,7 @@ The below features should be tested with each role. Features with role-based acc
 - Keyboard shortcuts to scroll instantly to various cards:
   - `shift` + `u`: Units
   - `shift` + `p`: People
-  - `shift` + `3`: EMS patient care
+  - `shift` + `3`: EMS patient care role: [editor, admin]
   - `shift` + `c`: Charges
   - `shift` + `n`: Notes
   - `shift` + `f`: Fatality Review Board recommendations
@@ -192,6 +194,7 @@ refresh materialized view location_crashes_view;
 
 ### EMS list - `/ems`
 
+- the navigation item is only visible to editor and admin roles
 - filter using various search input fields and filter card switches
 - filters are preserved (in local storage) when refreshing the page or navigating back to it
 - for records with a matching crash, the **Crash ID** column is populated with working URL to the crash details page
@@ -199,6 +202,7 @@ refresh materialized view location_crashes_view;
 
 ### EMS incident details - `/ems/[incident-number]`
 
+- This page will not load for readonly users
 - Page breadcrumb and title—which is the EMS record address—look normal
 - Incident map (top right of page)
   - Use the EMS list page to filter/find an incident that has been matched automatically to a crash, person, and non-cr3 record
@@ -273,6 +277,8 @@ refresh materialized view location_crashes_view;
   - Switch to the **Narrative** tab and confirm it looks normal
   - Switch back to the **Sumamary** tab, use the **Edit summary** button to clear the summary you created and then **Save summary**
   - Confirm that the **Summary** tab has disappeard and only the **Narrative** tab is shown
+  - [role: admin, editor] Use **Open crash report** button to view crash report pdf
+  - [role: readonly] The **Open crash report** button is disabled. Hover over button to see tooltip advising to contact the Vision Zero team for assistance
 - Observe that the **Details** card (second row, rightmost card) looks normal
   - [role: editor, admin] confirm that the LE YTD Fatal Crash, light condition, speed limit, and Object struct fields are editable
 - Observe that the FRB recommendations and notes cards are visible in the third row of card. If you haven't tested these on the crash details page, test them here (role: editor, admin).

--- a/editor/testing.md
+++ b/editor/testing.md
@@ -99,6 +99,9 @@ The below features should be tested with each role. Features with role-based acc
 - Crash map: use the address search to find a location within Austin metro area
 - Crash map: use the fit bounds control (top right corner of map, above +/- buttons) to recenter the map
 - Crash map: verify **Location ID** updates when crash is moved to another intersection
+- Crash map: verify orange **Location** polygon is entirely visible within the map extent on page load (will only be visibile if the map if the crash has an associated **Location ID**)
+- Crash map: verify orange **Location** polygon is visible on the map if the crash has an associated **Location ID**
+- Crash map: verify **Location** polygon updates on the map when the crash **Location ID** changes
 - Crash map: validation restricts keying in lat/lon with alpha characters
 - Crash map: validation restricts keying in empty/blank lat/lon
 - Crash map: validation restricts keying in lat/lon outside of Austin metro area
@@ -179,7 +182,7 @@ The below features should be tested with each role. Features with role-based acc
 ### Location details `/locations/[location_id]`
 
 - Verify page `<title>` element is formatted as `<location-ID> - <location-name>` (check how the title is rendered in your browser tab)
-- Location polygon map
+- Crash map: verify orange **Location** polygon is entirely visible within the map extent on page load
 - Location data card displays the location ID, crash counts and comp costs
 - combined cr3 and noncr3 crashes list
   - this will not load locally until you manually refresh the view:


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/29773

<img width="497" height="554" alt="Screenshot 2026-08-19 at 12 47 58 PM" src="https://github.com/user-attachments/assets/95402408-0bb1-4e4a-b721-ee65ef8579df" />


## Testing

**URL to test:** Local

1. In the `./api` directory, you might want to update your `AWS_S3_BUCKET_ENV` var to `"staging"`. Alternatively, you'll need to test with older crashes (+3 years) because we should have crash reports for those in the dev bucket.
2. Start your local DB + Hasura + Flask API: `./vision-zero local-stack-up` will take care of that for you. See the `./api` readme if you've never run the Flask API locally.
3.  Run the API tests by following the instructions in `/api/tests/readme.md`. If you've previously set up your env for testing, it is as easy as running this command from the `./api` directory:

```shell
# from ./api
docker compose -f docker-compose-tests.yaml run --rm cr3-user-api-test
```

4. Head to the `./editor` directory and make sure your `.env.local` file has you correctly pointed to the local flask API:

```shell
# double-check this env var
NEXT_PUBLIC_CR3_API_DOMAIN=http://localhost:8085
```

5.. Start your VZE, and login as using the read only creds in 1pass: **Vision Zero Editor (VZE) Test User: Read-only viewer**

6. Visit a few crash details pages for crashes that are more than 2 months old and confirm you cannot open any crash report PDFs. The **Open crash report button** should be disabled, and hovering over the button reveals a tooltip with a helpful message.

7. Log out and back in to the VZE with editor or admin credentials. Confirm that you are able to open crash reports normally.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
