### PR TITLE
Restrict access to EMS content for readonly user role

### DIFF
--- a/database/metadata/databases/default/tables/public_change_log_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_change_log_ems__incidents.yaml
@@ -13,17 +13,6 @@ select_permissions:
         - created_at
       filter: {}
     comment: ""
-  - role: readonly
-    permission:
-      columns:
-        - id
-        - record_id
-        - record_json
-        - created_by
-        - operation_type
-        - created_at
-      filter: {}
-    comment: ""
   - role: vz-admin
     permission:
       columns:

--- a/database/metadata/databases/default/tables/public_ems__incidents.yaml
+++ b/database/metadata/databases/default/tables/public_ems__incidents.yaml
@@ -61,46 +61,6 @@ select_permissions:
       filter: {}
       allow_aggregations: true
     comment: ""
-  - role: readonly
-    permission:
-      columns:
-        - apd_incident_numbers
-        - atd_apd_blueform_case_id
-        - austin_full_purpose
-        - crash_match_status
-        - crash_pk
-        - created_at
-        - created_by
-        - id
-        - incident_location_address
-        - incident_number
-        - incident_problem
-        - incident_received_datetime
-        - is_deleted
-        - latitude
-        - longitude
-        - matched_crash_pks
-        - matched_non_cr3_case_ids
-        - matched_person_ids
-        - mvc_form_position_in_vehicle
-        - non_cr3_match_status
-        - patient_injry_sev_id
-        - patient_injry_sev_reason
-        - pcr_patient_age
-        - pcr_patient_gender
-        - pcr_patient_race
-        - pcr_transport_destination
-        - person_id
-        - person_match_attributes
-        - person_match_score
-        - person_match_status
-        - travel_mode
-        - unparsed_apd_incident_numbers
-        - updated_at
-        - updated_by
-      filter: {}
-      allow_aggregations: true
-    comment: ""
   - role: vz-admin
     permission:
       columns:

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -23,7 +23,7 @@ import { crashDataCards } from "@/configs/crashDataCard";
 import { peopleRelatedRecordCols } from "@/configs/peopleRelatedRecordTable";
 import { emsRelatedRecordCols } from "@/configs/emsRelatedRecordTable";
 import { unitRelatedRecordCols } from "@/configs/unitRelatedRecordTable";
-import { getCrashDetailsQuery, UPDATE_CRASH } from "@/queries/crash";
+import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
 import { INSERT_CRASH_NOTE, UPDATE_CRASH_NOTE } from "@/queries/crashNotes";
 import { UPDATE_PERSON } from "@/queries/person";
 import { UPDATE_UNIT } from "@/queries/unit";
@@ -71,8 +71,8 @@ export default function CrashDetailsPage({
   useKeyboardShortcut(activeShortcutKeyLookup, scrollToElementOnKeyPress);
 
   const { data, error, refetch, isValidating } = useQuery<Crash>({
-    query: recordLocator ? getCrashDetailsQuery(includeEms) : null,
-    variables: { recordLocator },
+    query: recordLocator ? GET_CRASH : null,
+    variables: { recordLocator, includeEms },
     typename,
   });
 

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { notFound } from "next/navigation";
-import { use, useCallback } from "react";
+import { use, useCallback, useMemo } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import ChangeLog from "@/components/ChangeLog";
@@ -13,6 +14,7 @@ import CrashNarrativeCard from "@/components/CrashNarrativeCard";
 import CrashRecommendationCard from "@/components/CrashRecommendationCard";
 import DataCard from "@/components/DataCard";
 import NotesCard from "@/components/NotesCard";
+import PermissionsRequired from "@/components/PermissionsRequired";
 import RelatedRecordTable from "@/components/RelatedRecordTable";
 import ShortcutHelperText from "@/components/ShortcutHelperText";
 import UserEventsLogger from "@/components/UserEventsLogger";
@@ -21,12 +23,13 @@ import { crashDataCards } from "@/configs/crashDataCard";
 import { peopleRelatedRecordCols } from "@/configs/peopleRelatedRecordTable";
 import { emsRelatedRecordCols } from "@/configs/emsRelatedRecordTable";
 import { unitRelatedRecordCols } from "@/configs/unitRelatedRecordTable";
-import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
+import { getCrashDetailsQuery, UPDATE_CRASH } from "@/queries/crash";
 import { INSERT_CRASH_NOTE, UPDATE_CRASH_NOTE } from "@/queries/crashNotes";
 import { UPDATE_PERSON } from "@/queries/person";
 import { UPDATE_UNIT } from "@/queries/unit";
 import { Crash } from "@/types/crashes";
 import { ShortcutKeyLookup } from "@/types/keyboardShortcuts";
+import { canViewEms, EMS_VIEW_ROLES } from "@/utils/auth";
 import { useQuery } from "@/utils/graphql";
 import {
   scrollToElementOnKeyPress,
@@ -53,12 +56,22 @@ export default function CrashDetailsPage({
   params: Promise<{ record_locator: string }>;
 }) {
   const { record_locator: recordLocator } = use(params);
+  const { user } = useAuth0();
+  const includeEms = canViewEms(user);
+
+  const activeShortcutKeyLookup = useMemo(
+    () =>
+      includeEms
+        ? shortcutKeyLookup
+        : shortcutKeyLookup.filter((shortcut) => shortcut.key !== "E"),
+    [includeEms]
+  );
 
   // Call hook to watch out for the use of keyboard shortcuts
-  useKeyboardShortcut(shortcutKeyLookup, scrollToElementOnKeyPress);
+  useKeyboardShortcut(activeShortcutKeyLookup, scrollToElementOnKeyPress);
 
   const { data, error, refetch, isValidating } = useQuery<Crash>({
-    query: recordLocator ? GET_CRASH : null,
+    query: recordLocator ? getCrashDetailsQuery(includeEms) : null,
     variables: { recordLocator },
     typename,
   });
@@ -195,22 +208,24 @@ export default function CrashDetailsPage({
           />
         </Col>
       </Row>
-      <Row id="ems" className="offset-header-scroll-top">
-        <ShortcutHelperText shortcutKey="E" />
-        <Col sm={12} className="mb-1">
-          <RelatedRecordTable
-            records={crash.ems__incidents || []}
-            isValidating={isValidating}
-            header={<EMSCardHeader />}
-            noRowsMessage="No EMS records found"
-            columns={emsRelatedRecordCols}
-            mutation=""
-            onSaveCallback={onSaveCallback}
-            shouldShowColumnVisibilityPicker={true}
-            localStorageKey="crashPageEmsPatientCare"
-          />
-        </Col>
-      </Row>
+      <PermissionsRequired allowedRoles={EMS_VIEW_ROLES}>
+        <Row id="ems" className="offset-header-scroll-top">
+          <ShortcutHelperText shortcutKey="E" />
+          <Col sm={12} className="mb-1">
+            <RelatedRecordTable
+              records={crash.ems__incidents || []}
+              isValidating={isValidating}
+              header={<EMSCardHeader />}
+              noRowsMessage="No EMS records found"
+              columns={emsRelatedRecordCols}
+              mutation=""
+              onSaveCallback={onSaveCallback}
+              shouldShowColumnVisibilityPicker={true}
+              localStorageKey="crashPageEmsPatientCare"
+            />
+          </Col>
+        </Row>
+      </PermissionsRequired>
       <Row id="charges" className="offset-header-scroll-top">
         <ShortcutHelperText shortcutKey="C" />
         <Col sm={12} className="mb-1">

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -8,7 +8,7 @@ import { MapRef } from "react-map-gl";
 import { PointMap } from "@/components/PointMap";
 import FatalityUnitsCards from "@/components/FatalityUnitsCards";
 import CrashNarrativeEditableCard from "@/components/CrashNarrativeEditableCard";
-import { getCrashDetailsQuery, UPDATE_CRASH } from "@/queries/crash";
+import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
 import { canViewEms } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
@@ -47,8 +47,8 @@ export default function FatalCrashDetailsPage({
   const typename = "crashes";
 
   const { data, error, refetch } = useQuery<Crash>({
-    query: recordLocator ? getCrashDetailsQuery(canViewEms(user)) : null,
-    variables: { recordLocator },
+    query: recordLocator ? GET_CRASH : null,
+    variables: { recordLocator, includeEms: canViewEms(user) },
     typename,
   });
 

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -8,12 +8,13 @@ import { MapRef } from "react-map-gl";
 import { PointMap } from "@/components/PointMap";
 import FatalityUnitsCards from "@/components/FatalityUnitsCards";
 import CrashNarrativeEditableCard from "@/components/CrashNarrativeEditableCard";
-import { GET_CRASH } from "@/queries/crash";
+import { getCrashDetailsQuery, UPDATE_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
+import { canViewEms } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { formatIsoDateTimeWithDay, formatYear } from "@/utils/formatters";
 import { useQuery } from "@/utils/graphql";
-import { UPDATE_CRASH } from "@/queries/crash";
+import { useAuth0 } from "@auth0/auth0-react";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
 import DataCard from "@/components/DataCard";
 import { crashesColumns } from "@/configs/crashesColumns";
@@ -41,11 +42,12 @@ export default function FatalCrashDetailsPage({
   const mapRef = useRef<MapRef | null>(null);
 
   const { record_locator: recordLocator } = use(params);
+  const { user } = useAuth0();
 
   const typename = "crashes";
 
   const { data, error, refetch } = useQuery<Crash>({
-    query: recordLocator ? GET_CRASH : null,
+    query: recordLocator ? getCrashDetailsQuery(canViewEms(user)) : null,
     variables: { recordLocator },
     typename,
   });

--- a/editor/configs/routes.ts
+++ b/editor/configs/routes.ts
@@ -2,6 +2,7 @@ import { FaRegHeart, FaCarBurst } from "react-icons/fa6";
 import { RiDashboard3Line } from "react-icons/ri";
 import { LuMapPin, LuAmbulance, LuCloudUpload, LuUsers } from "react-icons/lu";
 import { IconType } from "react-icons";
+import { EMS_VIEW_ROLES } from "@/utils/auth";
 
 interface Route {
   path: string;
@@ -35,6 +36,7 @@ export const routes: Route[] = [
     path: "ems",
     label: "EMS",
     icon: LuAmbulance,
+    allowedRoles: EMS_VIEW_ROLES,
   },
   {
     path: "upload-non-cr3",

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -1,7 +1,43 @@
 import { gql } from "graphql-request";
 
-export const GET_CRASH = gql`
-  query CrashDetails($recordLocator: String!) {
+/**
+ * Optional EMS fields for crash details. This makes the GET_CRASH query dynamic and
+ * allows readonly users to load the page even if select permission is revoked
+ * on ems__incidents.
+ */
+const EMS_INCIDENTS_SELECTION = `
+      ems__incidents(
+        where: { is_deleted: { _eq: false } }
+        order_by: { id: asc }
+      ) {
+        id
+        apd_incident_numbers
+        crash_match_status
+        incident_location_address
+        incident_number
+        incident_problem
+        incident_received_datetime
+        patient_injry_sev {
+          id
+          label
+        }
+        mvc_form_position_in_vehicle
+        patient_injry_sev_id
+        person {
+          prsn_nbr
+          unit_nbr
+        }
+        pcr_patient_age
+        pcr_patient_gender
+        pcr_patient_race
+        person_id
+        travel_mode
+        unparsed_apd_incident_numbers
+      }
+`;
+
+const crashDetailsQuery = (includeEms: boolean) => gql`
+  query ${includeEms ? "CrashDetailsWithEms" : "CrashDetails"}($recordLocator: String!) {
     crashes(
       where: {
         _and: {
@@ -306,37 +342,19 @@ export const GET_CRASH = gql`
         text
         crash_pk
       }
-      ems__incidents(
-        where: { is_deleted: { _eq: false } }
-        order_by: { id: asc }
-      ) {
-        id
-        apd_incident_numbers
-        crash_match_status
-        incident_location_address
-        incident_number
-        incident_problem
-        incident_received_datetime
-        patient_injry_sev {
-          id
-          label
-        }
-        mvc_form_position_in_vehicle
-        patient_injry_sev_id
-        person {
-          prsn_nbr
-          unit_nbr
-        }
-        pcr_patient_age
-        pcr_patient_gender
-        pcr_patient_race
-        person_id
-        travel_mode
-        unparsed_apd_incident_numbers
-      }
+      ${includeEms ? EMS_INCIDENTS_SELECTION : ""}
     }
   }
 `;
+
+/** Crash details without EMS — safe for the readonly Hasura role */
+export const GET_CRASH = crashDetailsQuery(false);
+
+/** Crash details including EMS patient care records — editor and admin only */
+export const GET_CRASH_WITH_EMS = crashDetailsQuery(true);
+
+export const getCrashDetailsQuery = (includeEms: boolean) =>
+  includeEms ? GET_CRASH_WITH_EMS : GET_CRASH;
 
 /**
  * Record locator search used by the navbar search component

--- a/editor/queries/crash.ts
+++ b/editor/queries/crash.ts
@@ -1,43 +1,13 @@
 import { gql } from "graphql-request";
 
 /**
- * Optional EMS fields for crash details. This makes the GET_CRASH query dynamic and
- * allows readonly users to load the page even if select permission is revoked
- * on ems__incidents.
+ * Crash details. EMS is gated with @include(if: $includeEms) so we can test
+ * whether Hasura still validates ems__incidents against the role schema when
+ * includeEms is false (expected: validation-failed for readonly after select
+ * is revoked). If that holds, omit the field from the document instead.
  */
-const EMS_INCIDENTS_SELECTION = `
-      ems__incidents(
-        where: { is_deleted: { _eq: false } }
-        order_by: { id: asc }
-      ) {
-        id
-        apd_incident_numbers
-        crash_match_status
-        incident_location_address
-        incident_number
-        incident_problem
-        incident_received_datetime
-        patient_injry_sev {
-          id
-          label
-        }
-        mvc_form_position_in_vehicle
-        patient_injry_sev_id
-        person {
-          prsn_nbr
-          unit_nbr
-        }
-        pcr_patient_age
-        pcr_patient_gender
-        pcr_patient_race
-        person_id
-        travel_mode
-        unparsed_apd_incident_numbers
-      }
-`;
-
-const crashDetailsQuery = (includeEms: boolean) => gql`
-  query ${includeEms ? "CrashDetailsWithEms" : "CrashDetails"}($recordLocator: String!) {
+export const GET_CRASH = gql`
+  query CrashDetails($recordLocator: String!, $includeEms: Boolean!) {
     crashes(
       where: {
         _and: {
@@ -342,19 +312,37 @@ const crashDetailsQuery = (includeEms: boolean) => gql`
         text
         crash_pk
       }
-      ${includeEms ? EMS_INCIDENTS_SELECTION : ""}
+      ems__incidents(
+        where: { is_deleted: { _eq: false } }
+        order_by: { id: asc }
+      ) @include(if: $includeEms) {
+        id
+        apd_incident_numbers
+        crash_match_status
+        incident_location_address
+        incident_number
+        incident_problem
+        incident_received_datetime
+        patient_injry_sev {
+          id
+          label
+        }
+        mvc_form_position_in_vehicle
+        patient_injry_sev_id
+        person {
+          prsn_nbr
+          unit_nbr
+        }
+        pcr_patient_age
+        pcr_patient_gender
+        pcr_patient_race
+        person_id
+        travel_mode
+        unparsed_apd_incident_numbers
+      }
     }
   }
 `;
-
-/** Crash details without EMS — safe for the readonly Hasura role */
-export const GET_CRASH = crashDetailsQuery(false);
-
-/** Crash details including EMS patient care records — editor and admin only */
-export const GET_CRASH_WITH_EMS = crashDetailsQuery(true);
-
-export const getCrashDetailsQuery = (includeEms: boolean) =>
-  includeEms ? GET_CRASH_WITH_EMS : GET_CRASH;
 
 /**
  * Record locator search used by the navbar search component

--- a/editor/types/crashes.ts
+++ b/editor/types/crashes.ts
@@ -25,7 +25,7 @@ export type Crash = {
   cris_crash_id: number | null;
   collsn: LookupTableOption | null;
   diagram_transform: CrashDiagramOrientation | null;
-  ems__incidents: EMSPatientCareRecord[] | null;
+  ems__incidents?: EMSPatientCareRecord[] | null;
   fhe_collsn_id: number | null;
   investigat_agency_id: number | null;
   agency: LookupTableOption | null;

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -40,6 +40,15 @@ export const getHasuraRoleName = (roles?: string[]): string => {
 export const hasRole = (roles: string[], user: CustomUser) =>
   roles.includes(getHasuraRoleName(getRolesArray(user)));
 
+/** Roles that may view EMS patient care records */
+export const EMS_VIEW_ROLES = ["editor", "vz-admin"];
+
+/**
+ * True if the user may see EMS content (nav, crash details card, GraphQL fields)
+ */
+export const canViewEms = (user: CustomUser | undefined) =>
+  Boolean(user && hasRole(EMS_VIEW_ROLES, user));
+
 /**
  * Make the hasura role name human-friendly
  */


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29897

Restrict EMS patient care content in VZE to **editor** and **admin** (`vz-admin`). Viewer / `readonly` users should not see EMS in the UI, and Hasura should not return EMS tables for that role.

At first I tried this with some ternary logic until I discovered `@include` in the [Hasura docs](https://hasura.io/docs/2.0/queries/postgres/variables-aliases-fragments-directives/#using-directives) and verified it works for our use case. See https://github.com/cityofaustin/vision-zero/pull/2120/changes for the diff in those two approaches. 

## Testing
### Local, due to metadata updates

**Steps to test:**

Apply hasura metadata locally before viewer API checks:

```sh
cd database
hasura metadata apply
```

### (Optional but interesting) Test query and role permission with GraphiQL:

- start hasura console: `cd database && hasura console`. This should pop a new browser tab at http://localhost:9695
- Add a new "Request Header" with key: `x-hasura-role` & value: `readonly`
- Try this query:
```graphql
query {
  ems__incidents(limit: 1) {
    id
  }
}
```
_Expect `"code": "validation-failed"` & `"message": "field "ems__incidents" not found"`._

- Try the same query but update the `x-hasura-role` to `editor`.
    - Expect one `ems__incidents` id value to return (ex: 1166526). This should verify that readonly users can't query  `ems__incidents` but editors still can.
- Try a more robust query using `@include` with `x-hasura-role` set to `readonly`:
```graphql
query CrashDetails($recordLocator: String!, $includeEms: Boolean!) {
  crashes(where: { record_locator: { _eq: $recordLocator } }) {
    id
    record_locator
    ems__incidents @include(if: $includeEms) {
      id
    }
  }
}
```
Query Variables:
```graphql
{
  "recordLocator": "21559309",
  "includeEms": false
}
```
_Expect the query response return a crash but to exclude `ems__incidents`_

<img width="2047" height="1056" alt="Screenshot 2026-08-19 at 1 02 25 PM" src="https://github.com/user-attachments/assets/2d9721a9-3c24-4aa5-bd0c-4d4316fb362e" />

- Using the same query, try flipping `includeEms` variable to `true`. 
    - Expect `"code": "validation-failed"` & ` "message": "field 'ems__incidents' not found in type: 'crashes'"`
- Update `x-hasura-role` to `editor` & revert to `"includeEms": true`. 
    - It should resolve without error and with an ems__incidents id, verifying that the `@include` directive is properly shaping the schema when `includeEms` is used as a query variable.

### Login with `admin` or `editor` credentials (Test User: Editor || Test User: VZ Admin)
_No changes here, just checking for no regressions as a baseline._

- [ ] EMS is in the side nav. Click to index page and confirm EMS incident detail page still works.
- [ ] Go to a Crash details page and confirm the EMS Patient Care card shows. Linking/matching still works.
- [ ] From Crash details page, confirm Shift+E scroll shortcut still scrolls to EMS.

### Login with `readonly` credentials (Test User: Read-only viewer)

- [ ] When the app loads, EMS is not in the side nav.
- [ ] Go to any Crash details page. It should load with no query error (map, summary, units, people, charges, notes, changelog).
    - [ ] EMS Patient Care card is not on the page.
    - [ ] Shift+E does not jump to an EMS section.
    - [ ] In the Dev Console network tab, confirm `data.crashes` details `graphql` query does **not** request/receive `ems__incidents` in the query response (similar to what we demonstrated above using Hasura Console GraphiQL).
- [ ] Go to any Fatality details page and confirm the page still loads with no query error.
- [ ] Hardcode/url hack to navigate to `http://localhost:3002/editor/ems`. Expect GraphQL query failure with a field/permission validation error. _Preventing this type of URL hacking is out of scope per the issue._

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved