### PR TITLE
Redirects users who try to view restricted pages

### DIFF
--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -29,7 +29,6 @@ import { UPDATE_PERSON } from "@/queries/person";
 import { UPDATE_UNIT } from "@/queries/unit";
 import { Crash } from "@/types/crashes";
 import { ShortcutKeyLookup } from "@/types/keyboardShortcuts";
-import { canViewEms, EMS_VIEW_ROLES } from "@/utils/auth";
 import { useQuery } from "@/utils/graphql";
 import {
   scrollToElementOnKeyPress,
@@ -37,6 +36,8 @@ import {
 } from "@/utils/shortcuts";
 import EMSCardHeader from "@/components/EMSCardHeader";
 import { useDocumentTitle } from "@/utils/documentTitle";
+import { hasRole } from "@/utils/auth";
+import { EMS_VIEW_ROLES } from "@/utils/permissions";
 
 const typename = "crashes";
 
@@ -57,7 +58,7 @@ export default function CrashDetailsPage({
 }) {
   const { record_locator: recordLocator } = use(params);
   const { user } = useAuth0();
-  const includeEms = canViewEms(user);
+  const includeEms = hasRole(EMS_VIEW_ROLES);
 
   const activeShortcutKeyLookup = useMemo(
     () =>

--- a/editor/app/crashes/[record_locator]/page.tsx
+++ b/editor/app/crashes/[record_locator]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { notFound } from "next/navigation";
 import { use, useCallback, useMemo } from "react";
-import { useAuth0 } from "@auth0/auth0-react";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import ChangeLog from "@/components/ChangeLog";
@@ -36,8 +35,8 @@ import {
 } from "@/utils/shortcuts";
 import EMSCardHeader from "@/components/EMSCardHeader";
 import { useDocumentTitle } from "@/utils/documentTitle";
-import { hasRole } from "@/utils/auth";
-import { EMS_VIEW_ROLES } from "@/utils/permissions";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const typename = "crashes";
 
@@ -58,7 +57,7 @@ export default function CrashDetailsPage({
 }) {
   const { record_locator: recordLocator } = use(params);
   const { user } = useAuth0();
-  const includeEms = hasRole(EMS_VIEW_ROLES);
+  const includeEms = hasRole(ADMIN_EDIT_ROLES, user);
 
   const activeShortcutKeyLookup = useMemo(
     () =>
@@ -210,7 +209,7 @@ export default function CrashDetailsPage({
           />
         </Col>
       </Row>
-      <PermissionsRequired allowedRoles={EMS_VIEW_ROLES}>
+      <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
         <Row id="ems" className="offset-header-scroll-top">
           <ShortcutHelperText shortcutKey="E" />
           <Col sm={12} className="mb-1">

--- a/editor/app/crashes/page.tsx
+++ b/editor/app/crashes/page.tsx
@@ -10,7 +10,7 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import TableWrapper from "@/components/TableWrapper";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { LuCirclePlus } from "react-icons/lu";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 const localStorageKey = "crashesListViewQueryConfig";
 

--- a/editor/app/crashes/page.tsx
+++ b/editor/app/crashes/page.tsx
@@ -10,10 +10,11 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import TableWrapper from "@/components/TableWrapper";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { LuCirclePlus } from "react-icons/lu";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 const localStorageKey = "crashesListViewQueryConfig";
 
-const allowedCreateCrashRecordRoles = ["vz-admin", "editor"];
+const allowedCreateCrashRecordRoles = ADMIN_EDIT_ROLES;
 
 export default function Crashes() {
   useDocumentTitle("Crashes");

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -32,9 +32,9 @@ import { parseISO, subHours, addHours } from "date-fns";
 import { Crash } from "@/types/crashes";
 import EMSMapCard from "@/components/EMSMapCard";
 import { NonCR3Record } from "@/types/nonCr3";
-import { useAuth0 } from "@auth0/auth0-react";
-import { EMS_VIEW_ROLES, useRequiredPageRole } from "@/utils/auth";
+import { ADMIN_EDIT_ROLES, useRequiredPageRole } from "@/utils/auth";
 import UserEventsLogger from "@/components/UserEventsLogger";
+import { useAuth0 } from "@auth0/auth0-react";
 
 export default function EMSDetailsPage({
   params,
@@ -44,7 +44,7 @@ export default function EMSDetailsPage({
   const [selectedEmsPcr, setSelectedEmsPcr] =
     useState<EMSPatientCareRecord | null>(null);
 
-  const isAuthorized = useRequiredPageRole(EMS_VIEW_ROLES);
+  const isAuthorized = useRequiredPageRole(ADMIN_EDIT_ROLES);
 
   const { incident_number } = use(params);
 

--- a/editor/app/ems/[incident_number]/page.tsx
+++ b/editor/app/ems/[incident_number]/page.tsx
@@ -33,6 +33,7 @@ import { Crash } from "@/types/crashes";
 import EMSMapCard from "@/components/EMSMapCard";
 import { NonCR3Record } from "@/types/nonCr3";
 import { useAuth0 } from "@auth0/auth0-react";
+import { EMS_VIEW_ROLES, useRequiredPageRole } from "@/utils/auth";
 import UserEventsLogger from "@/components/UserEventsLogger";
 
 export default function EMSDetailsPage({
@@ -42,6 +43,8 @@ export default function EMSDetailsPage({
 }) {
   const [selectedEmsPcr, setSelectedEmsPcr] =
     useState<EMSPatientCareRecord | null>(null);
+
+  const isAuthorized = useRequiredPageRole(EMS_VIEW_ROLES);
 
   const { incident_number } = use(params);
 
@@ -54,7 +57,7 @@ export default function EMSDetailsPage({
     isValidating,
     refetch: refetchEMS,
   } = useQuery<EMSPatientCareRecord>({
-    query: incident_number ? GET_EMS_RECORDS : null,
+    query: incident_number && isAuthorized ? GET_EMS_RECORDS : null,
     variables: {
       incident_number: incident_number,
     },
@@ -122,7 +125,10 @@ export default function EMSDetailsPage({
    * if any of the ems pcrs are unmatched
    */
   const { data: unmatchedCrashes } = useQuery<Crash>({
-    query: unmatchedTimeInterval[0] ? GET_UNMATCHED_EMS_CRASHES : null,
+    query:
+      isAuthorized && unmatchedTimeInterval[0]
+        ? GET_UNMATCHED_EMS_CRASHES
+        : null,
     variables: {
       time4HoursBefore: unmatchedTimeInterval[0],
       time4HoursAfter: unmatchedTimeInterval[1],
@@ -146,7 +152,7 @@ export default function EMSDetailsPage({
    */
   const { data: matchingPeople, refetch: refetchPeople } =
     useQuery<PeopleListRow>({
-      query: allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
+      query: isAuthorized && allCrashPks[0] ? GET_MATCHING_PEOPLE : null,
       variables: {
         crash_pks: unmatchedTimeInterval[0] ? allCrashPks : matchedCrashPks,
       },
@@ -173,7 +179,9 @@ export default function EMSDetailsPage({
    */
   const { data: nonCR3Crashes } = useQuery<NonCR3Record>({
     query:
-      matchedNonCr3CaseId || possibleNonCR3Matches ? GET_NON_CR3_CRASHES : null,
+      isAuthorized && (matchedNonCr3CaseId || possibleNonCR3Matches)
+        ? GET_NON_CR3_CRASHES
+        : null,
     variables: {
       // If there is already a single case ID that has been matched then query that,
       // otherwise query the list of possible Non-CR3 matches
@@ -236,7 +244,7 @@ export default function EMSDetailsPage({
     }
   }, [incident]);
 
-  if (!ems_pcrs) {
+  if (!ems_pcrs || !isAuthorized) {
     return;
   }
 

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -5,7 +5,7 @@ import { emsListViewColumns } from "@/configs/emsColumns";
 import TableWrapper from "@/components/TableWrapper";
 import UserEventsLogger from "@/components/UserEventsLogger";
 import { emsListViewQueryConfig } from "@/configs/emsListViewTable";
-import { EMS_VIEW_ROLES, useRequiredPageRole } from "@/utils/auth";
+import { ADMIN_EDIT_ROLES, useRequiredPageRole } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { Filter } from "@/types/queryBuilder";
 import { LuInfo } from "react-icons/lu";
@@ -23,7 +23,7 @@ const isDeletedFilter: Filter[] = [
 
 export default function EMS() {
   useDocumentTitle("EMS");
-  const isAuthorized = useRequiredPageRole(EMS_VIEW_ROLES);
+  const isAuthorized = useRequiredPageRole(ADMIN_EDIT_ROLES);
   if (!isAuthorized) {
     return null;
   }

--- a/editor/app/ems/page.tsx
+++ b/editor/app/ems/page.tsx
@@ -5,6 +5,7 @@ import { emsListViewColumns } from "@/configs/emsColumns";
 import TableWrapper from "@/components/TableWrapper";
 import UserEventsLogger from "@/components/UserEventsLogger";
 import { emsListViewQueryConfig } from "@/configs/emsListViewTable";
+import { EMS_VIEW_ROLES, useRequiredPageRole } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { Filter } from "@/types/queryBuilder";
 import { LuInfo } from "react-icons/lu";
@@ -22,6 +23,10 @@ const isDeletedFilter: Filter[] = [
 
 export default function EMS() {
   useDocumentTitle("EMS");
+  const isAuthorized = useRequiredPageRole(EMS_VIEW_ROLES);
+  if (!isAuthorized) {
+    return null;
+  }
   return (
     <UserEventsLogger eventName="ems_list_view">
       <div className="h-100 d-flex flex-column">
@@ -35,8 +40,8 @@ export default function EMS() {
           <AlignedLabel>
             <LuInfo className="me-2" />
             <span>
-              EMS analysis is currently in beta. Data may be inaccurate or change
-              significantly as we continue to refine the system.
+              EMS analysis is currently in beta. Data may be inaccurate or
+              change significantly as we continue to refine the system.
             </span>
           </AlignedLabel>
         </div>

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -10,11 +10,9 @@ import FatalityUnitsCards from "@/components/FatalityUnitsCards";
 import CrashNarrativeEditableCard from "@/components/CrashNarrativeEditableCard";
 import { GET_CRASH, UPDATE_CRASH } from "@/queries/crash";
 import { Crash } from "@/types/crashes";
-import { canViewEms } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { formatIsoDateTimeWithDay, formatYear } from "@/utils/formatters";
 import { useQuery } from "@/utils/graphql";
-import { useAuth0 } from "@auth0/auth0-react";
 import CrashDiagramCard from "@/components/CrashDiagramCard";
 import DataCard from "@/components/DataCard";
 import { crashesColumns } from "@/configs/crashesColumns";
@@ -23,6 +21,8 @@ import NotesCard from "@/components/NotesCard";
 import UserEventsLogger from "@/components/UserEventsLogger";
 import { INSERT_CRASH_NOTE, UPDATE_CRASH_NOTE } from "@/queries/crashNotes";
 import CrashIsTemporaryBanner from "@/components/CrashIsTemporaryBanner";
+import { ADMIN_EDIT_ROLES, hasRole } from "@/utils/auth";
+import { useAuth0 } from "@auth0/auth0-react";
 
 const otherCardColumns = [
   crashesColumns.case_id,
@@ -43,12 +43,13 @@ export default function FatalCrashDetailsPage({
 
   const { record_locator: recordLocator } = use(params);
   const { user } = useAuth0();
+  const includeEms = hasRole(ADMIN_EDIT_ROLES, user)
 
   const typename = "crashes";
 
   const { data, error, refetch } = useQuery<Crash>({
     query: recordLocator ? GET_CRASH : null,
-    variables: { recordLocator, includeEms: canViewEms(user) },
+    variables: { recordLocator, includeEms },
     typename,
   });
 

--- a/editor/app/fatalities/[record_locator]/page.tsx
+++ b/editor/app/fatalities/[record_locator]/page.tsx
@@ -43,7 +43,7 @@ export default function FatalCrashDetailsPage({
 
   const { record_locator: recordLocator } = use(params);
   const { user } = useAuth0();
-  const includeEms = hasRole(ADMIN_EDIT_ROLES, user)
+  const includeEms = hasRole(ADMIN_EDIT_ROLES, user);
 
   const typename = "crashes";
 
@@ -102,10 +102,7 @@ export default function FatalCrashDetailsPage({
       {
         // show alert if crash is a temp record, hide delete button on fatalities pages
         crash.is_temp_record && (
-          <CrashIsTemporaryBanner
-            crash={crash}
-            dismissible
-          />
+          <CrashIsTemporaryBanner crash={crash} dismissible />
         )
       }
       <Row className="fatality-details-row">
@@ -146,9 +143,7 @@ export default function FatalCrashDetailsPage({
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">
                       Risk factors
                     </td>
-                    <td>
-                      {crashesColumns.risk_factors.valueRenderer(crash)}
-                    </td>
+                    <td>{crashesColumns.risk_factors.valueRenderer(crash)}</td>
                   </tr>
                   <tr>
                     <td style={{ textWrap: "nowrap" }} className="fw-bold">

--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import AlignedLabel from "@/components/AlignedLabel";
+import { useRouter } from "next/navigation";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import { LuShieldAlert } from "react-icons/lu";
+
+export default function Unauthorized() {
+  const router = useRouter();
+  return (
+    <div className="d-flex flex-column flex-grow-1 justify-content-center h-100">
+      <Row className="d-flex justify-content-center">
+        <Col xs={6} md={3} className="text-center">
+          <LuShieldAlert size="4rem" className="text-muted" />
+        </Col>
+      </Row>
+      <Row className="d-flex justify-content-center my-4">
+        <Col className="text-center">
+          <h2>Not Authorized</h2>
+          <h5 className="text-muted">
+            You don&apos;t have permission to view this page. If you need access, you can{" "}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
+            >
+              ask for help
+            </a>.
+          </h5>
+          <div className="my-3">
+            <Button onClick={() => router.back()}>Go back</Button>
+          </div>
+        </Col>
+      </Row>
+    </div>
+  );
+}

--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import AlignedLabel from "@/components/AlignedLabel";
 import { useRouter } from "next/navigation";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";

--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -4,10 +4,11 @@ import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import { LuShieldAlert } from "react-icons/lu";
-import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
+import { useServiceRequestUrl } from "@/utils/serviceRequest";
 
 export default function Unauthorized() {
   const router = useRouter();
+  const serviceRequestUrl = useServiceRequestUrl();
   return (
     <div className="d-flex flex-column flex-grow-1 justify-content-center h-100">
       <Row className="d-flex justify-content-center">
@@ -21,11 +22,7 @@ export default function Unauthorized() {
           <h5 className="text-muted">
             You don&apos;t have permission to view this page. If you need
             access, you can{" "}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href={SERVICE_REQUEST_URL}
-            >
+            <a target="_blank" rel="noreferrer" href={serviceRequestUrl}>
               ask for help
             </a>
             .

--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -18,17 +18,25 @@ export default function Unauthorized() {
         <Col className="text-center">
           <h2>Not Authorized</h2>
           <h5 className="text-muted">
-            You don&apos;t have permission to view this page. If you need access, you can{" "}
+            You don&apos;t have permission to view this page. If you need
+            access, you can{" "}
             <a
               target="_blank"
               rel="noreferrer"
               href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
             >
               ask for help
-            </a>.
+            </a>
+            .
           </h5>
           <div className="my-3">
-            <Button onClick={() => router.back()}>Go back</Button>
+            <Button
+              onClick={() => {
+                router.push("/");
+              }}
+            >
+              Go home
+            </Button>
           </div>
         </Col>
       </Row>

--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import AlignedLabel from "@/components/AlignedLabel";
+import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
 import { useRouter } from "next/navigation";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -19,14 +19,16 @@ export default function Unauthorized() {
         <Col className="text-center">
           <h2>Not Authorized</h2>
           <h5 className="text-muted">
-            You don&apos;t have permission to view this page. If you need access, you can{" "}
+            You don&apos;t have permission to view this page. If you need
+            access, you can{" "}
             <a
               target="_blank"
               rel="noreferrer"
-              href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
+              href={SERVICE_REQUEST_URL}
             >
               ask for help
-            </a>.
+            </a>
+            .
           </h5>
           <div className="my-3">
             <Button onClick={() => router.back()}>Go back</Button>

--- a/editor/app/upload-non-cr3/page.tsx
+++ b/editor/app/upload-non-cr3/page.tsx
@@ -24,6 +24,7 @@ import {
   LuInfo,
   LuTriangleAlert,
 } from "react-icons/lu";
+import { ADMIN_EDIT_ROLES, useRequiredPageRole } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 
 const MAX_ERRORS_TO_DISPLAY = 50;
@@ -38,6 +39,8 @@ export default function UploadNonCr3() {
   const [uploadError, setUploadError] = useState(false);
   const [success, setSuccess] = useState(false);
   const { mutate, loading: isMutating } = useMutation(INSERT_NON_CR3);
+
+  const isAuthorized = useRequiredPageRole(ADMIN_EDIT_ROLES);
 
   const onSelectFile = useCallback(
     (file: File) => {
@@ -83,6 +86,10 @@ export default function UploadNonCr3() {
     },
     [setValidationErrors, setParsing, setData]
   );
+
+  if (!isAuthorized) {
+    return null;
+  }
 
   const onUpload = async () => {
     try {

--- a/editor/app/users/[user_id]/page.tsx
+++ b/editor/app/users/[user_id]/page.tsx
@@ -16,7 +16,7 @@ import { useUser } from "@/utils/users";
 import { User } from "@/types/users";
 import { formatIsoDateTime } from "@/utils/formatters";
 
-const allowedUserEditRoles = [ADMIN_ROLE]
+const allowedUserEditRoles = [ADMIN_ROLE];
 
 type UserColumn = {
   name: keyof User;
@@ -29,7 +29,8 @@ const COLUMNS: UserColumn[] = [
   {
     name: "app_metadata",
     label: "Role",
-    renderer: (user) => formatRoleName(user.app_metadata?.roles?.[0] || "") || "",
+    renderer: (user) =>
+      formatRoleName(user.app_metadata?.roles?.[0] || "") || "",
   },
   { name: "name", label: "Name" },
   { name: "email", label: "Email" },

--- a/editor/app/users/[user_id]/page.tsx
+++ b/editor/app/users/[user_id]/page.tsx
@@ -11,12 +11,12 @@ import { FaUserEdit, FaUserAltSlash } from "react-icons/fa";
 import AlignedLabel from "@/components/AlignedLabel";
 import UserModal from "@/components/UserModal";
 import PermissionsRequired from "@/components/PermissionsRequired";
-import { formatRoleName, useGetToken } from "@/utils/auth";
+import { ADMIN_ROLE, formatRoleName, useGetToken } from "@/utils/auth";
 import { useUser } from "@/utils/users";
 import { User } from "@/types/users";
 import { formatIsoDateTime } from "@/utils/formatters";
 
-const allowedUserEditRoles = ["vz-admin"];
+const allowedUserEditRoles = [ADMIN_ROLE]
 
 type UserColumn = {
   name: keyof User;

--- a/editor/app/users/page.tsx
+++ b/editor/app/users/page.tsx
@@ -10,12 +10,12 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import UserModal from "@/components/UserModal";
 import { useUsersInfinite } from "@/utils/users";
 import { User } from "@/types/users";
-import { formatRoleName } from "@/utils/auth";
+import { ADMIN_ROLE, formatRoleName } from "@/utils/auth";
 import { useDocumentTitle } from "@/utils/documentTitle";
 import { LuCheck, LuCopy, LuUserPlus } from "react-icons/lu";
 import { formatIsoDateTime } from "@/utils/formatters";
 
-const allowedCreateUserRoles = ["vz-admin"];
+const allowedCreateUserRoles = [ADMIN_ROLE];
 
 export default function Users() {
   useDocumentTitle("Users");

--- a/editor/components/AppNavBar.tsx
+++ b/editor/components/AppNavBar.tsx
@@ -7,7 +7,6 @@ import Col from "react-bootstrap/Col";
 import Navbar from "react-bootstrap/Navbar";
 import {
   FaBug,
-  FaLightbulb,
   FaRightFromBracket,
   FaSquareArrowUpRight,
   FaToolbox,
@@ -18,6 +17,7 @@ import NavBarSearch from "@/components/NavBarSearch";
 import AlignedLabel from "@/components/AlignedLabel";
 import DropdownAnchorToggle from "@/components/DropdownAnchorToggle";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
@@ -33,9 +33,7 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
   const userId = user?.["https://hasura.io/jwt/claims"]?.["x-hasura-user-id"];
 
   return (
-    <Navbar
-      className="app-navbar border-bottom pe-3 w-100"
-    >
+    <Navbar className="app-navbar border-bottom pe-3 w-100">
       <Container fluid>
         <Col className="d-flex justify-content-start">
           <Navbar.Brand href="/crashes" as={Link}>
@@ -75,22 +73,11 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
               <Dropdown.Item
                 target="_blank"
                 rel="noreferrer"
-                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
+                href={SERVICE_REQUEST_URL}
               >
                 <AlignedLabel>
                   <FaBug className="me-3" />
-                  Report a bug
-                  <FaSquareArrowUpRight className="ms-3 text-muted" />
-                </AlignedLabel>
-              </Dropdown.Item>
-              <Dropdown.Item
-                target="_blank"
-                rel="noreferrer"
-                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
-              >
-                <AlignedLabel>
-                  <FaLightbulb className="me-3" />
-                  Request an enhancement
+                  Contact support
                   <FaSquareArrowUpRight className="ms-3 text-muted" />
                 </AlignedLabel>
               </Dropdown.Item>

--- a/editor/components/AppNavBar.tsx
+++ b/editor/components/AppNavBar.tsx
@@ -17,7 +17,7 @@ import NavBarSearch from "@/components/NavBarSearch";
 import AlignedLabel from "@/components/AlignedLabel";
 import DropdownAnchorToggle from "@/components/DropdownAnchorToggle";
 import DarkModeToggle from "@/components/DarkModeToggle";
-import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
+import { useServiceRequestUrl } from "@/utils/serviceRequest";
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
@@ -31,6 +31,7 @@ type NavBarProps = {
  */
 export default function AppNavBar({ user, logout }: NavBarProps) {
   const userId = user?.["https://hasura.io/jwt/claims"]?.["x-hasura-user-id"];
+  const serviceRequestUrl = useServiceRequestUrl();
 
   return (
     <Navbar className="app-navbar border-bottom pe-3 w-100">
@@ -73,7 +74,7 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
               <Dropdown.Item
                 target="_blank"
                 rel="noreferrer"
-                href={SERVICE_REQUEST_URL}
+                href={serviceRequestUrl}
               >
                 <AlignedLabel>
                   <FaBug className="me-3" />

--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -24,6 +24,7 @@ import { useImage } from "@/utils/images";
 import { hasRole } from "@/utils/auth";
 import ImageUploadModal from "@/components/ImageUploadModal";
 import { useAuth0 } from "@auth0/auth0-react";
+import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
 
 interface DiagramAlertProps {
   variant: "info" | "danger" | "success" | "warning";
@@ -265,8 +266,8 @@ export default function CrashDiagramCard({
             variant="danger"
             message={<p>The crash diagram is not available.</p>}
             link={{
-              href: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D",
-              text: "report a bug",
+              href: SERVICE_REQUEST_URL,
+              text: "contact support",
             }}
           />
         )}

--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -24,7 +24,7 @@ import { useImage } from "@/utils/images";
 import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import ImageUploadModal from "@/components/ImageUploadModal";
 import { useAuth0 } from "@auth0/auth0-react";
-import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
+import { useServiceRequestUrl } from "@/utils/serviceRequest";
 
 interface DiagramAlertProps {
   variant: "info" | "danger" | "success" | "warning";
@@ -81,6 +81,7 @@ export default function CrashDiagramCard({
   const [isTouched, setIsTouched] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const transformComponentRef = useRef<ReactZoomPanPinchRef | null>(null);
+  const serviceRequestUrl = useServiceRequestUrl();
 
   const defaultValues = useMemo(() => {
     return crash.diagram_transform
@@ -266,7 +267,7 @@ export default function CrashDiagramCard({
             variant="danger"
             message={<p>The crash diagram is not available.</p>}
             link={{
-              href: SERVICE_REQUEST_URL,
+              href: serviceRequestUrl,
               text: "contact support",
             }}
           />

--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -21,10 +21,9 @@ import {
 } from "@/components/CrashDiagramControls";
 import AlignedLabel from "@/components/AlignedLabel";
 import { useImage } from "@/utils/images";
-import { hasRole } from "@/utils/auth";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import ImageUploadModal from "@/components/ImageUploadModal";
 import { useAuth0 } from "@auth0/auth0-react";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface DiagramAlertProps {
   variant: "info" | "danger" | "success" | "warning";

--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -24,6 +24,7 @@ import { useImage } from "@/utils/images";
 import { hasRole } from "@/utils/auth";
 import ImageUploadModal from "@/components/ImageUploadModal";
 import { useAuth0 } from "@auth0/auth0-react";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface DiagramAlertProps {
   variant: "info" | "danger" | "success" | "warning";
@@ -150,11 +151,11 @@ export default function CrashDiagramCard({
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const hasEditPermssions = hasRole(ADMIN_EDIT_ROLES, user);
 
   return (
     <Card className="h-100">
-      {!isReadOnlyUser && (
+      {hasEditPermssions && (
         <ImageUploadModal
           showModal={showModal}
           setShowModal={setShowModal}
@@ -169,7 +170,7 @@ export default function CrashDiagramCard({
       <Card.Header>
         <Card.Title className="d-flex justify-content-between mb-0">
           Diagram
-          {!isReadOnlyUser && crash.is_temp_record && imageUrl && (
+          {hasEditPermssions && crash.is_temp_record && imageUrl && (
             <Button
               size="sm"
               variant="outline-primary"
@@ -251,7 +252,7 @@ export default function CrashDiagramCard({
               </>
             }
             button={
-              !isReadOnlyUser ? (
+              hasEditPermssions ? (
                 <Button onClick={() => setShowModal(true)}>
                   Upload crash diagram
                 </Button>

--- a/editor/components/CrashDiagramControls.tsx
+++ b/editor/components/CrashDiagramControls.tsx
@@ -19,8 +19,7 @@ import { useControls } from "react-zoom-pan-pinch";
 import { CrashDiagramOrientation } from "@/types/crashDiagramOrientation";
 import AlignedLabel from "@/components/AlignedLabel";
 import PermissionsRequired from "@/components/PermissionsRequired";
-
-const allowedUserSaveDiagramRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 export const RotateControls = ({
   setValue,
@@ -114,7 +113,7 @@ export const ZoomResetSaveControls = ({
           </AlignedLabel>
         </Button>
       </ButtonGroup>
-      <PermissionsRequired allowedRoles={allowedUserSaveDiagramRoles}>
+      <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
         <AlignedLabel>
           <Button
             size="sm"

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import { Button, Col, Row } from "react-bootstrap";
-import { useAuth0 } from "@auth0/auth0-react";
 import { Crash } from "@/types/crashes";
 import CrashInjuryIndicators from "@/components/CrashInjuryIndicators";
 import { LuSquarePen } from "react-icons/lu";
 import EditCrashAddressModal from "@/components/EditCrashAddressModal";
-import { hasRole } from "@/utils/auth";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import CopyValueButton from "@/components/CopyValueButton";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
+import { useAuth0 } from "@auth0/auth0-react";
 
 interface CrashHeaderProps {
   crash: Crash;

--- a/editor/components/CrashHeader.tsx
+++ b/editor/components/CrashHeader.tsx
@@ -7,6 +7,7 @@ import { LuSquarePen } from "react-icons/lu";
 import EditCrashAddressModal from "@/components/EditCrashAddressModal";
 import { hasRole } from "@/utils/auth";
 import CopyValueButton from "@/components/CopyValueButton";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface CrashHeaderProps {
   crash: Crash;
@@ -26,12 +27,12 @@ export default function CrashHeader({ crash, refetch }: CrashHeaderProps) {
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const hasEditPermissions = hasRole(ADMIN_EDIT_ROLES, user);
 
   return (
     <Row className="d-flex justify-content-between align-items-center mb-3">
       <Col className="d-flex align-items-center">
-        {isReadOnlyUser ? (
+        {!hasEditPermissions ? (
           <span className="fs-3 fw-bold text-uppercase me-2">
             {crash.address_display}
           </span>

--- a/editor/components/CrashIsTemporaryBanner.tsx
+++ b/editor/components/CrashIsTemporaryBanner.tsx
@@ -6,8 +6,7 @@ import AlignedLabel from "./AlignedLabel";
 import DeleteTemporaryCrashModal from "./DeleteTemporaryCrashModal";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import { Crash } from "@/types/crashes";
-
-const allowedDeleteCrashRecordEditRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 interface CrashIsTemporaryBannerProps {
   crash: Crash;
@@ -43,7 +42,7 @@ export default function CrashIsTemporaryBanner({
           </span>
         </span>
         {allowDelete && (
-          <PermissionsRequired allowedRoles={allowedDeleteCrashRecordEditRoles}>
+          <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
             <span>
               <Button variant="danger" onClick={() => setShowDeleteModal(true)}>
                 <AlignedLabel>

--- a/editor/components/CrashMapCard.tsx
+++ b/editor/components/CrashMapCard.tsx
@@ -19,8 +19,7 @@ import AlignedLabel from "@/components/AlignedLabel";
 import { LuSquarePen } from "react-icons/lu";
 import { Location } from "@/types/locations";
 import LocationPolygonLayer from "@/components/LocationPolygonLayer";
-
-const allowedMapEditRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 interface CrashMapCardProps {
   savedLatitude: number | null;
@@ -108,7 +107,7 @@ export default function CrashMapCard({
         </PointMap>
       </Card.Body>
       <Card.Footer>
-        <PermissionsRequired allowedRoles={allowedMapEditRoles}>
+        <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
           <div
             className={`d-flex align-items-center ${isEditing ? "justify-content-between" : "justify-content-end"}`}
           >

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -3,10 +3,9 @@ import Button from "react-bootstrap/Button";
 import { FaFilePdf } from "react-icons/fa6";
 import AlignedLabel from "@/components/AlignedLabel";
 import { Crash } from "@/types/crashes";
-import { hasRole, useGetToken } from "@/utils/auth";
-import { useAuth0 } from "@auth0/auth0-react";
+import { hasRole, useGetToken, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
+import { useAuth0 } from "@auth0/auth0-react";
 
 export const allowedCrashReportDownloadRoles = ADMIN_EDIT_ROLES;
 

--- a/editor/components/CrashNarrativeCard.tsx
+++ b/editor/components/CrashNarrativeCard.tsx
@@ -6,8 +6,9 @@ import { Crash } from "@/types/crashes";
 import { hasRole, useGetToken } from "@/utils/auth";
 import { useAuth0 } from "@auth0/auth0-react";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
-export const allowedCrashReportDownloadRoles = ["editor", "vz-admin"];
+export const allowedCrashReportDownloadRoles = ADMIN_EDIT_ROLES;
 
 // Downloads pdf from the crash report API and opens it in a new tab
 export const onDownloadCrashReport = async ({
@@ -49,9 +50,7 @@ export default function CrashNarrativeCard({ crash }: { crash: Crash }) {
   const getToken = useGetToken();
 
   const { user } = useAuth0();
-  const canDownloadCrashReport = user
-    ? hasRole(allowedCrashReportDownloadRoles, user)
-    : false;
+  const canDownloadCrashReport = hasRole(allowedCrashReportDownloadRoles, user);
 
   const isCrashReportStored = crash.cr3_stored_fl;
 

--- a/editor/components/CrashNarrativeEditableCard.tsx
+++ b/editor/components/CrashNarrativeEditableCard.tsx
@@ -42,10 +42,8 @@ export default function CrashNarrativeEditableCard({
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
-  const canDownloadCrashReport = user
-    ? hasRole(allowedCrashReportDownloadRoles, user)
-    : false;
+  const canDownloadCrashReport = hasRole(allowedCrashReportDownloadRoles, user);
+  const isReadOnlyUser = !canDownloadCrashReport;
 
   const { mutate, loading: isSubmitting } = useMutation(UPDATE_CRASH);
 

--- a/editor/components/CrashRecommendationCard.tsx
+++ b/editor/components/CrashRecommendationCard.tsx
@@ -26,8 +26,7 @@ import PermissionsRequired from "@/components/PermissionsRequired";
 import AlignedLabel from "@/components/AlignedLabel";
 import { LuSquarePen } from "react-icons/lu";
 import { stringToNumberNullable } from "@/utils/formHelpers";
-
-const allowedRecommendationEditRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 /**
  * Compares the old vs new RecommendationPartner arrays and returns
@@ -293,7 +292,7 @@ export default function CrashRecommendationCard({
           </Row>
         </Form>
       </Card.Body>
-      <PermissionsRequired allowedRoles={allowedRecommendationEditRoles}>
+      <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
         <Card.Footer>
           <div className="d-flex justify-content-end">
             {!isEditing && (

--- a/editor/components/DataCard.tsx
+++ b/editor/components/DataCard.tsx
@@ -17,6 +17,7 @@ import { hasRole } from "@/utils/auth";
 import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
 import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 import ColumnVisibilityAlert from "@/components/ColumnVisibilityAlert";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 export interface HeaderActionComponentProps<T extends Record<string, unknown>> {
   record: T;
@@ -91,7 +92,7 @@ export default function DataCard<T extends Record<string, unknown>>({
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const hasEditPermissions = hasRole(ADMIN_EDIT_ROLES, user);
 
   const {
     data: selectOptions,
@@ -139,7 +140,7 @@ export default function DataCard<T extends Record<string, unknown>>({
     <Card>
       <Card.Header className="d-flex justify-content-between">
         <Card.Title>{title}</Card.Title>
-        {HeaderActionComponent && !isReadOnlyUser && (
+        {HeaderActionComponent && hasEditPermissions && (
           <HeaderActionComponent
             record={record}
             mutation={mutation}
@@ -172,12 +173,12 @@ export default function DataCard<T extends Record<string, unknown>>({
                     key={String(col.path)}
                     style={{
                       cursor:
-                        col.editable && !isEditingThisColumn && !isReadOnlyUser
+                        col.editable && !isEditingThisColumn && hasEditPermissions
                           ? "pointer"
                           : "auto",
                     }}
                     onClick={() => {
-                      if (!col.editable || isReadOnlyUser) {
+                      if (!col.editable || !hasEditPermissions) {
                         return;
                       }
                       if (!isEditingThisColumn) {

--- a/editor/components/DataCard.tsx
+++ b/editor/components/DataCard.tsx
@@ -13,11 +13,10 @@ import {
 import { ColDataCardDef } from "@/types/types";
 import { LookupTableOption } from "@/types/relationships";
 import { useAuth0 } from "@auth0/auth0-react";
-import { hasRole } from "@/utils/auth";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import TableColumnVisibilityMenu from "@/components/TableColumnVisibilityMenu";
 import { useVisibleColumns } from "@/components/TableColumnVisibilityMenu";
 import ColumnVisibilityAlert from "@/components/ColumnVisibilityAlert";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 export interface HeaderActionComponentProps<T extends Record<string, unknown>> {
   record: T;
@@ -173,7 +172,9 @@ export default function DataCard<T extends Record<string, unknown>>({
                     key={String(col.path)}
                     style={{
                       cursor:
-                        col.editable && !isEditingThisColumn && hasEditPermissions
+                        col.editable &&
+                        !isEditingThisColumn &&
+                        hasEditPermissions
                           ? "pointer"
                           : "auto",
                     }}

--- a/editor/components/EMSLinkRecordButton.tsx
+++ b/editor/components/EMSLinkRecordButton.tsx
@@ -8,8 +8,7 @@ import AlignedLabel from "@/components/AlignedLabel";
 import { useMutation } from "@/utils/graphql";
 import { Modal } from "react-bootstrap";
 import { useState } from "react";
-
-const allowedLinkRecordRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 export interface EMSLinkRecordButtonProps extends Record<string, unknown> {
   onClick: (emsId: EMSPatientCareRecord) => void;
@@ -37,7 +36,7 @@ const EMSLinkRecordButton: React.FC<
   const { mutate: updateEMSRecord } = useMutation(mutation);
 
   return (
-    <PermissionsRequired allowedRoles={allowedLinkRecordRoles}>
+    <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
       <div className="d-flex">
         {!isEditingColumn && (
           <Button

--- a/editor/components/EMSLinkToPersonButton.tsx
+++ b/editor/components/EMSLinkToPersonButton.tsx
@@ -5,8 +5,7 @@ import { PeopleListRow } from "@/types/peopleList";
 import { FaLink } from "react-icons/fa6";
 import PermissionsRequired from "@/components/PermissionsRequired";
 import AlignedLabel from "@/components/AlignedLabel";
-
-const allowedLinkRecordRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 export interface EMSLinkToPersonButtonProps extends Record<string, unknown> {
   onClick: (emsId: number, personId: number) => void;
@@ -25,7 +24,7 @@ const EMSLinkToPersonButton: React.FC<
   }
 
   return (
-    <PermissionsRequired allowedRoles={allowedLinkRecordRoles}>
+    <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
       <Button
         size="sm"
         variant="primary"

--- a/editor/components/FatalityUnitCardFooter.tsx
+++ b/editor/components/FatalityUnitCardFooter.tsx
@@ -9,6 +9,7 @@ import ContributingFactorsModal from "@/components/ContributingFactorsModal";
 import ChargesModal from "@/components/ChargesModal";
 import { useAuth0 } from "@auth0/auth0-react";
 import { hasRole } from "@/utils/auth";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface FatalityUnitCardFooterProps {
   crashPk: number;
@@ -42,7 +43,7 @@ export default function FatalityUnitCardFooter({
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const hasEditPermissions = hasRole(ADMIN_EDIT_ROLES, user);
 
   return (
     <Card.Footer
@@ -66,7 +67,7 @@ export default function FatalityUnitCardFooter({
       {hasContribFactors && (
         <div className="pb-2">
           <span className="fw-bold">Contributing factors</span>
-          {isTempRecord && !isReadOnlyUser && (
+          {isTempRecord && hasEditPermissions && (
             <span className="ms-1 d-inline-flex align-items-center">
               <Button
                 className="border-0"
@@ -100,7 +101,7 @@ export default function FatalityUnitCardFooter({
           <div className="fw-bold">Contributing factors</div>
           <div className="d-flex justify-content-start align-items-center">
             <span className="ms-2 text-secondary">None</span>
-            {!isReadOnlyUser && (
+            {hasEditPermissions && (
               <span className="ms-1 d-inline-flex align-items-center">
                 <Button
                   className="border-0"
@@ -120,7 +121,7 @@ export default function FatalityUnitCardFooter({
       {hasCharges && !!unitCharges?.[0].charge && (
         <div>
           <span className="fw-bold">Charges</span>
-          {isTempRecord && !isReadOnlyUser && (
+          {isTempRecord && hasEditPermissions && (
             <span className="ms-1 d-inline-flex align-items-center">
               <Button
                 className="border-0"
@@ -149,7 +150,7 @@ export default function FatalityUnitCardFooter({
         <div>
           <div className="fw-bold">Charges</div>
           <span className="ms-2 text-secondary">None</span>
-          {!isReadOnlyUser && (
+          {hasEditPermissions && (
             <span className="ms-1 d-inline-flex align-items-center">
               <Button
                 className="border-0"

--- a/editor/components/FatalityUnitCardFooter.tsx
+++ b/editor/components/FatalityUnitCardFooter.tsx
@@ -8,8 +8,7 @@ import AlignedLabel from "@/components/AlignedLabel";
 import ContributingFactorsModal from "@/components/ContributingFactorsModal";
 import ChargesModal from "@/components/ChargesModal";
 import { useAuth0 } from "@auth0/auth0-react";
-import { hasRole } from "@/utils/auth";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 interface FatalityUnitCardFooterProps {
   crashPk: number;

--- a/editor/components/FatalityVictimListItem.tsx
+++ b/editor/components/FatalityVictimListItem.tsx
@@ -8,6 +8,7 @@ import { Unit } from "@/types/unit";
 import { hasRole } from "@/utils/auth";
 import { useImage } from "@/utils/images";
 import { useAuth0 } from "@auth0/auth0-react";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface FatalityVictimListItemProps {
   victim: PeopleListRow;
@@ -59,7 +60,7 @@ export default function FatalityVictimListItem({
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const hasEditPermissions = hasRole(ADMIN_EDIT_ROLES, user);
 
   return (
     <ListGroupItem
@@ -67,7 +68,7 @@ export default function FatalityVictimListItem({
       key={victim.id}
       style={{ border: "none" }}
     >
-      {!isReadOnlyUser && (
+      {hasEditPermissions && (
         <ImageUploadModal
           showModal={showModal}
           setShowModal={setShowModal}
@@ -86,7 +87,7 @@ export default function FatalityVictimListItem({
           onClick={() => setShowModal(true)}
           imageUrl={imageUrl}
           isLoading={isLoading}
-          isReadOnlyUser={isReadOnlyUser}
+          isReadOnlyUser={!hasEditPermissions}
         />
         <div className="d-flex flex-column">
           <div className="pb-1">

--- a/editor/components/FatalityVictimListItem.tsx
+++ b/editor/components/FatalityVictimListItem.tsx
@@ -5,10 +5,9 @@ import { PeopleListRow } from "@/types/peopleList";
 import { getInjuryColorClass } from "@/utils/people";
 import { useState } from "react";
 import { Unit } from "@/types/unit";
-import { hasRole } from "@/utils/auth";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import { useImage } from "@/utils/images";
 import { useAuth0 } from "@auth0/auth0-react";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface FatalityVictimListItemProps {
   victim: PeopleListRow;

--- a/editor/components/NavBarSearch.tsx
+++ b/editor/components/NavBarSearch.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useSyncExternalStore } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
 import Spinner from "react-bootstrap/Spinner";
 import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
@@ -16,6 +17,7 @@ import { EMSPatientCareRecord } from "@/types/ems";
 import { Location } from "@/types/locations";
 import { useQuery } from "@/utils/graphql";
 import { useLogUserEvent } from "@/utils/userEvents";
+import { ADMIN_EDIT_ROLES, hasRole, HasuraUserRoleName } from "@/utils/auth";
 
 const navSearchLocalStorageKey = "navBarSearchField";
 
@@ -34,6 +36,7 @@ type SearchField<T extends SearchableTypes = SearchableTypes> = {
   label: string;
   query: string;
   getUrl: (record: T) => string;
+  allowedRoles?: HasuraUserRoleName[];
 };
 
 /**
@@ -62,6 +65,7 @@ const SEARCH_FIELDS = [
     label: "EMS Incident #",
     query: EMS_INCIDENT_NAV_SEARCH,
     getUrl: (record: EMSPatientCareRecord) => `/ems/${record.incident_number}`,
+    allowedRoles: ADMIN_EDIT_ROLES,
   },
   {
     key: "location_id",
@@ -74,17 +78,21 @@ const SEARCH_FIELDS = [
 /**
  * Find a search field config from an input key - it's a safe way to handle an
  * arbitrary key string from local storage
- * @param val
+ * @param key
+ * @param fields - the permission-filtered fields to search/fall back within
  * @returns
  */
-const getValidSearchField = (key: string | null): AnySearchField => {
+const getValidSearchField = (
+  key: string | null,
+  fields: AnySearchField[]
+): AnySearchField => {
   if (!key) {
-    return SEARCH_FIELDS[0];
+    return fields[0];
   }
-  const foundSearchField = SEARCH_FIELDS.find(
+  const foundSearchField = fields.find(
     (searchField) => searchField.key === key
   );
-  return foundSearchField || SEARCH_FIELDS[0];
+  return foundSearchField || fields[0];
 };
 
 const subscribeToNavSearchStorage = (onStoreChange: () => void) => {
@@ -105,10 +113,15 @@ export default function NavBarSearch() {
     getNavSearchStorageSnapshot,
     () => null
   );
+  const { user } = useAuth0();
+  const visibleSearchFields = SEARCH_FIELDS.filter(
+    (field) => !field.allowedRoles || hasRole(field.allowedRoles, user)
+  );
   const [searchFieldOverride, setSearchFieldOverride] =
     useState<AnySearchField | null>(null);
   const searchField =
-    searchFieldOverride ?? getValidSearchField(storedSearchKey);
+    searchFieldOverride ??
+    getValidSearchField(storedSearchKey, visibleSearchFields);
   const [searchValue, setSearchValue] = useState("");
   const [searchClicked, setSearchClicked] = useState(false);
   const [pendingRoute, setPendingRoute] = useState<string | null>(null);
@@ -175,7 +188,7 @@ export default function NavBarSearch() {
               </AlignedLabel>
             </Dropdown.Toggle>
             <Dropdown.Menu>
-              {SEARCH_FIELDS.map((searchFieldOption) => (
+              {visibleSearchFields.map((searchFieldOption) => (
                 <Dropdown.Item
                   key={searchFieldOption.key}
                   active={searchFieldOption.key === searchField.key}

--- a/editor/components/NotesCard.tsx
+++ b/editor/components/NotesCard.tsx
@@ -11,8 +11,7 @@ import { CrashNote } from "@/types/crashNote";
 import { formatIsoDate, formatUserNameFromEmail } from "@/utils/formatters";
 import { LuSquarePen } from "react-icons/lu";
 import { LocationNote } from "@/types/locationNote";
-
-const allowedNoteRoles = ["vz-admin", "editor"];
+import { ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 interface NotesCardProps<T extends CrashNote | LocationNote> {
   notes: T[];
@@ -25,7 +24,7 @@ interface NotesCardProps<T extends CrashNote | LocationNote> {
 
 const AddNoteButton = ({ onClick }: { onClick: () => void }) => {
   return (
-    <PermissionsRequired allowedRoles={allowedNoteRoles}>
+    <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
       <Button size="sm" variant="primary" onClick={onClick}>
         <AlignedLabel>
           <LuCirclePlus className="me-2" />
@@ -82,7 +81,7 @@ export default function NotesCard<T extends CrashNote | LocationNote>({
                       </span>
                     </small>
                   </div>
-                  <PermissionsRequired allowedRoles={allowedNoteRoles}>
+                  <PermissionsRequired allowedRoles={ADMIN_EDIT_ROLES}>
                     <div className="d-flex align-self-start mt-2">
                       <Button
                         className="me-2"

--- a/editor/components/PermissionsRequired.tsx
+++ b/editor/components/PermissionsRequired.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
-import { hasRole } from "@/utils/auth";
+import { hasRole, HasuraUserRoleName } from "@/utils/auth";
 
 interface PermissionsRequiredProps {
   children: ReactNode;
-  allowedRoles?: string[];
+  allowedRoles?: HasuraUserRoleName[];
 }
 
 /**

--- a/editor/components/PermissionsRequired.tsx
+++ b/editor/components/PermissionsRequired.tsx
@@ -17,7 +17,7 @@ export default function PermissionsRequired({
   allowedRoles,
 }: PermissionsRequiredProps) {
   const { user } = useAuth0();
-  if (!allowedRoles || (user && hasRole(allowedRoles, user))) {
+  if (!allowedRoles || hasRole(allowedRoles, user)) {
     return children;
   }
   return null;

--- a/editor/components/RelatedRecordTableRow.tsx
+++ b/editor/components/RelatedRecordTableRow.tsx
@@ -12,8 +12,7 @@ import {
 import { ColDataCardDef } from "@/types/types";
 import { LookupTableOption } from "@/types/relationships";
 import { RowActionComponentProps } from "@/components/RelatedRecordTable";
-import { hasRole } from "@/utils/auth";
-import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
+import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 
 interface RelatedRecordTableRowProps<
   T extends Record<string, unknown>,

--- a/editor/components/RelatedRecordTableRow.tsx
+++ b/editor/components/RelatedRecordTableRow.tsx
@@ -13,6 +13,7 @@ import { ColDataCardDef } from "@/types/types";
 import { LookupTableOption } from "@/types/relationships";
 import { RowActionComponentProps } from "@/components/RelatedRecordTable";
 import { hasRole } from "@/utils/auth";
+import { ADMIN_EDIT_ROLES } from "@/utils/permissions";
 
 interface RelatedRecordTableRowProps<
   T extends Record<string, unknown>,
@@ -94,7 +95,7 @@ export default function RelatedRecordTableRow<
 
   const { user } = useAuth0();
 
-  const isReadOnlyUser = user && hasRole(["readonly"], user);
+  const hasEditPermissions = hasRole(ADMIN_EDIT_ROLES, user);
 
   const {
     data: selectOptions,
@@ -147,13 +148,13 @@ export default function RelatedRecordTableRow<
               key={String(col.path)}
               style={{
                 cursor:
-                  isEditable && !isEditingThisColumn && !isReadOnlyUser
+                  isEditable && !isEditingThisColumn && hasEditPermissions
                     ? "pointer"
                     : "auto",
                 ...(col.style || {}),
               }}
               onClick={() => {
-                if (!isEditable || isReadOnlyUser) {
+                if (!isEditable || !hasEditPermissions) {
                   return;
                 }
                 if (!isEditingThisColumn) {

--- a/editor/configs/routes.ts
+++ b/editor/configs/routes.ts
@@ -42,7 +42,7 @@ export const routes: Route[] = [
     path: "upload-non-cr3",
     label: "Upload Non-CR3",
     icon: LuCloudUpload,
-    allowedRoles: ["editor", "vz-admin"],
+    allowedRoles: ADMIN_EDIT_ROLES,
   },
   {
     path: "users",

--- a/editor/configs/routes.ts
+++ b/editor/configs/routes.ts
@@ -2,13 +2,13 @@ import { FaRegHeart, FaCarBurst } from "react-icons/fa6";
 import { RiDashboard3Line } from "react-icons/ri";
 import { LuMapPin, LuAmbulance, LuCloudUpload, LuUsers } from "react-icons/lu";
 import { IconType } from "react-icons";
-import { EMS_VIEW_ROLES } from "@/utils/auth";
+import { ADMIN_EDIT_ROLES, HasuraUserRoleName } from "@/utils/auth";
 
 interface Route {
   path: string;
   label: string;
   icon: IconType;
-  allowedRoles?: string[];
+  allowedRoles?: HasuraUserRoleName[];
 }
 
 export const routes: Route[] = [
@@ -36,7 +36,7 @@ export const routes: Route[] = [
     path: "ems",
     label: "EMS",
     icon: LuAmbulance,
-    allowedRoles: EMS_VIEW_ROLES,
+    allowedRoles: ADMIN_EDIT_ROLES,
   },
   {
     path: "upload-non-cr3",

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -110,10 +110,7 @@ export const useGetToken = (): (() => Promise<string | undefined>) => {
 
 /**
  * Hook that redirects the user away from a page if they don't have one of
- * the allowed roles. Returns whether the user is authorized so the calling
- * page can bail out of rendering (`if (!isAuthorized) return null;`) before
- * its real content — and, for pages with their own data-fetching hooks,
- * before those queries fire.
+ * the allowed roles.
  *
  * @example
  * const allowedEmsRoles = ["editor", "vz-admin"];

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -6,7 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
  * Add our claims to the Auth0 ID token—these are
  * added via Auth0 action
  */
-interface CustomUser extends User {
+export interface CustomUser extends User {
   "https://hasura.io/jwt/claims"?: {
     "x-hasura-allowed-roles"?: string[];
   };
@@ -37,20 +37,8 @@ export const getHasuraRoleName = (roles?: string[]): string => {
  * @param user - the user object
  * @returns True if the user has any of the provided roles
  */
-export const hasRole = (roles: string[], user: CustomUser) =>
-  roles.includes(getHasuraRoleName(getRolesArray(user)));
-
-/** Roles that have editor or administrator permisisons */
-export const ADMIN_EDIT_ROLES = ["editor", "vz-admin"];
-
-/** Roles that may view EMS patient care records */
-export const EMS_VIEW_ROLES = [...ADMIN_EDIT_ROLES];
-
-/**
- * True if the user may see EMS content (nav, crash details card, GraphQL fields)
- */
-export const canViewEms = (user: CustomUser | undefined) =>
-  Boolean(user && hasRole(EMS_VIEW_ROLES, user));
+export const hasRole = (roles: string[], user?: CustomUser): boolean =>
+  Boolean(user) && roles.includes(getHasuraRoleName(getRolesArray(user)));
 
 /**
  * Make the hasura role name human-friendly
@@ -123,7 +111,7 @@ export const useRequiredPageRole = (
 ): boolean => {
   const { user } = useAuth0();
   const router = useRouter();
-  const isAuthorized = !!user && hasRole(allowedRoles, user);
+  const isAuthorized = hasRole(allowedRoles, user);
 
   useEffect(() => {
     if (user && !isAuthorized) {

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -46,9 +46,7 @@ export const getRolesArray = (
 export const getHasuraRoleName = (
   roles: HasuraUserRoleName[]
 ): HasuraUserRoleName => {
-  {
-    return roles[0];
-  }
+  return roles[0];
 };
 
 /**

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -20,18 +20,25 @@ interface CustomUser extends User {
 const EDITOR_ROLE: HasuraUserRoleName = "editor";
 export const ADMIN_ROLE: HasuraUserRoleName = "vz-admin";
 
-export const ADMIN_EDIT_ROLES: HasuraUserRoleName[] = [
-  EDITOR_ROLE,
-  ADMIN_ROLE,
-];
+export const ADMIN_EDIT_ROLES: HasuraUserRoleName[] = [EDITOR_ROLE, ADMIN_ROLE];
 
 /**
  * Get the allowed roles array from a user object
  * */
-export const getRolesArray = (user: Partial<CustomUser>): HasuraUserRoleName[] =>
-  user?.["https://hasura.io/jwt/claims"]?.["x-hasura-allowed-roles"] || [
-    "readonly",
-  ];
+export const getRolesArray = (
+  user: Partial<CustomUser>
+): HasuraUserRoleName[] => {
+  const role =
+    user?.["https://hasura.io/jwt/claims"]?.["x-hasura-allowed-roles"];
+
+  if (!role) {
+    console.warn(
+      "User has malformed/missing Hasura JWT claims. No allowed role found."
+    );
+    return ["readonly"];
+  }
+  return role;
+};
 
 /**
  * Get a user's hasura role name from their allowed roles

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -1,6 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useAuth0, User } from "@auth0/auth0-react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 /**
  * Add our claims to the Auth0 ID token—these are
@@ -40,8 +40,11 @@ export const getHasuraRoleName = (roles?: string[]): string => {
 export const hasRole = (roles: string[], user: CustomUser) =>
   roles.includes(getHasuraRoleName(getRolesArray(user)));
 
+/** Roles that have editor or administrator permisisons */
+export const ADMIN_EDIT_ROLES = ["editor", "vz-admin"];
+
 /** Roles that may view EMS patient care records */
-export const EMS_VIEW_ROLES = ["editor", "vz-admin"];
+export const EMS_VIEW_ROLES = [...ADMIN_EDIT_ROLES];
 
 /**
  * True if the user may see EMS content (nav, crash details card, GraphQL fields)
@@ -103,4 +106,33 @@ export const useGetToken = (): (() => Promise<string | undefined>) => {
     // has us covered.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, pathname]);
+};
+
+/**
+ * Hook that redirects the user away from a page if they don't have one of
+ * the allowed roles. Returns whether the user is authorized so the calling
+ * page can bail out of rendering (`if (!isAuthorized) return null;`) before
+ * its real content — and, for pages with their own data-fetching hooks,
+ * before those queries fire.
+ *
+ * @example
+ * const allowedEmsRoles = ["editor", "vz-admin"];
+ * const isAuthorized = useRequiredPageRole(allowedEmsRoles);
+ * if (!isAuthorized) return null;
+ */
+export const useRequiredPageRole = (
+  allowedRoles: string[],
+  redirectTo: string = "/unauthorized"
+): boolean => {
+  const { user } = useAuth0();
+  const router = useRouter();
+  const isAuthorized = !!user && hasRole(allowedRoles, user);
+
+  useEffect(() => {
+    if (user && !isAuthorized) {
+      router.replace(redirectTo);
+    }
+  }, [user, isAuthorized, redirectTo, router]);
+
+  return isAuthorized;
 };

--- a/editor/utils/auth.ts
+++ b/editor/utils/auth.ts
@@ -3,42 +3,66 @@ import { useAuth0, User } from "@auth0/auth0-react";
 import { usePathname, useRouter } from "next/navigation";
 
 /**
+ * The allowed role names we've defined in Hasura
+ */
+export type HasuraUserRoleName = "vz-admin" | "editor" | "readonly";
+
+/**
  * Add our claims to the Auth0 ID token—these are
  * added via Auth0 action
  */
-export interface CustomUser extends User {
+interface CustomUser extends User {
   "https://hasura.io/jwt/claims"?: {
-    "x-hasura-allowed-roles"?: string[];
+    "x-hasura-allowed-roles"?: HasuraUserRoleName[];
   };
 }
+
+const EDITOR_ROLE: HasuraUserRoleName = "editor";
+export const ADMIN_ROLE: HasuraUserRoleName = "vz-admin";
+
+export const ADMIN_EDIT_ROLES: HasuraUserRoleName[] = [
+  EDITOR_ROLE,
+  ADMIN_ROLE,
+];
 
 /**
  * Get the allowed roles array from a user object
  * */
-export const getRolesArray = (user: CustomUser | undefined) =>
-  user?.["https://hasura.io/jwt/claims"]?.["x-hasura-allowed-roles"];
+export const getRolesArray = (user: Partial<CustomUser>): HasuraUserRoleName[] =>
+  user?.["https://hasura.io/jwt/claims"]?.["x-hasura-allowed-roles"] || [
+    "readonly",
+  ];
 
 /**
  * Get a user's hasura role name from their allowed roles
  */
-export const getHasuraRoleName = (roles?: string[]): string => {
-  if (!roles) {
-    // this would be the result of a malformed/corrupted user account -
-    // check this user's raw JSON in the Auth0 user database
-    return "";
-  } else {
-    return roles[0] || "";
+export const getHasuraRoleName = (
+  roles: HasuraUserRoleName[]
+): HasuraUserRoleName => {
+  {
+    return roles[0];
   }
 };
 
 /**
  * Check if a user has any of the provided role names
- * @param roles - an array of roles to check for
+ * @param roles - a role string or an array of roles to check for
  * @param user - the user object
  * @returns True if the user has any of the provided roles
  */
-export const hasRole = (roles: string[], user?: CustomUser): boolean =>
-  Boolean(user) && roles.includes(getHasuraRoleName(getRolesArray(user)));
+export const hasRole = (
+  roles: HasuraUserRoleName[] | HasuraUserRoleName,
+  user?: CustomUser
+): boolean => {
+  if (!user) return false;
+  const userRole = getHasuraRoleName(getRolesArray(user));
+
+  if (typeof roles === "string") {
+    return userRole === roles;
+  } else {
+    return roles.includes(userRole);
+  }
+};
 
 /**
  * Make the hasura role name human-friendly
@@ -106,7 +130,7 @@ export const useGetToken = (): (() => Promise<string | undefined>) => {
  * if (!isAuthorized) return null;
  */
 export const useRequiredPageRole = (
-  allowedRoles: string[],
+  allowedRoles: HasuraUserRoleName[],
   redirectTo: string = "/unauthorized"
 ): boolean => {
   const { user } = useAuth0();

--- a/editor/utils/graphql.ts
+++ b/editor/utils/graphql.ts
@@ -114,14 +114,14 @@ export const useQuery = <T extends Record<string, unknown>>({
     RequestDocument,
     Variables,
   ]): Promise<HasuraGraphQLResponse<T, typeof typename>> => {
-    const hasuraRoleName = getHasuraRoleName(getRolesArray(user));
+    const hasuraRoleName = getHasuraRoleName(getRolesArray(user || {}));
     const token = await getToken();
     return fetcher([query, variables, token || "", hasuraRoleName]);
   };
 
   const { data, error, isLoading, mutate, isValidating } = useSWR<
     HasuraGraphQLResponse<T, typeof typename>
-  >(query ? [query, variables] : null, fetchWithAuth, {
+  >(query && user ? [query, variables] : null, fetchWithAuth, {
     ...DEFAULT_SWR_OPTIONS,
     ...(options || {}),
   });
@@ -165,7 +165,7 @@ export const useMutation = (mutation: RequestDocument) => {
         variables.updates.updated_by = user.email;
       }
       try {
-        const hasuraRole = getHasuraRoleName(getRolesArray(user));
+        const hasuraRole = getHasuraRoleName(getRolesArray(user || {}));
         const token = await getToken();
         const client = new GraphQLClient(ENDPOINT, {
           headers: {

--- a/editor/utils/permissions.ts
+++ b/editor/utils/permissions.ts
@@ -1,7 +1,0 @@
-import { CustomUser, hasRole } from "@/utils/auth";
-
-/** Roles that have editor or administrator permisisons */
-export const ADMIN_EDIT_ROLES = ["editor", "vz-admin"];
-
-/** Roles that may view EMS patient care records */
-export const EMS_VIEW_ROLES = [...ADMIN_EDIT_ROLES];

--- a/editor/utils/permissions.ts
+++ b/editor/utils/permissions.ts
@@ -1,0 +1,7 @@
+import { CustomUser, hasRole } from "@/utils/auth";
+
+/** Roles that have editor or administrator permisisons */
+export const ADMIN_EDIT_ROLES = ["editor", "vz-admin"];
+
+/** Roles that may view EMS patient care records */
+export const EMS_VIEW_ROLES = [...ADMIN_EDIT_ROLES];

--- a/editor/utils/serviceRequest.ts
+++ b/editor/utils/serviceRequest.ts
@@ -1,0 +1,20 @@
+import { useAuth0 } from "@auth0/auth0-react";
+
+const serviceRequestParams = {
+  // "What applicaiton are you using (vision zero)"
+  field_1130: ["5da8d25798bb900018bf82e0"],
+  // "What do you need help with"
+  field_398: "Bug Report — Something is not working",
+  // email
+  field_406: "",
+};
+
+const SERVICE_REQUEST_BASE_URL =
+  "https://atd.knack.com/dts#new-service-request/?view_249_vars=";
+
+export const useServiceRequestUrl = () => {
+  const { user } = useAuth0();
+  const userEmail = user?.email || "";
+  const payload = { ...serviceRequestParams, field_406: userEmail };
+  return `${SERVICE_REQUEST_BASE_URL}${encodeURIComponent(JSON.stringify(payload))}`;
+};


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/29486

This PR adds a hook that re-directs unauthorized users away from restricted routes. Prior to this change, if a user reached a restricted page it would simply not fully load due to failing API requests.


<img width="775" height="645" alt="Screenshot 2026-08-20 at 2 30 18 PM" src="https://github.com/user-attachments/assets/2e764f55-ba48-41e1-a781-79496e70d88e" />

## Testing

**URL to test:** [Netlify](https://deploy-preview-2122--vze-staging.netlify.app/editor/crashes)

1. Login in using the **Test User: Read-only viewer** account

2. Try visiting the following pages and confirm you are redirected to the `/unauthorized` page.
- [EMS list page](https://deploy-preview-2122--vze-staging.netlify.app/editor/ems)
- [EMS details page](https://deploy-preview-2122--vze-staging.netlify.app/editor/ems/26196-0215)
- [Upload non-CR3 page](https://deploy-preview-2122--vze-staging.netlify.app/editor/upload-non-cr3)

3. On the `/unauthorized` page, use the **Ask for help** link and confirms it takes you to the service desk request form (I should update that url to pre-populate the app ID!)
3. Repeat steps with the editor and admin users (**Test User: Editor** and **Test User: VZ Admin**) and confirm you can reach all pages without issue.
 
---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
