### PR TITLE
The crash map marker is red when not editing

### DIFF
--- a/editor/components/PointMap.tsx
+++ b/editor/components/PointMap.tsx
@@ -300,7 +300,7 @@ export const PointMap = ({
       {/* editable + not editable point layers */}
       {savedLatitude && savedLongitude && !isEditing && (
         <Marker
-          key={dynamicMarkerKey}
+          key={`marker-view-${dynamicMarkerKey}`}
           latitude={savedLatitude}
           longitude={savedLongitude}
           color={COLORS.primary}
@@ -308,10 +308,10 @@ export const PointMap = ({
       )}
       {isEditing && draftLatLon && (
         <Marker
-          key={dynamicMarkerKey}
+          key={`marker-edit-${dynamicMarkerKey}`}
           latitude={draftLatLon.latitude}
           longitude={draftLatLon.longitude}
-          color={isEditing ? COLORS.danger : undefined}
+          color={COLORS.danger}
         />
       )}
     </MapGL>


### PR DESCRIPTION
## Associated issues
Closes https://github.com/cityofaustin/atd-data-tech/issues/29934

## Testing

**URL to test:** <!-- VZ URL or Netlify -->
[Netlify](https://deploy-preview-2139--vze-staging.netlify.app/editor/crashes)

**Steps to test:**
Go to a crash details page, the location marker should be blue. Edit the coordinate to be outside of a polygon (not on a major roadway, so try putting it over a house). On edit the marker should turn red, on save the marker should turn blue.

---

#### Ship list

- [ ] Check migrations for any conflicts with latest migrations in `main` branch
- [ ] Confirm Hasura role permissions for necessary access
- [ ] Code reviewed
- [ ] Product manager approved
