### PR TITLE
Fix the service request URL in the VZE

### DIFF
--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -4,10 +4,11 @@ import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 import { LuShieldAlert } from "react-icons/lu";
-import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
+import { useServiceRequestUrl } from "@/utils/serviceRequest";
 
 export default function Unauthorized() {
   const router = useRouter();
+  const serviceRequestUrl = useServiceRequestUrl();
   return (
     <div className="d-flex flex-column flex-grow-1 justify-content-center h-100">
       <Row className="d-flex justify-content-center">
@@ -21,11 +22,7 @@ export default function Unauthorized() {
           <h5 className="text-muted">
             You don&apos;t have permission to view this page. If you need
             access, you can{" "}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              href={SERVICE_REQUEST_URL}
-            >
+            <a target="_blank" rel="noreferrer" href={serviceRequestUrl}>
               ask for help
             </a>
             .

--- a/editor/app/unauthorized/page.tsx
+++ b/editor/app/unauthorized/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import AlignedLabel from "@/components/AlignedLabel";
+import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
 import { useRouter } from "next/navigation";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -19,14 +19,16 @@ export default function Unauthorized() {
         <Col className="text-center">
           <h2>Not Authorized</h2>
           <h5 className="text-muted">
-            You don&apos;t have permission to view this page. If you need access, you can{" "}
+            You don&apos;t have permission to view this page. If you need
+            access, you can{" "}
             <a
               target="_blank"
               rel="noreferrer"
-              href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
+              href={SERVICE_REQUEST_URL}
             >
               ask for help
-            </a>.
+            </a>
+            .
           </h5>
           <div className="my-3">
             <Button onClick={() => router.back()}>Go back</Button>

--- a/editor/components/AppNavBar.tsx
+++ b/editor/components/AppNavBar.tsx
@@ -7,7 +7,6 @@ import Col from "react-bootstrap/Col";
 import Navbar from "react-bootstrap/Navbar";
 import {
   FaBug,
-  FaLightbulb,
   FaRightFromBracket,
   FaSquareArrowUpRight,
   FaToolbox,
@@ -18,6 +17,7 @@ import NavBarSearch from "@/components/NavBarSearch";
 import AlignedLabel from "@/components/AlignedLabel";
 import DropdownAnchorToggle from "@/components/DropdownAnchorToggle";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
@@ -33,9 +33,7 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
   const userId = user?.["https://hasura.io/jwt/claims"]?.["x-hasura-user-id"];
 
   return (
-    <Navbar
-      className="app-navbar border-bottom pe-3 w-100"
-    >
+    <Navbar className="app-navbar border-bottom pe-3 w-100">
       <Container fluid>
         <Col className="d-flex justify-content-start">
           <Navbar.Brand href="/crashes" as={Link}>
@@ -75,22 +73,11 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
               <Dropdown.Item
                 target="_blank"
                 rel="noreferrer"
-                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
+                href={SERVICE_REQUEST_URL}
               >
                 <AlignedLabel>
                   <FaBug className="me-3" />
-                  Report a bug
-                  <FaSquareArrowUpRight className="ms-3 text-muted" />
-                </AlignedLabel>
-              </Dropdown.Item>
-              <Dropdown.Item
-                target="_blank"
-                rel="noreferrer"
-                href="https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Feature%20or%20Enhancement%20%E2%80%94%20An%20application%20I%20use%20could%20be%20improved%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D"
-              >
-                <AlignedLabel>
-                  <FaLightbulb className="me-3" />
-                  Request an enhancement
+                  Contact support
                   <FaSquareArrowUpRight className="ms-3 text-muted" />
                 </AlignedLabel>
               </Dropdown.Item>

--- a/editor/components/AppNavBar.tsx
+++ b/editor/components/AppNavBar.tsx
@@ -17,7 +17,7 @@ import NavBarSearch from "@/components/NavBarSearch";
 import AlignedLabel from "@/components/AlignedLabel";
 import DropdownAnchorToggle from "@/components/DropdownAnchorToggle";
 import DarkModeToggle from "@/components/DarkModeToggle";
-import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
+import { useServiceRequestUrl } from "@/utils/serviceRequest";
 
 const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
@@ -31,6 +31,7 @@ type NavBarProps = {
  */
 export default function AppNavBar({ user, logout }: NavBarProps) {
   const userId = user?.["https://hasura.io/jwt/claims"]?.["x-hasura-user-id"];
+  const serviceRequestUrl = useServiceRequestUrl();
 
   return (
     <Navbar className="app-navbar border-bottom pe-3 w-100">
@@ -73,7 +74,7 @@ export default function AppNavBar({ user, logout }: NavBarProps) {
               <Dropdown.Item
                 target="_blank"
                 rel="noreferrer"
-                href={SERVICE_REQUEST_URL}
+                href={serviceRequestUrl}
               >
                 <AlignedLabel>
                   <FaBug className="me-3" />

--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -24,6 +24,7 @@ import { useImage } from "@/utils/images";
 import { hasRole } from "@/utils/auth";
 import ImageUploadModal from "@/components/ImageUploadModal";
 import { useAuth0 } from "@auth0/auth0-react";
+import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
 
 interface DiagramAlertProps {
   variant: "info" | "danger" | "success" | "warning";
@@ -265,8 +266,8 @@ export default function CrashDiagramCard({
             variant="danger"
             message={<p>The crash diagram is not available.</p>}
             link={{
-              href: "https://atd.knack.com/dts#new-service-request/?view_249_vars=%7B%22field_398%22%3A%22Bug%20Report%20%E2%80%94%20Something%20is%20not%20working%22%2C%22field_399%22%3A%22Vision%20Zero%20Editor%22%7D",
-              text: "report a bug",
+              href: SERVICE_REQUEST_URL,
+              text: "contact support",
             }}
           />
         )}

--- a/editor/components/CrashDiagramCard.tsx
+++ b/editor/components/CrashDiagramCard.tsx
@@ -24,7 +24,7 @@ import { useImage } from "@/utils/images";
 import { hasRole, ADMIN_EDIT_ROLES } from "@/utils/auth";
 import ImageUploadModal from "@/components/ImageUploadModal";
 import { useAuth0 } from "@auth0/auth0-react";
-import { SERVICE_REQUEST_URL } from "@/utils/serviceRequest";
+import { useServiceRequestUrl } from "@/utils/serviceRequest";
 
 interface DiagramAlertProps {
   variant: "info" | "danger" | "success" | "warning";
@@ -81,6 +81,7 @@ export default function CrashDiagramCard({
   const [isTouched, setIsTouched] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const transformComponentRef = useRef<ReactZoomPanPinchRef | null>(null);
+  const serviceRequestUrl = useServiceRequestUrl();
 
   const defaultValues = useMemo(() => {
     return crash.diagram_transform
@@ -266,7 +267,7 @@ export default function CrashDiagramCard({
             variant="danger"
             message={<p>The crash diagram is not available.</p>}
             link={{
-              href: SERVICE_REQUEST_URL,
+              href: serviceRequestUrl,
               text: "contact support",
             }}
           />

--- a/editor/utils/serviceRequest.ts
+++ b/editor/utils/serviceRequest.ts
@@ -1,0 +1,20 @@
+import { useAuth0 } from "@auth0/auth0-react";
+
+const serviceRequestParams = {
+  // "What applicaiton are you using (vision zero)"
+  field_1130: ["5da8d25798bb900018bf82e0"],
+  // "What do you need help with"
+  field_398: "Bug Report — Something is not working",
+  // email
+  field_406: "",
+};
+
+const SERVICE_REQUEST_BASE_URL =
+  "https://atd.knack.com/dts#new-service-request/?view_249_vars=";
+
+export const useServiceRequestUrl = () => {
+  const { user } = useAuth0();
+  const userEmail = user?.email || "";
+  const payload = { ...serviceRequestParams, field_406: userEmail };
+  return `${SERVICE_REQUEST_BASE_URL}${encodeURIComponent(JSON.stringify(payload))}`;
+};


### PR DESCRIPTION
## Associated issues

* https://github.com/cityofaustin/atd-data-tech/issues/30128

## Testing

1. Start your local VZE
2. Login using our read-only user account. The service request URL appears in three places:
- Navbar dropdrop down menu (top right corner of page) -> **Contact support**
- The unauthorized page: `http://localhost:3002/editor/unauthorized` -> **ask for help** hyperlink
- A crash with a missing crash report: `http://localhost:3002/editor/crashes/11312355` -> crash diagram card -> **contact support** hyperlink.

Verify that these fields in the Knack service request form are populated:
- Email: your user email
- What do you need help with?: Bug Report — Something is not working
- What application are you using? Vision Zero Editor

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
